### PR TITLE
Fullscreen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ vala_precompile(UI ${EXEC_NAME}
     src/Widgets/FeedList.vala
     src/Widgets/FeedListFooter.vala
     src/Widgets/FeedRow.vala
+    src/Widgets/FullscreenButton.vala
     src/Widgets/FullscreenHeaderbar.vala
     src/Widgets/HoverButton.vala
     src/Widgets/ImagePopup.vala

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ vala_precompile(UI ${EXEC_NAME}
     src/Widgets/FeedList.vala
     src/Widgets/FeedListFooter.vala
     src/Widgets/FeedRow.vala
+    src/Widgets/FullscreenHeaderbar.vala
     src/Widgets/HoverButton.vala
     src/Widgets/ImagePopup.vala
     src/Widgets/InAppNotification.vala

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "e579caead31c878b274de0fdf0e420a15161a833";
+const string g_GIT_SHA1 = "2506aaf8d506e896167c15eb25b89419942a45f7";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "9f4802175d306d16458a6ae0a0d972a81e6199c3";
+const string g_GIT_SHA1 = "e579caead31c878b274de0fdf0e420a15161a833";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "2506aaf8d506e896167c15eb25b89419942a45f7";
+const string g_GIT_SHA1 = "a9e7704fad7f3ed46f30f20f82f274ebc29f5707";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "cf25aee64205546c8eda84589f881edfe2c2adb8";
+const string g_GIT_SHA1 = "19e711b120cd8eeb65ae78b1c484b9b93d1a3972";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "414f7f36d515221b154aa1732626df6a6c6b13cf";
+const string g_GIT_SHA1 = "de472ef3a1872521b0f46a934f5bbfa94dc62166";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "2e34153a067067795665138770029ec57dd334d8";
+const string g_GIT_SHA1 = "ae3e63874d523b0cfc6aeca1f870298b85fb9fec";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "ae3e63874d523b0cfc6aeca1f870298b85fb9fec";
+const string g_GIT_SHA1 = "cf25aee64205546c8eda84589f881edfe2c2adb8";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "19e711b120cd8eeb65ae78b1c484b9b93d1a3972";
+const string g_GIT_SHA1 = "1a36b68f8dc5c689446f976f2b80a6529b17686c";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "de472ef3a1872521b0f46a934f5bbfa94dc62166";
+const string g_GIT_SHA1 = "9f4802175d306d16458a6ae0a0d972a81e6199c3";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "348382c1bac92c61ec61233307529c4afe834fe3";
+const string g_GIT_SHA1 = "489333b1a0b0249b0bee9d4f0e575a6265976587";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "57ee1ea905b16fea3605f9ee3040bdf9f473a12c";
+const string g_GIT_SHA1 = "348382c1bac92c61ec61233307529c4afe834fe3";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "489333b1a0b0249b0bee9d4f0e575a6265976587";
+const string g_GIT_SHA1 = "414f7f36d515221b154aa1732626df6a6c6b13cf";

--- a/GitSHA1.vala
+++ b/GitSHA1.vala
@@ -1,1 +1,1 @@
-const string g_GIT_SHA1 = "1a36b68f8dc5c689446f976f2b80a6529b17686c";
+const string g_GIT_SHA1 = "57ee1ea905b16fea3605f9ee3040bdf9f473a12c";

--- a/data/ArticleView/style.css
+++ b/data/ArticleView/style.css
@@ -177,6 +177,8 @@ body {
     cursor: default;
     font-family: 'Droid Sans', 'Open Sans';
     font-weight: 300;
+    max-width: 1200px;
+    margin: auto;
 }
 
 .tlblue {

--- a/data/shortcuts.ui
+++ b/data/shortcuts.ui
@@ -32,6 +32,13 @@
                                 <property name="accelerator">&lt;Primary&gt;Q</property>
                             </object>
                         </child>
+                        <child>
+                            <object class="GtkShortcutsShortcut">
+                                <property name="visible">True</property>
+                                <property name="title" translatable="yes" context="shortcut window">Fullscreen the selected article</property>
+                                <property name="accelerator">&lt;SHIFT&gt;F</property>
+                            </object>
+                        </child>
                     </object>
                 </child>
                 <child>

--- a/libVilistextum/fileio.c
+++ b/libVilistextum/fileio.c
@@ -45,7 +45,7 @@ void open_files(char *input)
 
 	if(OUTPUT != NULL)
 		free(OUTPUT);
-	OUTPUT = (CHAR*)malloc(3*sizeof(CHAR)*strlen(input));
+	OUTPUT = (CHAR*)malloc(4*sizeof(CHAR)*strlen(input));
 	OUTPUT[0]='\0';
 }
 

--- a/src/Widgets/ArticleList.vala
+++ b/src/Widgets/ArticleList.vala
@@ -286,26 +286,24 @@ public class FeedReader.articleList : Gtk.Overlay {
         });
 	}
 
-	public void toggleReadSelected()
+	public bool toggleReadSelected()
 	{
 		articleRow selected_row = m_currentList.get_selected_row() as articleRow;
 
 		if(selected_row == null)
-			return;
+			return false;
 
-		selected_row.toggleUnread();
-		selected_row.show_all();
+		return selected_row.toggleUnread();
 	}
 
-	public void toggleMarkedSelected()
+	public bool toggleMarkedSelected()
 	{
 		articleRow selected_row = m_currentList.get_selected_row() as articleRow;
 
 		if(selected_row == null)
-			return;
+			return false;
 
-		selected_row.toggleMarked();
-		selected_row.show_all();
+		return selected_row.toggleMarked();
 	}
 
 	public void openSelected()

--- a/src/Widgets/ArticleList.vala
+++ b/src/Widgets/ArticleList.vala
@@ -486,9 +486,6 @@ public class FeedReader.articleList : Gtk.Overlay {
 		if(selected_row != null)
 			return selected_row.getID();
 
-		if(m_currentList.get_children().length() == 0)
-			return "empty";
-
 		return "";
 	}
 
