### PR TITLE
Use article title as header title

### DIFF
--- a/src/Widgets/ColumnView.vala
+++ b/src/Widgets/ColumnView.vala
@@ -57,6 +57,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			m_articleList.setSelectedType(FeedListType.FEED);
 			m_article_view.clearContent();
 			m_headerbar.showArticleButtons(false);
+                        m_headerbar.clearTitle();
 			m_articleList.setSelectedFeed(feedID);
 			newArticleList();
 
@@ -76,6 +77,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			m_articleList.setSelectedType(FeedListType.TAG);
 			m_article_view.clearContent();
 			m_headerbar.showArticleButtons(false);
+                        m_headerbar.clearTitle();
 			m_articleList.setSelectedFeed(tagID);
 			newArticleList();
 			m_footer.setRemoveButtonSensitive(true);
@@ -87,6 +89,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			m_articleList.setSelectedType(FeedListType.CATEGORY);
 			m_article_view.clearContent();
 			m_headerbar.showArticleButtons(false);
+                        m_headerbar.clearTitle();
 			m_articleList.setSelectedFeed(categorieID);
 			newArticleList();
 
@@ -135,6 +138,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			{
 				m_article_view.load(row.getID());
 				m_headerbar.showArticleButtons(true);
+                                m_headerbar.setTitle(row.getName());
 				Logger.debug("ContentPage: set headerbar");
 				m_headerbar.setRead(row.isUnread());
 				m_headerbar.setMarked(row.isMarked());
@@ -289,6 +293,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 	private void clearArticleView()
 	{
 		m_headerbar.showArticleButtons(false);
+                m_headerbar.clearTitle();
 		m_article_view.clearContent();
 	}
 

--- a/src/Widgets/ColumnViewHeader.vala
+++ b/src/Widgets/ColumnViewHeader.vala
@@ -119,7 +119,7 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 		m_header_right.show_close_button = true;
 		m_header_right.get_style_context().add_class("header_left");
 		m_header_right.get_style_context().add_class("titlebar");
-		m_header_right.set_title("FeedReader");
+		this.clearTitle();
 		m_header_right.set_size_request(450, 0);
 		m_header_right.toggledMarked.connect(() => {
 			toggledMarked();
@@ -234,4 +234,13 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 		state.setSearchTerm(m_search.text);
 		state.setArticleListState(m_state);
 	}
+	public void setTitle(string title)
+	{
+		m_header_right.set_title(title);
+	}
+	public void clearTitle()
+	{
+		m_header_right.set_title("FeedReader");
+	}
+
 }


### PR DESCRIPTION
From GTK+ docs: "The title should help a user identify the current
view. A good title should not include the application name." [1]

It is already the case for the fullscreen header. This change is for
the column view header.  See other gnome applications for reference,
like Terminal, Polari.

[1] https://developer.gnome.org/gtk3/stable/GtkHeaderBar.html#gtk-header-bar-set-title