### PR TITLE
Font settings improvements

### DIFF
--- a/data/ArticleView/article.html
+++ b/data/ArticleView/article.html
@@ -13,9 +13,9 @@
 <body style="font-size:$FONTSIZEpt;font-family:$FONTFAMILY;">
     <div class="$THEME">
         <header class="post unselectable">
-            <span class="source" style="font-size:$SOURCEFONTSIZE;">$FEED</span>
-            <h1><a href="$URL" target="_blank">$TITLE</a></h1>
-            <span class="author" style="font-size:$SOURCEFONTSIZE;">$AUTHOR</span>
+            <span class="source" style="font-size:$SMALLSIZEpt;">$FEED</span>
+            <h1><a href="$URL" target="_blank" style="font-size:$LARGESIZEpt;">$TITLE</a></h1>
+            <span class="author" style="font-size:$SMALLSIZEpt;">$AUTHOR</span>
         </header>
 
         <div class="content  $UNSELECTABLE">

--- a/src/UtilsUI.vala
+++ b/src/UtilsUI.vala
@@ -147,7 +147,7 @@ public class FeedReader.UtilsUI : GLib.Object {
 		string font = Settings.general().get_string("font");
 		var desc = Pango.FontDescription.from_string(font);
 		string fontfamilly = desc.get_family();
-		int fontsize = GLib.Math.roundf(desc.get_size()/Pango.SCALE).to_string().to_int();
+		int fontsize = int.parse(GLib.Math.roundf(desc.get_size()/Pango.SCALE).to_string());
 		string small_size = (fontsize - 2).to_string();
 		string large_size = (fontsize + 2).to_string();
 		string normal_size = fontsize.to_string();

--- a/src/UtilsUI.vala
+++ b/src/UtilsUI.vala
@@ -147,22 +147,29 @@ public class FeedReader.UtilsUI : GLib.Object {
 		string font = Settings.general().get_string("font");
 		var desc = Pango.FontDescription.from_string(font);
 		string fontfamilly = desc.get_family();
-		string fontsize = GLib.Math.roundf(desc.get_size()/Pango.SCALE).to_string();
+		int fontsize = GLib.Math.roundf(desc.get_size()/Pango.SCALE).to_string().to_int();
+		string small_size = (fontsize - 2).to_string();
+		string large_size = (fontsize + 2).to_string();
+		string normal_size = fontsize.to_string();
 		int fontfamilly_pos = article.str.index_of(fontfamily_id);
 		article.erase(fontfamilly_pos, fontfamily_id.length);
 		article.insert(fontfamilly_pos, fontfamilly);
 
-		string sourcefontsize = "0.75rem";
 		string fontsize_id = "$FONTSIZE";
-		string sourcefontsize_id = "$SOURCEFONTSIZE";
+		string sourcefontsize_id = "$SMALLSIZE";
 		int fontsize_pos = article.str.index_of(fontsize_id);
 		article.erase(fontsize_pos, fontsize_id.length);
-		article.insert(fontsize_pos, fontsize);
+		article.insert(fontsize_pos, normal_size);
+
+		string largesize_id = "$LARGESIZE";
+		int largesize_pos = article.str.index_of(largesize_id);
+		article.erase(largesize_pos, largesize_id.length);
+		article.insert(largesize_pos, large_size);
 
 		for(int i = article.str.index_of(sourcefontsize_id, 0); i != -1; i = article.str.index_of(sourcefontsize_id, i))
 		{
 			article.erase(i, sourcefontsize_id.length);
-			article.insert(i, sourcefontsize);
+			article.insert(i, small_size);
 		}
 
 


### PR DESCRIPTION
- Don't hard code font size 
   I used a large font size and a small font size, the larger size is the selected size + 2pt and the small size is the selected one -2pt, this way the font size won't be too small if you have a  4K screen and you wanted to have larger fonts;

- Follow font style: (not done yet)
For now, if the selected font is bold/italic or whatever kind of font, it's won't work as expected as we don't implement this yet. Should we really implement this or not?

