### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For translators : https://www.transifex.com/dev-feedreader/feedreader
 ### How to build the latest version
 ```
 git clone https://github.com/jangernert/FeedReader && cd ./FeedReader
-mkdir build & cd ./build 
+mkdir build && cd ./build 
 cmake -DCMAKE_INSTALL_PREFIX=/usr ..
 make
 sudo make install


### PR DESCRIPTION
Setup instructions use `&` which causes `cd ./build` to be run before `mkdir build` has completed, leading to an error. 

`&&` gives the expected behaviour.