### PR TITLE
Add tooltips for two tool buttons

### DIFF
--- a/src/Widgets/ArticleViewHeader.vala
+++ b/src/Widgets/ArticleViewHeader.vala
@@ -42,11 +42,13 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 
         m_mark_button = new HoverButton(unmarked_icon, marked_icon, false);
 		m_mark_button.sensitive = false;
+		m_mark_button.set_tooltip_text(_("Mark article as starred or unstarred"));
 		m_mark_button.clicked.connect(() => {
 			toggledMarked();
 		});
 		m_read_button = new HoverButton(read_icon, unread_icon, false);
 		m_read_button.sensitive = false;
+		m_read_button.set_tooltip_text(_("Mark article as read or unread"));
 		m_read_button.clicked.connect(() => {
 			toggledRead();
 		});

--- a/src/Widgets/HoverButton.vala
+++ b/src/Widgets/HoverButton.vala
@@ -118,5 +118,10 @@ public class FeedReader.HoverButton : Gtk.EventBox {
         return true;
     }
 
+    public void set_tooltip_text(string tooltip_text)
+    {
+        m_button.set_tooltip_text(tooltip_text);
+    }
+
 
 }


### PR DESCRIPTION
Adding tooltips for the following tool buttons that are missing one:

- Star icon to mark article as starred / unstarred
- Circle icon to mark article as read / unread

This assists users with disabilities as well as giving a translation for
an unrecognized icon, like the circle for Mark read/unread that isn't
obvious.