@@ -966,7 +963,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No unread articles that fit \"%s\" in the feed \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No unread articles in the feed \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					if(m_only_unread && m_only_marked){
 						if(m_searchTerm != "")
@@ -974,7 +971,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No unread articles and marked that fit \"%s\" in the feed \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No unread and marked articles in the feed \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					if(!m_only_unread && m_only_marked){
 						if(m_searchTerm != "")
@@ -982,7 +979,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No marked articles that fit \"%s\" in the feed \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No marked articles in the feed \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					break;
 				case FeedListType.TAG:
@@ -993,7 +990,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No unread articles that fit \"%s\" in the tag \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No unread articles in the tag \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					if(m_only_unread && m_only_marked){
 						if(m_searchTerm != "")
@@ -1001,7 +998,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No unread articles and marked that fit \"%s\" in the tag \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No unread and marked articles in the tag \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					if(!m_only_unread && m_only_marked){
 						if(m_searchTerm != "")
@@ -1009,7 +1006,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No marked articles that fit \"%s\" in the tag \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No marked articles in the tag \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					break;
 				case FeedListType.CATEGORY:
@@ -1020,7 +1017,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No unread articles that fit \"%s\" in the category \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No unread articles in the category \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					if(m_only_unread && m_only_marked){
 						if(m_searchTerm != "")
@@ -1028,7 +1025,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No unread articles and marked that fit \"%s\" in the category \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No unread and marked articles in the category \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					if(!m_only_unread && m_only_marked){
 						if(m_searchTerm != "")
@@ -1036,7 +1033,7 @@ public class FeedReader.articleList : Gtk.Overlay {
 							message = _("No marked articles that fit \"%s\" in the category \"%s\" could be found").printf(Utils.parseSearchTerm(m_searchTerm), name);
 						}else {
 							message = _("No marked articles in the category \"%s\" could be found").printf(name);
-						}	
+						}
 					}
 					break;
 			}

--- a/src/Widgets/ArticleList.vala
+++ b/src/Widgets/ArticleList.vala
@@ -486,6 +486,9 @@ public class FeedReader.articleList : Gtk.Overlay {
 		if(selected_row != null)
 			return selected_row.getID();
 
+		if(m_currentList.get_children().length() == 0)
+			return "empty";
+
 		return "";
 	}
 

--- a/src/Widgets/ArticleList.vala
+++ b/src/Widgets/ArticleList.vala
@@ -1222,4 +1222,28 @@ public class FeedReader.articleList : Gtk.Overlay {
 		}
 	}
 
+	public bool selectedIsFirst()
+	{
+		var selected_row = m_currentList.get_selected_row() as articleRow;
+		var ArticleListChildren = m_currentList.get_children();
+		int n = ArticleListChildren.index(selected_row);
+
+		if(n == 0)
+			return true;
+
+		return false;
+	}
+
+	public bool selectedIsLast()
+	{
+		var selected_row = m_currentList.get_selected_row() as articleRow;
+		var ArticleListChildren = m_currentList.get_children();
+		int n = ArticleListChildren.index(selected_row);
+
+		if(n + 1 == ArticleListChildren.length())
+			return true;
+
+		return false;
+	}
+
 }

--- a/src/Widgets/ArticleRow.vala
+++ b/src/Widgets/ArticleRow.vala
@@ -384,8 +384,9 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		return true;
 	}
 
