### PR TITLE
Favicon caching improvements

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -501,6 +501,75 @@ public class FeedReader.Utils : GLib.Object {
 		return downloadIcon(feed_id, icon_url, icon_path);
 	}
 
+	private struct ResourceMetadata
+	{
+		private const string CACHE_GROUP = "cache";
+		private const string ETAG_KEY = "etag";
+		private const string LAST_MODIFIED_KEY = "last_modified";
+
+		string? etag;
+		string? last_modified;
+
+		public ResourceMetadata()
+		{
+		}
+
+		public ResourceMetadata.from_file(string filename)
+		{
+			var config = new KeyFile();
+			try
+			{
+				config.load_from_file(filename, KeyFileFlags.NONE);
+				try { this.etag = config.get_string(CACHE_GROUP, ETAG_KEY); }
+				catch (KeyFileError.KEY_NOT_FOUND e) {}
+				catch (KeyFileError.GROUP_NOT_FOUND e) {}
+				try { this.last_modified = config.get_string(CACHE_GROUP, LAST_MODIFIED_KEY); }
+				catch (KeyFileError.KEY_NOT_FOUND e) {}
+				catch (KeyFileError.GROUP_NOT_FOUND e) {}
+			}
+			catch (KeyFileError.PARSE e)
+			{
+				// Try to load old-style etag metadata
+				// TODO: At some point we should remove this backwards compatibility
+				// Removing it will cause old clients to re-download all favicons,
+				// so for efficiency it might be nice to leave this for one release
+				Logger.warning(@"FaviconMetadata.from_file: Failed to load $filename as an INI. Treating it like an etag file instead.");
+				this.etag = getFileContent(filename);
+			}
+			catch (KeyFileError e)
+			{
+				Logger.warning(@"FaviconMetadata.from_file: Failed to load $filename: " + e.message);
+			}
+			catch (FileError e)
+			{
+				Logger.warning(@"FaviconMetadata.from_file: Failed to load $filename: " + e.message);
+			}
+		}
+
+		public void save_to_file(string filename)
+		{
+			if(this.etag == null && this.last_modified == null)
+			{
+				if(FileUtils.unlink(filename) != 0)
+					Logger.warning(@"FaviconMetadata.save_to_file: Error deleting metadata file $filename");
+			}
+			else
+			{
+				var config = new KeyFile();
+				config.set_string(CACHE_GROUP, ETAG_KEY, this.etag);
+				config.set_string(CACHE_GROUP, LAST_MODIFIED_KEY, this.last_modified);
+				try
+				{
+					config.save_to_file(filename);
+				}
+				catch (FileError e)
+				{
+					Logger.warning(@"FaviconMetadata.save_to_file: Failed to save metadata file $filename: " + e.message);
+				}
+			}
+		}
+	}
+
 	public static bool downloadIcon(string feed_id, string? icon_url, string icon_path = GLib.Environment.get_user_data_dir() + "/feedreader/data/feed_icons/")
 	{
 		if(icon_url == "" || icon_url == null || GLib.Uri.parse_scheme(icon_url) == null)
@@ -514,51 +583,17 @@ public class FeedReader.Utils : GLib.Object {
 		string filename_prefix = icon_path + feed_id.replace("/", "_").replace(".", "_");
 		string local_filename = filename_prefix + ".ico";
 		string metadata_filename = filename_prefix + ".txt";
-		string cache_group = "cache";
-		string etag_key = "etag";
-		string last_modified_key = "last_modified";
 
 		string? etag = null;
 		// Normally, we would store a last modified time as a datetime type, but
 		// servers aren't consistent about the format so we need to treat it as a
 		// black box.
 		string? last_modified = null;
-		if(FileUtils.test(local_filename, GLib.FileTest.EXISTS)
-		&& FileUtils.test(metadata_filename, GLib.FileTest.EXISTS))
+		if(FileUtils.test(local_filename, GLib.FileTest.EXISTS))
 		{
-			var metadata = new KeyFile();
-			try
-			{
-				try
-				{
-					metadata.load_from_file(metadata_filename, KeyFileFlags.NONE);
-					try { etag = metadata.get_string(cache_group, etag_key); }
-					catch (KeyFileError.KEY_NOT_FOUND e) {}
-					catch (KeyFileError.GROUP_NOT_FOUND e) {}
-					try { last_modified = metadata.get_string(cache_group, last_modified_key); }
-					catch (KeyFileError.KEY_NOT_FOUND e) {}
-					catch (KeyFileError.GROUP_NOT_FOUND e) {}
-				}
-				catch (KeyFileError.PARSE e)
-				{
-					// Try to load old-style etag metadata
-					// TODO: At some point we should remove this backwards compatibility
-					// Removing it will cause old clients to re-download all favicons,
-					// so for efficiency it might be nice to leave this for one release
-					Logger.warning(@"Utils.downloadIcon: Failed to load $metadata_filename as an INI. Treating it like an etag file instead.");
-					etag = getFileContent(metadata_filename);
-				}
-				catch (KeyFileError e)
-				{
-					var message = e.message;
-					Logger.warning(@"Utils.downloadIcon: Failed to read favicon metadata file $metadata_filename: $message");
-				}
-			}
-			catch (FileError e)
-			{
-				var message = e.message;
-				Logger.warning(@"Utils.downloadIcon: Failed to read favicon metadata file $metadata_filename: $message");
-			}
+			var metadata = ResourceMetadata.from_file(metadata_filename);
+			etag = metadata.etag;
+			last_modified = metadata.last_modified;
 		}
 
 		Logger.debug(@"Utils.downloadIcon: url = $icon_url");
@@ -610,31 +645,10 @@ public class FeedReader.Utils : GLib.Object {
 				}
 			}
 
-			etag = message.response_headers.get_one("ETag");
-			last_modified = message.response_headers.get_one("Last-Modified");
-			// File downloaded successfully; time to save the caching metadata
-			if(etag == null && last_modified == null)
-			{
-				if(FileUtils.unlink(metadata_filename) != 0)
-					Logger.warning(@"Error deleting metadata file $metadata_filename");
-			}
-			else
-			{
-				var metadata = new KeyFile();
-				if(etag != null)
-					metadata.set_string(cache_group, etag_key, etag);
-				if(last_modified != null)
-					metadata.set_string(cache_group, last_modified_key, last_modified);
-				try
-				{
-					metadata.save_to_file(metadata_filename);
-				}
-				catch (FileError e)
-				{
-					Logger.warning(@"Failed to save metadata file $metadata_filename: " + e.message);
-				}
-			}
-
+			var metadata = ResourceMetadata();
+			metadata.etag = message.response_headers.get_one("ETag");
+			metadata.last_modified = message.response_headers.get_one("Last-Modified");
+			metadata.save_to_file(metadata_filename);
 			return true;
 		}
 		Logger.warning(@"Could not download icon for feed: $feed_id $icon_url, got response code $status");


### PR DESCRIPTION
This makes two major changes:

 - Sends caching headers instead of sending a HEAD request and checking the results.
 - Also sends the last modified time, which a lot of CDN's use instead of ETags.

I changed the format of the icon .txt file to be an INI file with multiple values instead of just etags, but I left the etag-only version as a backup so we don't waste users' bandwidth the first time they run this.