### PR TITLE
Use Gee.List interface instead of requiring exactly Gee.LinkedList

### DIFF
--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -80,7 +80,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		return false;
 	}
 
-	public bool getFeeds(Gee.LinkedList<feed> feeds)
+	public bool getFeeds(Gee.List<feed> feeds)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -147,7 +147,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		return true;
 	}
 
-	public bool getCategoriesAndTags(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getCategoriesAndTags(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -247,7 +247,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 	}
 
 
-	public string? updateArticles(Gee.LinkedList<string> ids, int count, string? continuation = null)
+	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -285,7 +285,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.LinkedList<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");

--- a/plugins/backend/bazqux/bazquxInterface.vala
+++ b/plugins/backend/bazqux/bazquxInterface.vala
@@ -189,7 +189,7 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		return "feed/" + feedURL;
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		//FIXME
 	}
@@ -240,7 +240,7 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getFeeds(feeds) && m_api.getCategoriesAndTags(feeds, categories, tags))
 			return true;

--- a/plugins/backend/bazqux/bazquxUtils.vala
+++ b/plugins/backend/bazqux/bazquxUtils.vala
@@ -155,7 +155,7 @@ public class FeedReader.bazquxUtils : GLib.Object {
 		}
 	}
 
-	public bool tagIsCat(string tagID, Gee.LinkedList<feed> feeds)
+	public bool tagIsCat(string tagID, Gee.List<feed> feeds)
 	{
 		foreach(feed Feed in feeds)
 		{

--- a/plugins/backend/demo/demoInterface.vala
+++ b/plugins/backend/demo/demoInterface.vala
@@ -415,7 +415,7 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	// Fill up the emtpy LinkedList's that are provided with instances of the
 	// model-classes category, feed and article
 	//--------------------------------------------------------------------------------------
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 
 	}
@@ -439,7 +439,7 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	// "isTagID":	false if "feedID" is a feed-ID, true if "feedID" is a tag-ID
 	//
 	// It is recommended after getting the articles from the server to use the signal
-	// "writeArticles(Gee.LinkedList<article> articles)"
+	// "writeArticles(Gee.List<article> articles)"
 	// to automatically process them in the content-grabber, write them to the
 	// data-base and send all the signals to the UI to update accordingly.
 	// But if the API suggests a different approach you can everything on your

--- a/plugins/backend/feedbin/feedbinAPI.vala
+++ b/plugins/backend/feedbin/feedbinAPI.vala
@@ -41,7 +41,7 @@ public class FeedReader.feedbinAPI : Object {
 		return LoginResponse.UNKNOWN_ERROR;
 	}
 
-	public bool getSubscriptionList(Gee.LinkedList<feed> feeds)
+	public bool getSubscriptionList(Gee.List<feed> feeds)
 	{
 		var response = m_connection.getRequest("subscriptions.json");
 
@@ -99,7 +99,7 @@ public class FeedReader.feedbinAPI : Object {
 		return true;
 	}
 
-	public bool getTaggings(Gee.LinkedList<category> categories, Gee.LinkedList<feed> feeds)
+	public bool getTaggings(Gee.List<category> categories, Gee.List<feed> feeds)
 	{
 		var response = m_connection.getRequest("taggings.json");
 
@@ -157,7 +157,7 @@ public class FeedReader.feedbinAPI : Object {
 
 
 
-	public int getEntries(Gee.LinkedList<article> articles, int page, bool starred, DateTime? timestamp, string? feedID = null)
+	public int getEntries(Gee.List<article> articles, int page, bool starred, DateTime? timestamp, string? feedID = null)
 	{
 		string request = "entries.json?per_page=100";
 		request += "&page=%i".printf(page);
@@ -239,7 +239,7 @@ public class FeedReader.feedbinAPI : Object {
 		return (int)length;
 	}
 
-	public Gee.LinkedList<string> unreadEntries()
+	public Gee.List<string> unreadEntries()
 	{
 		string response = m_connection.getRequest("unread_entries.json").data;
 		response = response.substring(1, response.length-2);
@@ -254,7 +254,7 @@ public class FeedReader.feedbinAPI : Object {
 		return ids;
 	}
 
-	public Gee.LinkedList<string> starredEntries()
+	public Gee.List<string> starredEntries()
 	{
 		string response = m_connection.getRequest("starred_entries.json").data;
 		response = response.substring(1, response.length-2);

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -216,7 +216,7 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		return "";
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		return;
 	}
@@ -266,7 +266,7 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getSubscriptionList(feeds)
 		&& m_api.getTaggings(categories, feeds))

--- a/plugins/backend/feedbin/feedbinUtils.vala
+++ b/plugins/backend/feedbin/feedbinUtils.vala
@@ -106,7 +106,7 @@ public class FeedReader.feedbinUtils : GLib.Object {
 		return removed;
 	}
 
-	public string? catExists(Gee.LinkedList<category> categories, string name)
+	public string? catExists(Gee.List<category> categories, string name)
 	{
 		foreach(category cat in categories)
 		{
@@ -117,7 +117,7 @@ public class FeedReader.feedbinUtils : GLib.Object {
 		return null;
 	}
 
-	public void addFeedToCat(Gee.LinkedList<feed> feeds, string feedID, string catID)
+	public void addFeedToCat(Gee.List<feed> feeds, string feedID, string catID)
 	{
 		foreach(feed f in feeds)
 		{

--- a/plugins/backend/feedhq/feedhqAPI.vala
+++ b/plugins/backend/feedhq/feedhqAPI.vala
@@ -83,7 +83,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		return false;
 	}
 
-	public bool getFeeds(Gee.LinkedList<feed> feeds)
+	public bool getFeeds(Gee.List<feed> feeds)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
@@ -150,7 +150,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		return true;
 	}
 
-	public bool getCategoriesAndTags(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getCategoriesAndTags(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
@@ -235,7 +235,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 	}
 
 
-	public string? updateArticles(Gee.LinkedList<string> ids, int count, string? continuation = null)
+	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
@@ -280,7 +280,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.LinkedList<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -190,7 +190,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		return "feed/" + feedURL;
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		return;
 	}
@@ -240,7 +240,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.import(opml);
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getFeeds(feeds) && m_api.getCategoriesAndTags(feeds, categories, tags))
 			return true;

--- a/plugins/backend/feedhq/feedhqUtils.vala
+++ b/plugins/backend/feedhq/feedhqUtils.vala
@@ -127,7 +127,7 @@ public class FeedReader.FeedHQUtils : GLib.Object {
 	}
 
 
-	public bool tagIsCat(string tagID, Gee.LinkedList<feed> feeds)
+	public bool tagIsCat(string tagID, Gee.List<feed> feeds)
 	{
 		foreach(feed Feed in feeds)
 		{

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -133,7 +133,7 @@ public class FeedReader.FeedlyAPI : Object {
 	}
 
 
-	public bool getCategories(Gee.LinkedList<category> categories)
+	public bool getCategories(Gee.List<category> categories)
 	{
 		string response = m_connection.send_get_request_to_feedly ("/v3/categories/");
 
@@ -178,7 +178,7 @@ public class FeedReader.FeedlyAPI : Object {
 	}
 
 
-	public bool getFeeds(Gee.LinkedList<feed> feeds)
+	public bool getFeeds(Gee.List<feed> feeds)
 	{
 		string response = m_connection.send_get_request_to_feedly("/v3/subscriptions/");
 
@@ -258,7 +258,7 @@ public class FeedReader.FeedlyAPI : Object {
 	}
 
 
-	public bool getTags(Gee.LinkedList<tag> tags)
+	public bool getTags(Gee.List<tag> tags)
 	{
 		string response = m_connection.send_get_request_to_feedly("/v3/tags/");
 
@@ -294,7 +294,7 @@ public class FeedReader.FeedlyAPI : Object {
 
 
 
-	public string getArticles(Gee.LinkedList<article> articles, int count, string continuation = "", ArticleStatus whatToGet = ArticleStatus.ALL, string tagID = "", string feed_id = "")
+	public string getArticles(Gee.List<article> articles, int count, string continuation = "", ArticleStatus whatToGet = ArticleStatus.ALL, string tagID = "", string feed_id = "")
 	{
 		string steamID = "user/" + m_userID + "/category/global.all";
 		string cont = "";

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -198,7 +198,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		return "feed/" + feedURL;
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		foreach(feed f in feeds)
 		{
@@ -253,7 +253,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.importOPML(opml);
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		m_api.getUnreadCounts();
 

--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -34,7 +34,7 @@ public class FeedReader.freshAPI : Object {
 		return m_connection.getSID();
 	}
 
-	public bool getSubscriptionList(Gee.LinkedList<feed> feeds)
+	public bool getSubscriptionList(Gee.List<feed> feeds)
 	{
 		string response = m_connection.getRequest("reader/api/0/subscription/list?output=json");
 
@@ -100,7 +100,7 @@ public class FeedReader.freshAPI : Object {
 		return true;
 	}
 
-	public bool getTagList(Gee.LinkedList<category> categories)
+	public bool getTagList(Gee.List<category> categories)
 	{
 		string response = m_connection.getRequest("reader/api/0/tag/list?output=json");
 		string prefix = "user/-/label/";

--- a/plugins/backend/fresh/freshInterface.vala
+++ b/plugins/backend/fresh/freshInterface.vala
@@ -178,7 +178,7 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		return m_api.editStream("subscribe", {"feed/" + feedURL}, null, cat, null);
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		string cat = "";
 		string[] urls = {};
@@ -244,7 +244,7 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getSubscriptionList(feeds)
 		&& m_api.getTagList(categories))

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -83,7 +83,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		return false;
 	}
 
-	public bool getFeeds(Gee.LinkedList<feed> feeds)
+	public bool getFeeds(Gee.List<feed> feeds)
 	{
 		string response = m_connection.send_request("subscription/list");
 
@@ -149,7 +149,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		return true;
 	}
 
-	public bool getCategoriesAndTags(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getCategoriesAndTags(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		string response = m_connection.send_request("tag/list");
 
@@ -243,7 +243,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 	}
 
 
-	public string? updateArticles(Gee.LinkedList<string> ids, int count, string? continuation = null)
+	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
 	{
 		var message_string = "n=" + count.to_string();
 		message_string += "&xt=user/-/state/com.google/read";
@@ -278,7 +278,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.LinkedList<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
 	{
 		var message_string = "n=" + count.to_string();
 

--- a/plugins/backend/inoreader/InoReaderInterface.vala
+++ b/plugins/backend/inoreader/InoReaderInterface.vala
@@ -190,7 +190,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return "feed/" + feedURL;
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		string cat = "";
 		string[] urls = {};
@@ -256,7 +256,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getFeeds(feeds)
 		&& m_api.getCategoriesAndTags(feeds, categories, tags))

--- a/plugins/backend/inoreader/InoReaderUtils.vala
+++ b/plugins/backend/inoreader/InoReaderUtils.vala
@@ -173,7 +173,7 @@ public class FeedReader.InoReaderUtils : GLib.Object {
 	}
 
 
-	public bool tagIsCat(string tagID, Gee.LinkedList<feed> feeds)
+	public bool tagIsCat(string tagID, Gee.List<feed> feeds)
 	{
 		foreach(feed Feed in feeds)
 		{

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -207,7 +207,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		return "";
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		var finishedFeeds = new Gee.LinkedList<feed>();
 
@@ -306,7 +306,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		var cats = dbDaemon.get_default().read_categories();
 		foreach(category cat in cats)

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -79,7 +79,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		return false;
 	}
 
-	public bool getFeeds(Gee.LinkedList<feed> feeds)
+	public bool getFeeds(Gee.List<feed> feeds)
 	{
 
 		string response = m_connection.send_get_request("subscription/list?output=json");
@@ -141,7 +141,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		return true;
 	}
 
-	public bool getCategoriesAndTags(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getCategoriesAndTags(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		string response = m_connection.send_get_request("tag/list?output=json");
 		if(response == "" || response == null)
@@ -219,7 +219,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 	}
 
 
-	public string? updateArticles(Gee.LinkedList<string> ids, int count, string? continuation = null)
+	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
 	{
 		var message_string = "n=" + count.to_string();
 		message_string += "&xt=user/-/state/com.google/read";
@@ -252,7 +252,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.LinkedList<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
 	{
 		var message_string = "n=" + count.to_string();
 

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -190,7 +190,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return "feed/" + feedURL;
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		string cat = "";
 		string[] urls = {};
@@ -257,7 +257,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getFeeds(feeds)
 		&& m_api.getCategoriesAndTags(feeds, categories, tags))

--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -99,7 +99,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		return false;
 	}
 
-    public bool getFeeds(Gee.LinkedList<feed> feeds)
+    public bool getFeeds(Gee.List<feed> feeds)
 	{
 		if(isloggedin())
 		{
@@ -154,7 +154,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 	}
 
 
-    public bool getCategories(Gee.LinkedList<category> categories, Gee.LinkedList<feed> feeds)
+    public bool getCategories(Gee.List<category> categories, Gee.List<feed> feeds)
 	{
 		if(isloggedin())
 		{
@@ -204,7 +204,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 	}
 
 
-    public void getNewArticles(Gee.LinkedList<article> articles, int lastModified, OwnCloudType type, int id)
+    public void getNewArticles(Gee.List<article> articles, int lastModified, OwnCloudType type, int id)
 	{
 		var message = new OwnCloudNewsMessage(m_OwnCloudURL + "/items/updated", m_username, m_password, "GET");
         message.add_int("lastModified", lastModified);
@@ -273,7 +273,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 
 
-    public void getArticles(Gee.LinkedList<article> articles, int skip, int count, bool read, OwnCloudType type, int id)
+    public void getArticles(Gee.List<article> articles, int skip, int count, bool read, OwnCloudType type, int id)
 	{
         var message = new OwnCloudNewsMessage(m_OwnCloudURL + "items", m_username, m_password, "GET");
         message.add_bool("oldestFirst", false);

--- a/plugins/backend/owncloud/OwncloudNewsInterface.vala
+++ b/plugins/backend/owncloud/OwncloudNewsInterface.vala
@@ -170,7 +170,7 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		return m_api.addFeed(feedURL, catID).to_string();
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		foreach(feed f in feeds)
 		{
@@ -224,7 +224,7 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getFeeds(feeds)
 		&& m_api.getCategories(categories, feeds))

--- a/plugins/backend/owncloud/OwncloudNewsUtils.vala
+++ b/plugins/backend/owncloud/OwncloudNewsUtils.vala
@@ -255,7 +255,7 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 	}
 
 
-    public int countUnread(Gee.LinkedList<feed> feeds, string id)
+    public int countUnread(Gee.List<feed> feeds, string id)
     {
         int unread = 0;
 

--- a/plugins/backend/ttrss/ttrssAPI.vala
+++ b/plugins/backend/ttrss/ttrssAPI.vala
@@ -174,7 +174,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 
-	public bool getFeeds(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories)
+	public bool getFeeds(Gee.List<feed> feeds, Gee.List<category> categories)
 	{
 		foreach(var item in categories)
 		{
@@ -222,7 +222,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 
-	public bool getUncategorizedFeeds(Gee.LinkedList<feed> feeds)
+	public bool getUncategorizedFeeds(Gee.List<feed> feeds)
 	{
 		var message = new ttrssMessage(m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -261,7 +261,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return false;
 	}
 
-	public bool getTags(Gee.LinkedList<tag> tags)
+	public bool getTags(Gee.List<tag> tags)
 	{
 		var message = new ttrssMessage(m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -309,7 +309,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 
-	public bool getCategories(Gee.LinkedList<category> categories)
+	public bool getCategories(Gee.List<category> categories)
 	{
 		var message = new ttrssMessage(m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -331,7 +331,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 
-	private void getSubCategories(Gee.LinkedList<category> categories, Json.Object categorie, int level, string parent)
+	private void getSubCategories(Gee.List<category> categories, Json.Object categorie, int level, string parent)
 	{
 		level++;
 		int orderID = 0;
@@ -407,7 +407,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 
-	public void getHeadlines(Gee.LinkedList<article> articles, int skip, int limit, ArticleStatus whatToGet, int feedID)
+	public void getHeadlines(Gee.List<article> articles, int skip, int limit, ArticleStatus whatToGet, int feedID)
 	{
 		var message = new ttrssMessage(m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -500,7 +500,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 	// tt-rss server needs newsplusplus extention
-	public Gee.LinkedList<string>? NewsPlus(ArticleStatus type, int limit)
+	public Gee.List<string>? NewsPlus(ArticleStatus type, int limit)
 	{
 		var message = new ttrssMessage(m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -534,7 +534,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	}
 
 
-	public void getArticles(string articleIDs, Gee.LinkedList<article> articles)
+	public void getArticles(string articleIDs, Gee.List<article> articles)
 	{
 		var message = new ttrssMessage(m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);

--- a/plugins/backend/ttrss/ttrssInterface.vala
+++ b/plugins/backend/ttrss/ttrssInterface.vala
@@ -178,7 +178,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		return (int.parse(dbDaemon.get_default().getHighestFeedID()) + 1).to_string();
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		foreach(feed f in feeds)
 		{
@@ -235,7 +235,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(m_api.getCategories(categories)
 		&& m_api.getFeeds(feeds, categories)

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -259,7 +259,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		return;
 	}
 
-	private void writeArticles(Gee.LinkedList<article> articles)
+	private void writeArticles(Gee.List<article> articles)
 	{
 		if(articles.size > 0)
 		{
@@ -723,7 +723,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		m_plugin.addFeed(feedURL, catID, newCatName);
 	}
 
-	public void addFeeds(Gee.LinkedList<feed> feeds)
+	public void addFeeds(Gee.List<feed> feeds)
 	{
 		if(!m_pluginLoaded)
 			return;
@@ -803,7 +803,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		m_plugin.importOPML(opml);
 	}
 
-	public bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags)
 	{
 		if(!m_pluginLoaded)
 			return false;

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -264,11 +264,13 @@ public class FeedReader.FeedServer : GLib.Object {
 		if(articles.size > 0)
 		{
 			dbDaemon.get_default().update_articles(articles);
-			var new_articles = new Gee.LinkedList<article>();
 
-			var it = articles.bidir_list_iterator();
-			for (var has_next = it.last(); has_next; has_next = it.previous())
-				new_articles.add(it.get());
+			// Reverse the list
+			var new_articles = new Gee.LinkedList<article>();
+			foreach(var article in articles)
+			{
+				new_articles.insert(0, article);
+			}
 
 			dbDaemon.get_default().write_articles(new_articles);
 			updateFeedList();

--- a/src/Backend/FeedServerInterface.vala
+++ b/src/Backend/FeedServerInterface.vala
@@ -20,7 +20,7 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 	public signal void updateArticleList();
 	public signal void writeInterfaceState();
 	public signal void showArticleListOverlay();
-	public signal void writeArticles(Gee.LinkedList<article> articles);
+	public signal void writeArticles(Gee.List<article> articles);
 
 	public abstract void init();
 
@@ -83,7 +83,7 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract string addFeed(string feedURL, string? catID = null, string? newCatName = null);
 
-	public abstract void addFeeds(Gee.LinkedList<feed> feeds);
+	public abstract void addFeeds(Gee.List<feed> feeds);
 
 	public abstract void removeFeed(string feedID);
 
@@ -103,7 +103,7 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract void importOPML(string opml);
 
-	public abstract bool getFeedsAndCats(Gee.LinkedList<feed> feeds, Gee.LinkedList<category> categories, Gee.LinkedList<tag> tags);
+	public abstract bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags);
 
 	public abstract int getUnreadCount();
 

--- a/src/Backend/OPMLparser.vala
+++ b/src/Backend/OPMLparser.vala
@@ -17,7 +17,7 @@ public class FeedReader.OPMLparser : GLib.Object {
 
 	private string m_opmlString;
 	private uint m_level = 0;
-	private Gee.LinkedList<feed> m_feeds;
+	private Gee.List<feed> m_feeds;
 
 	public OPMLparser(string opml)
 	{

--- a/src/Logger.vala
+++ b/src/Logger.vala
@@ -17,7 +17,7 @@ public class FeedReader.Logger : GLib.Object {
 
 	private int m_LogLevel;
 	private GLib.FileOutputStream m_stream;
-	private Gee.LinkedList<string> m_pendingWrites;
+	private Gee.List<string> m_pendingWrites;
 
 	private static Logger? m_logger = null;
 	private static string? m_fileName = null;

--- a/src/UtilsDaemon.vala
+++ b/src/UtilsDaemon.vala
@@ -15,7 +15,7 @@
 
 public class FeedReader.UtilsDaemon : GLib.Object {
 
-    public static void generatePreviews(Gee.LinkedList<article> articles)
+    public static void generatePreviews(Gee.List<article> articles)
 	{
 		string noPreview = _("No Preview Available");
 		foreach(var Article in articles)
@@ -68,7 +68,7 @@ public class FeedReader.UtilsDaemon : GLib.Object {
 		}
 	}
 
-    public static void checkHTML(Gee.LinkedList<article> articles)
+    public static void checkHTML(Gee.List<article> articles)
 	{
 		foreach(var Article in articles)
 		{

--- a/src/Widgets/ArticleList/ArticleList.vala
+++ b/src/Widgets/ArticleList/ArticleList.vala
@@ -128,7 +128,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 		Logger.debug("ArticleList: disallow signals from scroll");
 		m_currentScroll.allowSignals(false);
-		var articles = new Gee.LinkedList<article>();
+		Gee.List<article> articles = new Gee.LinkedList<article>();
 		uint offset = 0;
 		bool newArticles = false;
 		if(Settings.state().get_int("articlelist-new-rows") > 0 && m_state == ArticleListState.ALL)
@@ -243,7 +243,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		if(m_loadThread != null)
 			m_loadThread.join();
 
-		var articles = new Gee.LinkedList<article>();
+		Gee.List<article> articles = new Gee.LinkedList<article>();
 		SourceFunc callback = loadMore.callback;
 		//-----------------------------------------------------------------------------------------------------------------------------------------------------
 		ThreadFunc<void*> run = () => {
@@ -288,7 +288,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		if(m_loadThread != null)
 			m_loadThread.join();
 
-		var articles = new Gee.LinkedList<article>();
+		Gee.List<article> articles = new Gee.LinkedList<article>();
 		SourceFunc callback = loadNewer.callback;
 		//-----------------------------------------------------------------------------------------------------------------------------------------------------
 		ThreadFunc<void*> run = () => {
@@ -362,7 +362,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		if(firstRowID == null)
 			return;
 
-		var articles = new Gee.LinkedList<article>();
+		Gee.List<article> articles = new Gee.LinkedList<article>();
 		SourceFunc callback = updateArticleList.callback;
 		//-----------------------------------------------------------------------------------------------------------------------------------------------------
 		ThreadFunc<void*> run = () => {

--- a/src/Widgets/ArticleList/ArticleListBox.vala
+++ b/src/Widgets/ArticleList/ArticleListBox.vala
@@ -15,7 +15,7 @@
 
 public class FeedReader.ArticleListBox : Gtk.ListBox {
 
-	private Gee.LinkedList<article> m_lazyQeue;
+	private Gee.List<article> m_lazyQeue;
 	private uint m_idleID = 0;
 	private string m_name;
 	private uint m_selectSourceID = 0;
@@ -39,7 +39,7 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		this.row_activated.connect(rowActivated);
 	}
 
-	public void newList(Gee.LinkedList<article> articles)
+	public void newList(Gee.List<article> articles)
 	{
 		stopLoading();
 		emptyList();
@@ -47,14 +47,14 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		addRow(ArticleListBalance.NONE);
 	}
 
-	public void addTop(Gee.LinkedList<article> articles)
+	public void addTop(Gee.List<article> articles)
 	{
 		stopLoading();
 		m_lazyQeue = articles;
 		addRow(ArticleListBalance.TOP, 0, true);
 	}
 
-	public void addBottom(Gee.LinkedList<article> articles)
+	public void addBottom(Gee.List<article> articles)
 	{
 		stopLoading();
 		m_lazyQeue = articles;

--- a/src/dbBase.vala
+++ b/src/dbBase.vala
@@ -1384,7 +1384,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return tmp;
 	}
 
-	public Gee.LinkedList<article> readUnfetchedArticles()
+	public Gee.List<article> readUnfetchedArticles()
 	{
 		var query = new QueryBuilder(QueryType.SELECT, "main.articles");
 		query.selectField("articleID");
@@ -1429,7 +1429,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return tmp;
 	}
 
-	public Gee.LinkedList<article> read_articles(string ID, FeedListType selectedType, ArticleListState state, string searchTerm, uint limit = 20, uint offset = 0, int searchRows = 0)
+	public Gee.List<article> read_articles(string ID, FeedListType selectedType, ArticleListState state, string searchTerm, uint limit = 20, uint offset = 0, int searchRows = 0)
 	{
 		var query = new QueryBuilder(QueryType.SELECT, "main.articles");
 		query.selectField("ROWID");

--- a/src/dbDaemon.vala
+++ b/src/dbDaemon.vala
@@ -165,7 +165,7 @@ public class FeedReader.dbDaemon : dbBase {
         }
     }
 
-    public void write_feeds(Gee.LinkedList<feed> feeds)
+    public void write_feeds(Gee.List<feed> feeds)
     {
         executeSQL("BEGIN TRANSACTION");
 
@@ -226,7 +226,7 @@ public class FeedReader.dbDaemon : dbBase {
         executeSQL("COMMIT TRANSACTION");
     }
 
-    public void write_tags(Gee.LinkedList<tag> tags)
+    public void write_tags(Gee.List<tag> tags)
     {
         executeSQL("BEGIN TRANSACTION");
 
@@ -266,7 +266,7 @@ public class FeedReader.dbDaemon : dbBase {
         executeSQL("COMMIT TRANSACTION");
     }
 
-    public void update_tags(Gee.LinkedList<tag> tags)
+    public void update_tags(Gee.List<tag> tags)
     {
         executeSQL("BEGIN TRANSACTION");
 
@@ -312,7 +312,7 @@ public class FeedReader.dbDaemon : dbBase {
 
 
 
-    public void write_categories(Gee.LinkedList<category> categories)
+    public void write_categories(Gee.List<category> categories)
     {
         executeSQL("BEGIN TRANSACTION");
 
@@ -360,7 +360,7 @@ public class FeedReader.dbDaemon : dbBase {
         executeSQL("COMMIT TRANSACTION");
     }
 
-    public void updateArticlesByID(Gee.LinkedList<string> ids, string field)
+    public void updateArticlesByID(Gee.List<string> ids, string field)
     {
         // first reset all articles
         var reset_query = new QueryBuilder(QueryType.UPDATE, "main.articles");
@@ -442,7 +442,7 @@ public class FeedReader.dbDaemon : dbBase {
         executeSQL("COMMIT TRANSACTION");
     }
 
-    public void update_articles(Gee.LinkedList<article> articles)
+    public void update_articles(Gee.List<article> articles)
     {
         executeSQL("BEGIN TRANSACTION");
 
@@ -500,7 +500,7 @@ public class FeedReader.dbDaemon : dbBase {
     }
 
 
-    public void write_articles(Gee.LinkedList<article> articles)
+    public void write_articles(Gee.List<article> articles)
     {
         FeedReader.UtilsDaemon.generatePreviews(articles);
         FeedReader.UtilsDaemon.checkHTML(articles);


### PR DESCRIPTION
This just changes all references to `Gee.LinkedList` in type parameters to `Gee.List`. Everything has the same type as before, but it will be a lot easier to use certain functions (like `List.slice`) if we use the interface instead of a concrete type.

The only change needed was to reverse the list in `FeedServer.writeArticles()` in a way that doesn't require a bidirectional iterator, and hopefully this is easier to read anyway.