-	public void toggleUnread()
+	public bool toggleUnread()
 	{
+		bool unread = false;
 		string articleID = "";
 		var window = ((rssReaderApp)GLib.Application.get_default()).getWindow();
 		if(window != null)
@@ -397,6 +398,7 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		{
 			case ArticleStatus.READ:
 				updateUnread(ArticleStatus.UNREAD);
+				unread = true;
 				if(articleID != "" && articleID == m_article.getArticleID())
 				{
 					window.getHeaderBar().setRead(true);
@@ -404,6 +406,7 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 				break;
 			case ArticleStatus.UNREAD:
 				updateUnread(ArticleStatus.READ);
+				unread = false;
 				if(articleID != "" && articleID == m_article.getArticleID())
 				{
 					window.getHeaderBar().setRead(false);
@@ -413,6 +416,8 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 
 
 		feedDaemon_interface.changeArticle(m_article.getArticleID(), m_article.getUnread());
+		show_all();
+		return unread;
 	}
 
 	public void updateUnread(ArticleStatus unread)
@@ -491,8 +496,9 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		return true;
 	}
 
-	public void toggleMarked()
+	public bool toggleMarked()
 	{
+		bool marked = false;
 		string articleID = "";
 		var window = ((rssReaderApp)GLib.Application.get_default()).getWindow();
 		if(window != null)
@@ -504,6 +510,7 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		{
 			case ArticleStatus.MARKED:
 				updateMarked(ArticleStatus.UNMARKED);
+				marked = false;
 				if(articleID != "" && articleID == m_article.getArticleID())
 				{
 					window.getHeaderBar().setMarked(false);
@@ -512,6 +519,7 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 
 			case ArticleStatus.UNMARKED:
 				updateMarked(ArticleStatus.MARKED);
+				marked = true;
 				if(articleID != "" && articleID == m_article.getArticleID())
 				{
 					window.getHeaderBar().setMarked(true);
@@ -520,6 +528,8 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		}
 
 		feedDaemon_interface.changeArticle(m_article.getArticleID(), m_article.getMarked());
+		this.show_all();
+		return marked;
 	}
 
 	public void updateMarked(ArticleStatus marked)

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -641,6 +641,9 @@ public class FeedReader.articleView : Gtk.Overlay {
 		m_FullscreenVideo = true;
 		m_connected = false;
 		enterFullscreen(true);
+		m_fsHead.hide();
+		m_prevButton.hide();
+		m_nextButton.hide();
 		return false;
 	}
 

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -29,6 +29,8 @@ public class FeedReader.articleView : Gtk.Overlay {
 	private WebKit.FindController m_search;
 	private Gtk.Stack m_stack;
 	private fullscreenHeaderbar m_fsHead;
+	private fullscreenButton m_prevButton;
+	private fullscreenButton m_nextButton;
 	private string m_currentArticle;
 	private bool m_firstTime = true;
 	private string m_searchTerm = "";
@@ -139,7 +141,27 @@ public class FeedReader.articleView : Gtk.Overlay {
 		fullscreenHeaderOverlay.add(m_stack);
 		fullscreenHeaderOverlay.add_overlay(m_fsHead);
 
-		this.add(fullscreenHeaderOverlay);
+		m_prevButton = new fullscreenButton("go-previous-symbolic", Gtk.Align.START);
+		m_prevButton.click.connect(() => {
+			var window = this.get_toplevel() as readerUI;
+			if(window != null && window.is_toplevel())
+				window.getContent().ArticleListPREV();
+		});
+		var prevOverlay = new Gtk.Overlay();
+		prevOverlay.add(fullscreenHeaderOverlay);
+		prevOverlay.add_overlay(m_prevButton);
+
+		m_nextButton = new fullscreenButton("go-next-symbolic", Gtk.Align.END);
+		m_nextButton.click.connect(() => {
+			var window = this.get_toplevel() as readerUI;
+			if(window != null && window.is_toplevel())
+				window.getContent().ArticleListNEXT();
+		});
+		var nextOverlay = new Gtk.Overlay();
+		nextOverlay.add(prevOverlay);
+		nextOverlay.add_overlay(m_nextButton);
+
+		this.add(nextOverlay);
 		this.add_overlay(m_overlayLabel);
 
 		Bus.watch_name(BusType.SESSION, "org.gnome.feedreader.FeedReaderArticleView", GLib.BusNameWatcherFlags.NONE,
@@ -639,12 +661,16 @@ public class FeedReader.articleView : Gtk.Overlay {
 		if(fs)
 		{
 			m_fsHead.show();
+			m_prevButton.show();
+			m_nextButton.show();
 		}
 		else
 		{
 			m_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE);
 			m_stack.set_transition_duration(100);
 			m_fsHead.hide();
+			m_prevButton.hide();
+			m_nextButton.hide();
 		}
 	}
 

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -130,7 +130,7 @@ public class FeedReader.articleView : Gtk.Overlay {
 		m_fsHead = new fullscreenHeaderbar();
 		m_fsHead.close.connect(() => {
 			leaveFullscreen(false);
-			var window = this.get_toplevel() as Gtk.ApplicationWindow;
+			var window = this.get_toplevel() as readerUI;
 			if(window != null && window.is_toplevel())
 				window.unfullscreen();
 		});
@@ -294,6 +294,8 @@ public class FeedReader.articleView : Gtk.Overlay {
 
 		setBackgroundColor();
 		m_fsHead.setTitle(Article.getTitle());
+		m_fsHead.setMarked( (Article.getMarked() == ArticleStatus.MARKED) ? true : false);
+		m_fsHead.setUnread( (Article.getUnread() == ArticleStatus.UNREAD) ? true : false);
 
 		m_currentView.load_html(
 			Utils.buildArticle(
@@ -684,6 +686,16 @@ public class FeedReader.articleView : Gtk.Overlay {
 		m_currentView.motion_notify_event.connect(onMouseMotion);
 		m_currentView.enter_fullscreen.connect(enter_fullscreen);
 		m_currentView.leave_fullscreen.connect(leave_fullscreen);
+	}
+
+	public void setMarked(bool marked)
+	{
+		m_fsHead.setMarked(marked);
+	}
+
+	public void setUnread(bool unread)
+	{
+		m_fsHead.setUnread(unread);
 	}
 
 }

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -642,8 +642,8 @@ public class FeedReader.articleView : Gtk.Overlay {
 		m_connected = false;
 		enterFullscreen(true);
 		m_fsHead.hide();
-		m_prevButton.hide();
-		m_nextButton.hide();
+		m_prevButton.reveal(false);
+		m_nextButton.reveal(false);
 		return false;
 	}
 
@@ -664,16 +664,24 @@ public class FeedReader.articleView : Gtk.Overlay {
 		if(fs)
 		{
 			m_fsHead.show();
-			m_prevButton.show();
-			m_nextButton.show();
+
+			var window = this.get_toplevel() as readerUI;
+			var content = window.getContent();
+
+			if(!content.ArticleListSelectedIsFirst())
+				m_nextButton.reveal(true);
+
+			if(!content.ArticleListSelectedIsLast())
+				m_prevButton.reveal(true);
+
 		}
 		else
 		{
 			m_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE);
 			m_stack.set_transition_duration(100);
 			m_fsHead.hide();
-			m_prevButton.hide();
-			m_nextButton.hide();
+			m_prevButton.reveal(false);
+			m_nextButton.reveal(false);
 		}
 	}
 
@@ -725,6 +733,16 @@ public class FeedReader.articleView : Gtk.Overlay {
 	public void setUnread(bool unread)
 	{
 		m_fsHead.setUnread(unread);
+	}
+
+	public void nextButtonVisible(bool vis)
+	{
+		m_nextButton.reveal(vis);
+	}
+
+	public void prevButtonVisible(bool vis)
+	{
+		m_prevButton.reveal(vis);
 	}
 
 }

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -28,8 +28,7 @@ public class FeedReader.articleView : Gtk.Overlay {
 	private WebKit.WebView m_currentView;
 	private WebKit.FindController m_search;
 	private Gtk.Stack m_stack;
-	private Gtk.EventBox m_eventBox;
-	private Gtk.Revealer m_revealer;
+	private fullscreenHeaderbar m_fsHead;
 	private string m_currentArticle;
 	private bool m_firstTime = true;
 	private string m_searchTerm = "";
@@ -128,49 +127,17 @@ public class FeedReader.articleView : Gtk.Overlay {
 			}
         });
 
-		var close_icon = new Gtk.Image.from_icon_name("view-restore-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-		var closeButton = new Gtk.Button();
-		closeButton.add(close_icon);
-		closeButton.set_relief(Gtk.ReliefStyle.NONE);
-		closeButton.set_focus_on_click(false);
-		closeButton.set_tooltip_text(_("Leave fullscreen mode"));
-		closeButton.clicked.connect(() => {
+		m_fsHead = new fullscreenHeaderbar();
+		m_fsHead.close.connect(() => {
 			leaveFullscreen(false);
 			var window = this.get_toplevel() as Gtk.ApplicationWindow;
 			if(window != null && window.is_toplevel())
 				window.unfullscreen();
 		});
-		var fullscreenHeader = new Gtk.HeaderBar();
-		fullscreenHeader.get_style_context().add_class("titlebar");
-		fullscreenHeader.get_style_context().add_class("imageOverlay");
-		fullscreenHeader.valign = Gtk.Align.START;
-		fullscreenHeader.pack_end(closeButton);
-		m_revealer = new Gtk.Revealer();
-		m_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
-		m_revealer.set_transition_duration(300);
-		m_revealer.valign = Gtk.Align.START;
-		m_revealer.add(fullscreenHeader);
-		m_eventBox = new Gtk.EventBox();
-		m_eventBox.set_size_request(0, 50);
-		m_eventBox.no_show_all = true;
-		m_eventBox.enter_notify_event.connect((event) => {
-			m_revealer.set_reveal_child(true);
-			m_revealer.show_all();
-			return true;
-		});
-		m_eventBox.leave_notify_event.connect((event) => {
-			if(event.detail == Gdk.NotifyType.INFERIOR)
-				return false;
-
-			m_revealer.set_reveal_child(false);
-			return true;
-		});
-		m_eventBox.add(m_revealer);
-		m_eventBox.valign = Gtk.Align.START;
 
 		var fullscreenHeaderOverlay = new Gtk.Overlay();
 		fullscreenHeaderOverlay.add(m_stack);
-		fullscreenHeaderOverlay.add_overlay(m_eventBox);
+		fullscreenHeaderOverlay.add_overlay(m_fsHead);
 
 		this.add(fullscreenHeaderOverlay);
 		this.add_overlay(m_overlayLabel);
@@ -326,8 +293,7 @@ public class FeedReader.articleView : Gtk.Overlay {
 		yield;
 
 		setBackgroundColor();
-
-
+		m_fsHead.setTitle(Article.getTitle());
 
 		m_currentView.load_html(
 			Utils.buildArticle(
@@ -670,13 +636,13 @@ public class FeedReader.articleView : Gtk.Overlay {
 
 		if(fs)
 		{
-			m_eventBox.show();
+			m_fsHead.show();
 		}
 		else
 		{
 			m_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE);
 			m_stack.set_transition_duration(100);
-			m_eventBox.hide();
+			m_fsHead.hide();
 		}
 	}
 

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -44,8 +44,10 @@ public class FeedReader.articleView : Gtk.Stack {
 	private bool m_connected = false;
 	private int m_height = 0;
 	private int m_width = 0;
-	public signal void enterFullscreen();
-	public signal void leaveFullscreen();
+	private bool m_FullscreenVideo = false;
+	private bool m_FullscreenArticle = false;
+	public signal void enterFullscreen(bool video);
+	public signal void leaveFullscreen(bool video);
 
 
 	public articleView()
@@ -76,13 +78,15 @@ public class FeedReader.articleView : Gtk.Stack {
 		m_view.button_release_event.connect(onRelease);
 		m_view.motion_notify_event.connect(onMouseMotion);
 		m_view.enter_fullscreen.connect(() => {
+			m_FullscreenVideo = true;
 			m_connected = false;
-			enterFullscreen();
+			enterFullscreen(true);
 			return false;
 		});
 		m_view.leave_fullscreen.connect(() => {
+			m_FullscreenVideo = false;
 			m_connected = true;
-			leaveFullscreen();
+			leaveFullscreen(true);
 			return false;
 		});
 		m_search = m_view.get_find_controller();
@@ -583,6 +587,21 @@ public class FeedReader.articleView : Gtk.Stack {
 				return true;
 			});
 		}
+	}
+
+	public bool fullscreenVideo()
+	{
+		return m_FullscreenVideo;
+	}
+
+	public bool fullscreenArticle()
+	{
+		return m_FullscreenArticle;
+	}
+
+	public void setFullscreenArticle(bool fs)
+	{
+		m_FullscreenArticle = fs;
 	}
 
 }

--- a/src/Widgets/ContentPage.vala
+++ b/src/Widgets/ContentPage.vala
@@ -184,6 +184,16 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 			m_article_view.setTransition(Gtk.StackTransitionType.SLIDE_LEFT, 500);
 
 		m_articleList.move(false);
+
+		if(m_article_view.fullscreenArticle())
+		{
+			m_article_view.prevButtonVisible(true);
+
+			if(m_articleList.selectedIsFirst())
+				m_article_view.nextButtonVisible(false);
+			else
+				m_article_view.nextButtonVisible(true);
+		}
 	}
 
 	public void ArticleListPREV()
@@ -194,6 +204,16 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 			m_article_view.setTransition(Gtk.StackTransitionType.SLIDE_RIGHT, 500);
 
 		m_articleList.move(true);
+
+		if(m_article_view.fullscreenArticle())
+		{
+			m_article_view.nextButtonVisible(true);
+
+			if(m_articleList.selectedIsLast())
+				m_article_view.prevButtonVisible(false);
+			else
+				m_article_view.prevButtonVisible(true);
+		}
 	}
 
 	public void newHeadlineList(Gtk.StackTransitionType transition = Gtk.StackTransitionType.CROSSFADE)
@@ -453,5 +473,15 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 	public bool isFullscreen()
 	{
 		return m_article_view.fullscreenArticle();
+	}
+
+	public bool ArticleListSelectedIsFirst()
+	{
+		return m_articleList.selectedIsFirst();
+	}
+
+	public bool ArticleListSelectedIsLast()
+	{
+		return m_articleList.selectedIsLast();
 	}
 }

--- a/src/Widgets/ContentPage.vala
+++ b/src/Widgets/ContentPage.vala
@@ -151,26 +151,42 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 		this.add(m_pane1);
 	}
 
-	public void enterFullscreen()
+	public void enterFullscreen(bool video)
 	{
-		if(settings_tweaks.get_boolean("fullscreen-videos"))
-			m_pane2.set_visible(false);
+		if(video)
+		{
+			if(!settings_tweaks.get_boolean("fullscreen-videos"))
+				return;
+		}
+		else
+		{
+			m_article_view.setFullscreenArticle(true);
+		}
+
+		m_pane2.set_visible(false);
 	}
 
-	public void leaveFullscreen()
+	public void leaveFullscreen(bool video)
 	{
+		if(!video)
+		{
+			m_article_view.setFullscreenArticle(false);
+		}
+
 		m_pane2.set_visible(true);
 	}
 
 	public void ArticleListNEXT()
 	{
-		leaveFullscreen();
+		if(!m_article_view.fullscreenArticle())
+			leaveFullscreen(true);
 		m_articleList.move(false);
 	}
 
 	public void ArticleListPREV()
 	{
-		leaveFullscreen();
+		if(!m_article_view.fullscreenArticle())
+			leaveFullscreen(true);
 		m_articleList.move(true);
 	}
 
@@ -424,5 +440,10 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 		this.add_overlay(notification);
 		this.show_all();
 		return notification;
+	}
+
+	public bool isFullscreen()
+	{
+		return m_article_view.fullscreenArticle();
 	}
 }

--- a/src/Widgets/ContentPage.vala
+++ b/src/Widgets/ContentPage.vala
@@ -325,12 +325,14 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 
 	public void toggleReadSelectedArticle()
 	{
-		m_articleList.toggleReadSelected();
+		bool unread = m_articleList.toggleReadSelected();
+		m_article_view.setUnread(unread);
 	}
 
 	public void toggleMarkedSelectedArticle()
 	{
-		m_articleList.toggleMarkedSelected();
+		bool marked = m_articleList.toggleMarkedSelected();
+		m_article_view.setMarked(marked);
 	}
 
 	public void openSelectedArticle()

--- a/src/Widgets/ContentPage.vala
+++ b/src/Widgets/ContentPage.vala
@@ -180,6 +180,9 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 	{
 		if(!m_article_view.fullscreenArticle())
 			leaveFullscreen(true);
+		else
+			m_article_view.setTransition(Gtk.StackTransitionType.SLIDE_LEFT, 500);
+
 		m_articleList.move(false);
 	}
 
@@ -187,6 +190,9 @@ public class FeedReader.ContentPage : Gtk.Overlay {
 	{
 		if(!m_article_view.fullscreenArticle())
 			leaveFullscreen(true);
+		else
+			m_article_view.setTransition(Gtk.StackTransitionType.SLIDE_RIGHT, 500);
+
 		m_articleList.move(true);
 	}
 

--- a/src/Widgets/FullscreenButton.vala
+++ b/src/Widgets/FullscreenButton.vala
@@ -79,9 +79,12 @@ public class FeedReader.fullscreenButton : Gtk.EventBox {
             m_timeout_source_id = 0;
         }
 
-		this.visible = true;
-		m_icon.show();
-
+		if(show)
+		{
+			this.visible = true;
+			m_icon.show();
+		}
+		
 		m_timeout_source_id = Timeout.add(20, () => {
 
 			if(show)

--- a/src/Widgets/FullscreenButton.vala
+++ b/src/Widgets/FullscreenButton.vala
@@ -17,6 +17,8 @@ public class FeedReader.fullscreenButton : Gtk.EventBox {
 
 	private Gtk.Image m_icon;
 	private double m_opacity = 0.4;
+	private bool m_hover = false;
+	private uint m_timeout_source_id = 0;
 	public signal void click();
 
 	public fullscreenButton(string iconName, Gtk.Align align)
@@ -37,19 +39,21 @@ public class FeedReader.fullscreenButton : Gtk.EventBox {
 
 		m_icon = new Gtk.Image.from_icon_name(iconName, Gtk.IconSize.DIALOG);
 		m_icon.margin = 20;
-		this.opacity = m_opacity;
+		this.opacity = 0.0;
 		this.add(m_icon);
 	}
 
 	private bool onEnter(Gdk.EventCrossing event)
     {
 		this.opacity = 1.0;
+		m_hover = true;
         return true;
     }
 
     private bool onLeave(Gdk.EventCrossing event)
     {
 		this.opacity = m_opacity;
+		m_hover = false;
         return true;
     }
 
@@ -67,10 +71,45 @@ public class FeedReader.fullscreenButton : Gtk.EventBox {
         return true;
     }
 
-	public void show()
+	public void reveal(bool show)
 	{
+		if (m_timeout_source_id > 0)
+		{
+            GLib.Source.remove(m_timeout_source_id);
+            m_timeout_source_id = 0;
+        }
+
 		this.visible = true;
 		m_icon.show();
+
+		m_timeout_source_id = Timeout.add(20, () => {
+
+			if(show)
+			{
+				if(!m_hover && this.opacity-m_opacity <= 0.02)
+				{
+					this.opacity = m_opacity;
+					return false;
+				}
+
+				if(m_hover && this.opacity == 1.0)
+					return false;
+
+				this.opacity += 0.02;
+			}
+			else
+			{
+				if(this.opacity == 0.0)
+				{
+					this.hide();
+					return false;
+				}
+
+				this.opacity -= 0.02;
+			}
+
+            return true;
+        });
 	}
 
 }

--- a/src/Widgets/FullscreenButton.vala
+++ b/src/Widgets/FullscreenButton.vala
@@ -1,0 +1,76 @@
+//	This file is part of FeedReader.
+//
+//	FeedReader is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or
+//	(at your option) any later version.
+//
+//	FeedReader is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//
+//	You should have received a copy of the GNU General Public License
+//	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
+
+public class FeedReader.fullscreenButton : Gtk.EventBox {
+
+	private Gtk.Image m_icon;
+	private double m_opacity = 0.4;
+	public signal void click();
+
+	public fullscreenButton(string iconName, Gtk.Align align)
+	{
+		this.valign = Gtk.Align.CENTER;
+		this.halign = align;
+		this.get_style_context().add_class("overlay");
+		this.margin = 40;
+		this.no_show_all = true;
+
+		this.set_events(Gdk.EventMask.ENTER_NOTIFY_MASK);
+		this.set_events(Gdk.EventMask.LEAVE_NOTIFY_MASK);
+		this.set_events(Gdk.EventMask.BUTTON_PRESS_MASK);
+
+		this.enter_notify_event.connect(onEnter);
+		this.leave_notify_event.connect(onLeave);
+		this.button_press_event.connect(onClick);
+
+		m_icon = new Gtk.Image.from_icon_name(iconName, Gtk.IconSize.DIALOG);
+		m_icon.margin = 20;
+		this.opacity = m_opacity;
+		this.add(m_icon);
+	}
+
+	private bool onEnter(Gdk.EventCrossing event)
+    {
+		this.opacity = 1.0;
+        return true;
+    }
+
+    private bool onLeave(Gdk.EventCrossing event)
+    {
+		this.opacity = m_opacity;
+        return true;
+    }
+
+	private bool onClick(Gdk.EventButton event)
+    {
+		switch(event.type)
+		{
+			case Gdk.EventType.BUTTON_RELEASE:
+			case Gdk.EventType.@2BUTTON_PRESS:
+			case Gdk.EventType.@3BUTTON_PRESS:
+				return false;
+		}
+
+		click();
+        return true;
+    }
+
+	public void show()
+	{
+		this.visible = true;
+		m_icon.show();
+	}
+
+}

--- a/src/Widgets/FullscreenHeaderbar.vala
+++ b/src/Widgets/FullscreenHeaderbar.vala
@@ -103,7 +103,7 @@ public class FeedReader.fullscreenHeaderbar : Gtk.EventBox {
 		m_revealer.valign = Gtk.Align.START;
 		m_revealer.add(m_header);
 
-		this.set_size_request(0, 50);
+		this.set_size_request(0, 80);
 		this.no_show_all = true;
 		this.enter_notify_event.connect((event) => {
 			m_revealer.show_all();

--- a/src/Widgets/FullscreenHeaderbar.vala
+++ b/src/Widgets/FullscreenHeaderbar.vala
@@ -1,0 +1,68 @@
+//	This file is part of FeedReader.
+//
+//	FeedReader is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or
+//	(at your option) any later version.
+//
+//	FeedReader is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//
+//	You should have received a copy of the GNU General Public License
+//	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
+
+public class FeedReader.fullscreenHeaderbar : Gtk.EventBox {
+
+	private Gtk.Revealer m_revealer;
+	private Gtk.HeaderBar m_header;
+	public signal void close();
+
+	public fullscreenHeaderbar()
+	{
+		var close_icon = new Gtk.Image.from_icon_name("view-restore-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var closeButton = new Gtk.Button();
+		closeButton.add(close_icon);
+		closeButton.set_relief(Gtk.ReliefStyle.NONE);
+		closeButton.set_focus_on_click(false);
+		closeButton.set_tooltip_text(_("Leave fullscreen mode"));
+		closeButton.clicked.connect(() => {
+			close();
+		});
+		m_header = new Gtk.HeaderBar();
+		m_header.get_style_context().add_class("titlebar");
+		m_header.get_style_context().add_class("imageOverlay");
+		m_header.valign = Gtk.Align.START;
+		m_header.pack_end(closeButton);
+		m_revealer = new Gtk.Revealer();
+		m_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
+		m_revealer.set_transition_duration(300);
+		m_revealer.valign = Gtk.Align.START;
+		m_revealer.add(m_header);
+
+		this.set_size_request(0, 50);
+		this.no_show_all = true;
+		this.enter_notify_event.connect((event) => {
+			m_revealer.show_all();
+			m_revealer.set_reveal_child(true);
+			return true;
+		});
+		this.leave_notify_event.connect((event) => {
+			if(event.detail == Gdk.NotifyType.INFERIOR)
+				return false;
+
+			m_revealer.set_reveal_child(false);
+			return true;
+		});
+		this.add(m_revealer);
+		this.valign = Gtk.Align.START;
+	}
+
+	public void setTitle(string title)
+	{
+		m_header.set_title(title);
+	}
+
+
+}

--- a/src/Widgets/FullscreenHeaderbar.vala
+++ b/src/Widgets/FullscreenHeaderbar.vala
@@ -17,10 +17,68 @@ public class FeedReader.fullscreenHeaderbar : Gtk.EventBox {
 
 	private Gtk.Revealer m_revealer;
 	private Gtk.HeaderBar m_header;
+	private HoverButton m_mark_button;
+	private HoverButton m_read_button;
+	private Gtk.Button m_share_button;
+	private Gtk.Button m_tag_button;
+	private bool m_popover = false;
+	private bool m_hover = false;
 	public signal void close();
 
 	public fullscreenHeaderbar()
 	{
+		var marked_icon = new Gtk.Image.from_icon_name("feed-marked-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var unmarked_icon = new Gtk.Image.from_icon_name("feed-unmarked-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var read_icon = new Gtk.Image.from_icon_name("feed-read-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var unread_icon = new Gtk.Image.from_icon_name("feed-unread-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var share_icon = new Gtk.Image.from_icon_name("feed-share-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var tag_icon = new Gtk.Image.from_icon_name("feed-tag-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+
+		m_mark_button = new HoverButton(unmarked_icon, marked_icon, false);
+		m_mark_button.set_tooltip_text(_("Mark article (un)starred"));
+		m_mark_button.clicked.connect(() => {
+			var window = this.get_toplevel() as readerUI;
+			if(window != null && window.is_toplevel())
+				window.getContent().toggleMarkedSelectedArticle();
+		});
+		m_read_button = new HoverButton(read_icon, unread_icon, false);
+		m_read_button.set_tooltip_text(_("Mark article (un)read"));
+		m_read_button.clicked.connect(() => {
+			var window = this.get_toplevel() as readerUI;
+			if(window != null && window.is_toplevel())
+				window.getContent().toggleReadSelectedArticle();
+		});
+
+		m_tag_button = new Gtk.Button();
+		m_tag_button.add(tag_icon);
+		m_tag_button.set_relief(Gtk.ReliefStyle.NONE);
+		m_tag_button.set_focus_on_click(false);
+		m_tag_button.set_tooltip_text(_("Tag Article"));
+		m_tag_button.clicked.connect(() => {
+			m_popover = true;
+			var pop = new TagPopover(m_tag_button);
+			pop.closed.connect(() => {
+				m_popover = false;
+				if(!m_hover)
+					m_revealer.set_reveal_child(false);
+			});
+		});
+
+		m_share_button = new Gtk.Button();
+		m_share_button.add(share_icon);
+		m_share_button.set_relief(Gtk.ReliefStyle.NONE);
+		m_share_button.set_focus_on_click(false);
+		m_share_button.set_tooltip_text(_("Share Article"));
+		m_share_button.clicked.connect(() => {
+			m_popover = true;
+			var pop = new SharePopover(m_share_button);
+			pop.closed.connect(() => {
+				m_popover = false;
+				if(!m_hover)
+					m_revealer.set_reveal_child(false);
+			});
+		});
+
 		var close_icon = new Gtk.Image.from_icon_name("view-restore-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		var closeButton = new Gtk.Button();
 		closeButton.add(close_icon);
@@ -34,7 +92,11 @@ public class FeedReader.fullscreenHeaderbar : Gtk.EventBox {
 		m_header.get_style_context().add_class("titlebar");
 		m_header.get_style_context().add_class("imageOverlay");
 		m_header.valign = Gtk.Align.START;
+		m_header.pack_start(m_mark_button);
+		m_header.pack_start(m_read_button);
 		m_header.pack_end(closeButton);
+		m_header.pack_end(m_share_button);
+		m_header.pack_end(m_tag_button);
 		m_revealer = new Gtk.Revealer();
 		m_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
 		m_revealer.set_transition_duration(300);
@@ -46,10 +108,19 @@ public class FeedReader.fullscreenHeaderbar : Gtk.EventBox {
 		this.enter_notify_event.connect((event) => {
 			m_revealer.show_all();
 			m_revealer.set_reveal_child(true);
+			m_hover = true;
 			return true;
 		});
 		this.leave_notify_event.connect((event) => {
 			if(event.detail == Gdk.NotifyType.INFERIOR)
+				return false;
+
+			if(event.detail == Gdk.NotifyType.NONLINEAR_VIRTUAL)
+		        return false;
+
+			m_hover = false;
+
+			if(m_popover)
 				return false;
 
 			m_revealer.set_reveal_child(false);
@@ -64,5 +135,13 @@ public class FeedReader.fullscreenHeaderbar : Gtk.EventBox {
 		m_header.set_title(title);
 	}
 
+	public void setMarked(bool marked)
+	{
+		m_mark_button.setActive(marked);
+	}
 
+	public void setUnread(bool unread)
+	{
+		m_read_button.setActive(unread);
+	}
 }

--- a/src/Widgets/HoverButton.vala
+++ b/src/Widgets/HoverButton.vala
@@ -90,7 +90,7 @@ public class FeedReader.HoverButton : Gtk.EventBox {
     }
 
 
-    private bool onEnter()
+    private bool onEnter(Gdk.EventCrossing event)
     {
         if(m_isActive)
         {
@@ -103,8 +103,11 @@ public class FeedReader.HoverButton : Gtk.EventBox {
         return true;
     }
 
-    private bool onLeave()
+    private bool onLeave(Gdk.EventCrossing event)
     {
+        if(event.detail == Gdk.NotifyType.NONLINEAR_VIRTUAL)
+            return false;
+
         if(m_just_clicked)
         {
             m_just_clicked = false;

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -657,6 +657,17 @@ public class FeedReader.readerUI : Gtk.ApplicationWindow
 				m_content.ArticleListNEXT();
 				break;
 
+			case Gdk.Key.Left:
+			case Gdk.Key.Right:
+				if(m_content.isFullscreen())
+				{
+					if(event.keyval == Gdk.Key.Left)
+						m_content.ArticleListPREV();
+					else
+						m_content.ArticleListNEXT();
+				}
+				break;
+
 			case Gdk.Key.r:
 				logger.print(LogMessage.DEBUG, "shortcut: toggle read");
 				m_content.toggleReadSelectedArticle();

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -716,7 +716,9 @@ public class FeedReader.readerUI : Gtk.ApplicationWindow
 				break;
 
 			case Gdk.Key.F:
-				if(!m_content.isFullscreen() && m_content.getSelectedArticle() != "")
+				if(!m_content.isFullscreen()
+				&& m_content.getSelectedArticle() != ""
+				&& m_content.getSelectedArticle() != "empty")
 				{
 					this.fullscreen();
 					m_content.enterFullscreen(false);

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -715,6 +715,19 @@ public class FeedReader.readerUI : Gtk.ApplicationWindow
 				}
 				break;
 
+			case Gdk.Key.F:
+				if(!m_content.isFullscreen() && m_content.getSelectedArticle() != "")
+				{
+					this.fullscreen();
+					m_content.enterFullscreen(false);
+				}
+				else if(m_content.isFullscreen())
+				{
+					this.unfullscreen();
+					m_content.leaveFullscreen(false);
+				}
+				break;
+
 			default:
 				return false;
 		}

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -642,9 +642,6 @@ public class FeedReader.readerUI : Gtk.ApplicationWindow
 		if(m_headerbar.searchFocused())
 			return false;
 
-		if(m_headerbar.tagEntryFocused())
-			return false;
-
 		switch(event.keyval)
 		{
 			case Gdk.Key.j:

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -707,6 +707,14 @@ public class FeedReader.readerUI : Gtk.ApplicationWindow
 				}
 				break;
 
+			case Gdk.Key.Escape:
+				if(m_content.isFullscreen())
+				{
+					this.unfullscreen();
+					m_content.leaveFullscreen(false);
+				}
+				break;
+
 			default:
 				return false;
 		}

--- a/src/Widgets/ReaderHeaderbar.vala
+++ b/src/Widgets/ReaderHeaderbar.vala
@@ -19,6 +19,7 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 	private Gtk.Button m_tag_button;
 	private HoverButton m_mark_button;
 	private HoverButton m_read_button;
+	private Gtk.Button m_fullscreen_button;
 	private ModeButton m_modeButton;
 	private UpdateButton m_refresh_button;
 	private Gtk.SearchEntry m_search;
@@ -58,13 +59,13 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 			toggledRead();
 		});
 
-		var fullscreen_button = new Gtk.Button();
-		fullscreen_button.add(fs_icon);
-		fullscreen_button.set_relief(Gtk.ReliefStyle.NONE);
-		fullscreen_button.set_focus_on_click(false);
-		fullscreen_button.set_tooltip_text(_("Read article fullscreen"));
-		fullscreen_button.sensitive = true;
-		fullscreen_button.clicked.connect(() => {
+		m_fullscreen_button = new Gtk.Button();
+		m_fullscreen_button.add(fs_icon);
+		m_fullscreen_button.set_relief(Gtk.ReliefStyle.NONE);
+		m_fullscreen_button.set_focus_on_click(false);
+		m_fullscreen_button.set_tooltip_text(_("Read article fullscreen"));
+		m_fullscreen_button.sensitive = false;
+		m_fullscreen_button.clicked.connect(() => {
 			var window = this.get_toplevel() as readerUI;
 			window.fullscreen();
 			window.getContent().enterFullscreen(false);
@@ -167,7 +168,7 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 		m_header_left.pack_start(m_modeButton);
 		m_header_left.pack_start(m_refresh_button);
 
-		m_header_right.pack_start(fullscreen_button);
+		m_header_right.pack_start(m_fullscreen_button);
 		m_header_right.pack_start(m_mark_button);
 		m_header_right.pack_start(m_read_button);
 		m_header_right.pack_end(m_share_button);
@@ -211,6 +212,7 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 	{
 		m_mark_button.sensitive = show;
 		m_read_button.sensitive = show;
+		m_fullscreen_button.sensitive = show;
 
 		if(m_online)
 		{

--- a/src/Widgets/ReaderHeaderbar.vala
+++ b/src/Widgets/ReaderHeaderbar.vala
@@ -58,6 +58,14 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 			toggledRead();
 		});
 
+		var fullscreen_button = new Gtk.Button.from_icon_name("view-fullscreen-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		fullscreen_button.set_tooltip_text(_("Read article fullscreen"));
+		fullscreen_button.clicked.connect(() => {
+			var window = this.get_toplevel() as readerUI;
+			window.fullscreen();
+			window.getContent().enterFullscreen(false);
+		});
+
 
 		m_header_left = new Gtk.HeaderBar ();
 		m_header_left.show_close_button = true;
@@ -155,6 +163,7 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 		m_header_left.pack_start(m_modeButton);
 		m_header_left.pack_start(m_refresh_button);
 
+		m_header_right.pack_start(fullscreen_button);
 		m_header_right.pack_start(m_mark_button);
 		m_header_right.pack_start(m_read_button);
 		m_header_right.pack_end(m_share_button);

--- a/src/Widgets/ReaderHeaderbar.vala
+++ b/src/Widgets/ReaderHeaderbar.vala
@@ -25,7 +25,6 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 	private ArticleListState m_state;
 	private Gtk.HeaderBar m_header_left;
 	private Gtk.HeaderBar m_header_right;
-	private TagPopover m_pop;
 	private bool m_online = true;
 	public signal void refresh();
 	public signal void change_state(ArticleListState state, Gtk.StackTransitionType transition);
@@ -103,7 +102,7 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 		m_tag_button.set_tooltip_text(_("Tag Article"));
 		m_tag_button.sensitive = false;
 		m_tag_button.clicked.connect(() => {
-			m_pop = new TagPopover(m_tag_button);
+			var pop = new TagPopover(m_tag_button);
 		});
 
 		m_share_button = new Gtk.Button();
@@ -244,14 +243,6 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 	public bool searchFocused()
 	{
 		return m_search.has_focus;
-	}
-
-	public bool tagEntryFocused()
-	{
-		if(m_pop == null)
-			return false;
-
-		return m_pop.entryFocused();
 	}
 
 	public void setMarked(bool marked)

--- a/src/Widgets/ReaderHeaderbar.vala
+++ b/src/Widgets/ReaderHeaderbar.vala
@@ -42,6 +42,7 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 		var unmarked_icon = new Gtk.Image.from_icon_name("feed-unmarked-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		var read_icon = new Gtk.Image.from_icon_name("feed-read-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		var unread_icon = new Gtk.Image.from_icon_name("feed-unread-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var fs_icon = new Gtk.Image.from_icon_name("view-fullscreen-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		m_state = (ArticleListState)settings_state.get_enum("show-articles");
 
 
@@ -58,8 +59,12 @@ public class FeedReader.readerHeaderbar : Gtk.Paned {
 			toggledRead();
 		});
 
-		var fullscreen_button = new Gtk.Button.from_icon_name("view-fullscreen-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+		var fullscreen_button = new Gtk.Button();
+		fullscreen_button.add(fs_icon);
+		fullscreen_button.set_relief(Gtk.ReliefStyle.NONE);
+		fullscreen_button.set_focus_on_click(false);
 		fullscreen_button.set_tooltip_text(_("Read article fullscreen"));
+		fullscreen_button.sensitive = true;
 		fullscreen_button.clicked.connect(() => {
 			var window = this.get_toplevel() as readerUI;
 			window.fullscreen();


### PR DESCRIPTION
This implements a fullsceen-mode for articles.
When fullscreen articles don't crossfade anymore but slide left or right.
Hovering the top reveals a headerbar that mimics the right side of the default headerbar.
There are big next/previous-overlay-buttons that show/hide depending on being at the beginning or end of the article-list.