### PR TITLE
Prefer "content" over "summary" in libmrss

### DIFF
--- a/plugins/backend/local/libmrss/mrss_parser.c
+++ b/plugins/backend/local/libmrss/mrss_parser.c
@@ -1,16 +1,16 @@
-/* mRss - Copyright (C) 2005-2007 bakunin - Andrea Marchesini 
+/* mRss - Copyright (C) 2005-2007 bakunin - Andrea Marchesini
  *                                    <bakunin@autistici.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -360,9 +360,17 @@ __mrss_parser_atom_entry (nxml_t * doc, nxml_data_t * cur, mrss_t * data)
 	    item->link = c;
 
 	  /* content -> description */
-	  else if (!item->description && !strcmp (cur->value, "content"))
+	  /* Note: We intentionally override summary with content */
+	  else if (!strcmp (cur->value, "content"))
+	  {
+	  	if (item->description)
+	  	{
+	  	  nxml_free(item->description);
+	  	  item->description = NULL;
+	  	}
 	    __mrss_parser_atom_string (doc, cur, &item->description,
 				       &item->description_type);
+	  }
 
 	  /* summary -> description */
 	  else if (!item->description && !strcmp (cur->value, "summary"))


### PR DESCRIPTION
See bug #463 

This isn't ideal because `<content>` in ATOM isn't required to contain text, but I think from a practical perspective, it's probably better than `<description>` in (almost?) all cases.

https://validator.w3.org/feed/docs/atom.html#contentElement