### PR TITLE
Fix some string capitalisation in the UI

### DIFF
--- a/Constants.vala.in
+++ b/Constants.vala.in
@@ -37,7 +37,7 @@ namespace FeedReader {
 		public const string settings = _("Settings");
 		public const string reset = _("Change Account");
 		public const string quit = _("Quit");
-		public const string bugs = _("Report a bug");
+		public const string bugs = _("Report a Bug");
 		public const string bounty = _("Bounties");
 		public const string shortcuts = _("Shortcuts");
 	}

--- a/src/Widgets/ArticleViewHeader.vala
+++ b/src/Widgets/ArticleViewHeader.vala
@@ -65,7 +65,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 		m_tag_button.add(tag_icon);
 		m_tag_button.set_relief(Gtk.ReliefStyle.NONE);
 		m_tag_button.set_focus_on_click(false);
-		m_tag_button.set_tooltip_text(_("Tag Article"));
+		m_tag_button.set_tooltip_text(_("Tag article"));
 		m_tag_button.sensitive = false;
 		m_tag_button.clicked.connect(() => {
             popOpened();
@@ -79,7 +79,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 		m_print_button = new Gtk.Button.from_icon_name("printer-symbolic");
 		m_print_button.set_relief(Gtk.ReliefStyle.NONE);
 		m_print_button.set_focus_on_click(false);
-		m_print_button.set_tooltip_text(_("Print Article"));
+		m_print_button.set_tooltip_text(_("Print article"));
 		m_print_button.sensitive = false;
 		m_print_button.clicked.connect(() => {
 			ColumnView.get_default().print();
@@ -90,7 +90,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 		m_share_button.add(share_icon);
 		m_share_button.set_relief(Gtk.ReliefStyle.NONE);
 		m_share_button.set_focus_on_click(false);
-		m_share_button.set_tooltip_text(_("Share Article"));
+		m_share_button.set_tooltip_text(_("Share article"));
 		m_share_button.sensitive = false;
 
 		var shareSpinner = new Gtk.Spinner();

--- a/src/Widgets/ColumnViewHeader.vala
+++ b/src/Widgets/ColumnViewHeader.vala
@@ -57,7 +57,7 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 			change_state(m_state, transition);
 		});
 
-		m_refresh_button = new UpdateButton.from_icon_name("feed-refresh-symbolic", _("Update Feeds"));
+		m_refresh_button = new UpdateButton.from_icon_name("feed-refresh-symbolic", _("Update feeds"));
 		m_refresh_button.clicked.connect(() => {
 			if(!m_refresh_button.getStatus())
 				refresh();

--- a/src/Widgets/FeedListFooter.vala
+++ b/src/Widgets/FeedListFooter.vala
@@ -121,6 +121,7 @@ public class FeedReader.AddButton : Gtk.Button {
 		this.image.opacity = 0.8;
 		this.clicked.connect(onClick);
 		this.relief = Gtk.ReliefStyle.NONE;
+		this.set_tooltip_text(_("Add feed"));
 	}
 
 	public void onClick()
@@ -149,6 +150,7 @@ public class FeedReader.RemoveButton : Gtk.Button {
 		this.image.opacity = 0.8;
 		this.clicked.connect(onClick);
 		this.relief = Gtk.ReliefStyle.NONE;
+		this.set_tooltip_text(_("Remove feed"));
 	}
 
 	public void onClick()

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -352,7 +352,7 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 
 		m_ignore_tls_errors = m_error_bar.add_button("Ignore", Gtk.ResponseType.APPLY);
 		m_ignore_tls_errors.get_style_context().add_class(Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-		m_ignore_tls_errors.set_tooltip_text(_("Ignore all tls errors from now on"));
+		m_ignore_tls_errors.set_tooltip_text(_("Ignore all TLS errors from now on"));
 		m_ignore_tls_errors.set_visible(false);
 
 		m_error_bar.response.connect((response_id) => {


### PR DESCRIPTION
Trivial patches to make some bits of the UI conform to the [GNOME HIG](https://developer.gnome.org/hig/unstable/writing-style.html.en#capitalization).