### PR TITLE
Solus is just called Solus, not Solus OS

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@
         <ul class="nav nav-tabs nav-justified">
             <li role="presentation" class="active"><a data-toggle="tab" href="#ubuntu">Ubuntu / elementary OS</a></li>
             <li role="presentation"><a data-toggle="tab" href="#arch">Arch Linux</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#solus">Solus OS</a></li>
+            <li role="presentation"><a data-toggle="tab" href="#solus">Solus</a></li>
             <li role="presentation"><a data-toggle="tab" href="#fedora">Fedora</a></li>
             <li role="presentation"><a data-toggle="tab" href="#source">Build from source</a></li>
         </ul>


### PR DESCRIPTION
Nit-pick: It's simply Solus. (I believe the history is Solus OS -> Evolve OS -> Solus)