### PR TITLE
Add CircleCI build info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (FeedReader)
+project (FeedReader C)
 cmake_minimum_required (VERSION 2.6)
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include_directories(${CMAKE_SOURCE_DIR}/libVilistextum)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Join the chat at https://gitter.im/Feedreader-dev/Lobby](https://badges.gitter.im/Feedreader-dev/Lobby.svg)](https://gitter.im/Feedreader-dev/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+[![CircleCI](https://circleci.com/gh/jangernert/FeedReader.svg?style=shield)](https://circleci.com/gh/jangernert/FeedReader)
 
 # [FeedReader](http://jangernert.github.io/FeedReader/)
 
@@ -84,4 +85,3 @@ make
 sudo make install
 ```
 Arch users can build the latest version using `yaourt -S feedreader-git`
-

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,32 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: fedora:latest
+    working_directory: ~/FeedReader
+    steps:
+      - run: >
+          dnf -y install
+          cmake
+          gcc
+          gettext
+          git
+          gnome-online-accounts-devel
+          gstreamer1-devel
+          gstreamer1-plugins-base-devel
+          gtk3-devel
+          json-glib-devel
+          libcurl-devel
+          libgee-devel
+          libnotify-devel
+          libpeas-devel
+          libsecret-devel
+          libsoup-devel
+          libxml2-devel
+          rest-devel
+          sqlite-devel
+          vala
+          webkitgtk4-devel
+      - checkout
+      - run: cmake .
+      - run: make


### PR DESCRIPTION
This will enable CirclECI builds and show a build badge in the README.

You will need to create a CircleCI account and add the project, since it won't let me add a repo I don't own.

I also changed the cmake project type to "C" so it won't fail if we don't have a C++ compiler.

I used Fedora as the build image since that's what I use (easiest for me to setup). Feel free to change it to something else if you prefer. We can make the build *a lot* faster if we make a custom docker image, but I didn't feel like doing that right now.

Also this mainly just tests that everything compiles. We should add some tests at some point.