### PR TITLE
Favicons

### DIFF
--- a/Constants.vala.in
+++ b/Constants.vala.in
@@ -58,6 +58,7 @@ namespace FeedReader {
 		public const string USER_AGENT		= "FeedReader @VERSION@";
 		public const int DBusAPIVersion = 17;
 		public const int DB_SCHEMA_VERSION = 5;
+		public const int REDOWNLOAD_FAVICONS_AFTER_DAYS = 7;
 
 		// tango colors
 		public const string[] COLORS = {

--- a/Constants.vala.in
+++ b/Constants.vala.in
@@ -57,6 +57,7 @@ namespace FeedReader {
 		public const string GIT_SHA1		= "@GIT_SHA1@";
 		public const string USER_AGENT		= "FeedReader @VERSION@";
 		public const int DBusAPIVersion = 17;
+		public const int DB_SCHEMA_VERSION = 5;
 
 		// tango colors
 		public const string[] COLORS = {

--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -115,7 +115,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : "";
+			string? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))

--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -116,10 +116,6 @@ public class FeedReader.bazquxAPI : GLib.Object {
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
 			string icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : "";
-			if(icon_url != "" && !Utils.downloadIcon(feedID, "https:"+icon_url))
-				icon_url = "";
-			else if(!Utils.downloadFavIcon(feedID, url))
-				icon_url = "something";
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -143,9 +139,9 @@ public class FeedReader.bazquxAPI : GLib.Object {
 						feedID,
 						title,
 						url,
-						(icon_url == "") ? false : true,
 						0,
-						categories
+						categories,
+						icon_url
 					)
 			);
 		}

--- a/plugins/backend/feedbin/feedbinAPI.vala
+++ b/plugins/backend/feedbin/feedbinAPI.vala
@@ -84,9 +84,9 @@ public class FeedReader.feedbinAPI : Object {
 					id,
 					title,
 					url,
-					Utils.downloadFavIcon(id, url),
 					0,
 					{ "0" },
+					null,
 					xmlURL)
 			);
 		}

--- a/plugins/backend/feedhq/feedhqAPI.vala
+++ b/plugins/backend/feedhq/feedhqAPI.vala
@@ -117,12 +117,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id").replace("/", "_");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : "";
-
-			if(icon_url != "" && !Utils.downloadIcon(feedID, "https:"+icon_url))
-				icon_url = "";
-			else if(!Utils.downloadFavIcon(feedID, url))
-				icon_url = "something";
+			string? icon_url = object.has_member("iconUrl") ? "https:"+object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -146,9 +141,9 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 						feedID,
 						title,
 						url,
-						(icon_url == "") ? false : true,
 						0,
-						categories
+						categories,
+						icon_url
 					)
 			);
 		}

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -217,20 +217,11 @@ public class FeedReader.FeedlyAPI : Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("website") ? object.get_string_member("website") : "";
-			string icon_url = "";
+			string? icon_url = null;
 			if(object.has_member("iconUrl"))
-			{
 				icon_url = object.get_string_member("iconUrl");
-			}
 			else if(object.has_member("visualUrl"))
-			{
 				icon_url = object.get_string_member("visualUrl");
-			}
-
-			if(icon_url != "" && !Utils.downloadIcon(feedID, icon_url))
-			{
-				icon_url = "";
-			}
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -261,9 +252,9 @@ public class FeedReader.FeedlyAPI : Object {
 						feedID,
 						title,
 						url,
-						(icon_url == "") ? false : true,
 						getUnreadCountforID(object.get_string_member("id")),
-						categories
+						categories,
+						icon_url
 					)
 			);
 		}

--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -73,26 +73,18 @@ public class FeedReader.freshAPI : Object {
 				title = Utils.URLtoFeedName(url);
 			}
 
-			string icon_url = "";
+			string? icon_url = null;
 			if(object.has_member("iconUrl"))
-			{
 				icon_url = object.get_string_member("iconUrl");
-			}
-			if(icon_url != "" && !Utils.downloadIcon(id, icon_url))
-			{
-				icon_url = "";
-			}
-
-			bool hasIcon = (icon_url == "") ? false : true;
 
 			feeds.add(
 				new feed(
 					id,
 					title,
 					url,
-					hasIcon,
 					0,
 					{ catID },
+					icon_url,
 					xmlURL)
 			);
 		}

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -117,12 +117,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : "";
-
-			if(icon_url != "" && !Utils.downloadIcon(feedID, icon_url))
-			{
-				icon_url = "";
-			}
+			string? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -147,9 +142,9 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 						feedID,
 						title,
 						url,
-						(icon_url == "") ? false : true,
 						0,
-						categories
+						categories,
+						icon_url
 					)
 			);
 		}

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -327,8 +327,8 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		var f = dbDaemon.get_default().read_feeds();
 		foreach(feed Feed in f)
 		{
-			m_utils.downloadFeed(m_session, Feed.getXmlUrl(), Feed.getFeedID(), Feed.getCatIDs());
-			feeds.add(Feed);
+			feed? tmpFeed = m_utils.downloadFeed(m_session, Feed.getXmlUrl(), Feed.getFeedID(), Feed.getCatIDs());
+			feeds.add((tmpFeed == null) ? Feed : tmpFeed);
 		}
 
 		return true;

--- a/plugins/backend/local/localUtils.vala
+++ b/plugins/backend/local/localUtils.vala
@@ -31,7 +31,6 @@ public class FeedReader.localUtils : GLib.Object {
 	        var msg = new Soup.Message("GET", xmlURL.escape(""));
 			session.send_message(msg);
 			string xml = (string)msg.response_body.flatten().data;
-			bool hasIcon = true;
 			string url = "https://google.com";
 
 			// parse
@@ -44,26 +43,7 @@ public class FeedReader.localUtils : GLib.Object {
 				url = doc.link;
 
 			var uri = new Soup.URI(url);
-
-			if(doc.image_url != null
-			&& doc.image_url != "")
-			{
-				if(Utils.downloadIcon(feedID, doc.image_url))
-				{
-					// success
-				}
-				else if(uri != null)
-				{
-					Utils.downloadFavIcon(feedID, uri.get_scheme() + "://" + uri.get_host());
-				}
-			}
-			else if(uri != null)
-			{
-				Utils.downloadFavIcon(feedID, uri.get_scheme() + "://" + uri.get_host());
-			}
-			else
-				hasIcon = false;
-
+			string? icon_url = (doc.image_url != "") ? doc.image_url : null;
 			string? title = doc.title;
 			if(title == null)
 			{
@@ -77,9 +57,9 @@ public class FeedReader.localUtils : GLib.Object {
 						feedID,
 						title,
 						url,
-						hasIcon,
 						0,
 						catIDs,
+						icon_url,
 						xmlURL);
 
 			return Feed;

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -112,11 +112,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : "";
-			if(icon_url != "" && Utils.downloadIcon(feedID, "https:"+icon_url))
-			{
-				icon_url = "";
-			}
+			string? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -140,9 +136,9 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 						feedID,
 						title,
 						url,
-						(icon_url == "") ? false : true,
 						0,
-						categories
+						categories,
+						icon_url
 					)
 			);
 		}

--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -132,23 +132,16 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
     				{
     					var feed_node = feed_array.get_object_element(i);
     					string feed_id = feed_node.get_int_member("id").to_string();
-                        bool hasIcon = false;
-
-    					if(feed_node.has_member("faviconLink"))
-                        {
-                            string icon_url = feed_node.get_string_member("faviconLink");
-                            if(icon_url != "" && icon_url != null && GLib.Uri.parse_scheme(icon_url) != null)
-                                hasIcon = Utils.downloadIcon(feed_id, icon_url);
-                        }
+                        string? icon_url = feed_node.has_member("faviconLink") ? feed_node.get_string_member("faviconLink") : null;
 
     					feeds.add(
     						new feed (
     								feed_id,
     								feed_node.get_string_member("title"),
     								feed_node.get_string_member("link"),
-    								hasIcon,
     								(int)feed_node.get_int_member("unreadCount"),
-    								{ feed_node.get_int_member("folderId").to_string() }
+    								{ feed_node.get_int_member("folderId").to_string() },
+                                    icon_url
     							)
     					);
     				}

--- a/plugins/backend/ttrss/ttrssAPI.vala
+++ b/plugins/backend/ttrss/ttrssAPI.vala
@@ -212,22 +212,16 @@ public class FeedReader.ttrssAPI : GLib.Object {
 					{
 						var feed_node = response.get_object_element(i);
 						string feed_id = feed_node.get_int_member("id").to_string();
-
-						bool hasIcon = feed_node.get_boolean_member("has_icon");
-
-						if(hasIcon)
-							Utils.downloadIcon(feed_id, m_iconDir + feed_id + ".ico");
-						else
-							hasIcon = Utils.downloadFavIcon(feed_id, feed_node.get_string_member("feed_url"));
+						string? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir+feed_id+".ico" : null;
 
 						feeds.add(
 							new feed (
 									feed_id,
 									feed_node.get_string_member("title"),
 									feed_node.get_string_member("feed_url"),
-									hasIcon,
 									(int)feed_node.get_int_member("unread"),
-									{ feed_node.get_int_member("cat_id").to_string() }
+									{ feed_node.get_int_member("cat_id").to_string() },
+									icon_url
 								)
 						);
 					}
@@ -259,21 +253,16 @@ public class FeedReader.ttrssAPI : GLib.Object {
 			{
 				var feed_node = response.get_object_element(i);
 				string feed_id = feed_node.get_int_member("id").to_string();
-				bool hasIcon = feed_node.get_boolean_member("has_icon");
-
-				if(feed_node.get_boolean_member("has_icon"))
-					Utils.downloadIcon(feed_id, m_iconDir + feed_id + ".ico");
-				else
-					hasIcon = Utils.downloadFavIcon(feed_id, feed_node.get_string_member("feed_url"));
+				string? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir+feed_id+".ico" : null;
 
 				feeds.add(
 					new feed (
 							feed_id,
 							feed_node.get_string_member("title"),
 							feed_node.get_string_member("feed_url"),
-							hasIcon,
 							(int)feed_node.get_int_member("unread"),
-							{ feed_node.get_int_member("cat_id").to_string() }
+							{ feed_node.get_int_member("cat_id").to_string() },
+							icon_url
 						)
 				);
 			}

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -141,6 +141,9 @@ public class FeedReader.FeedServer : GLib.Object {
 			return;
 		}
 
+		// download favicons for all feeds
+		Utils.getFavIcons(feeds);
+
 		// write categories
 		dbDaemon.get_default().reset_exists_flag();
 		dbDaemon.get_default().write_categories(categories);
@@ -224,6 +227,9 @@ public class FeedReader.FeedServer : GLib.Object {
 		syncProgress(_("Getting feeds and categories"));
 
 		getFeedsAndCats(feeds, categories, tags);
+
+		// download favicons for all feeds
+		Utils.getFavIcons(feeds);
 
 		// write categories
 		dbDaemon.get_default().write_categories(categories);

--- a/src/Backend/OPMLparser.vala
+++ b/src/Backend/OPMLparser.vala
@@ -144,9 +144,9 @@ public class FeedReader.OPMLparser : GLib.Object {
 			}
 
 			if(catID == null)
-				m_feeds.add(new feed("", title, website, false, 0,  { FeedServer.get_default().uncategorizedID() }, feedURL));
+				m_feeds.add(new feed("", title, website, 0,  { FeedServer.get_default().uncategorizedID() }, feedURL));
 			else
-				m_feeds.add(new feed("", title, website, false, 0,  { catID }, feedURL));
+				m_feeds.add(new feed("", title, website, 0,  { catID }, feedURL));
 		}
 	}
 

--- a/src/Model/Feed.vala
+++ b/src/Model/Feed.vala
@@ -19,18 +19,18 @@ public class FeedReader.feed : GLib.Object {
 	private string m_title;
 	private string m_url;
 	private string? m_xmlURL;
-	private bool m_hasIcon;
 	private uint m_unread;
 	private string[] m_catIDs;
+	private string? m_iconURL;
 
-	public feed(string feedID, string title, string url, bool hasIcon, uint unread, string[] catIDs, string? xmlURL = null)
+	public feed(string feedID, string title, string url, uint unread, string[] catIDs, string? iconURL = null, string? xmlURL = null)
 	{
 		m_feedID = feedID;
 		m_title = title;
 		m_url = url;
 		m_unread = unread;
 		m_catIDs = catIDs;
-		m_hasIcon = hasIcon;
+		m_iconURL = (iconURL == "") ? null : iconURL;
 		m_xmlURL = xmlURL;
 	}
 
@@ -52,11 +52,6 @@ public class FeedReader.feed : GLib.Object {
 	public string getURL()
 	{
 		return m_url;
-	}
-
-	public bool hasIcon()
-	{
-		return m_hasIcon;
 	}
 
 	public uint getUnread()
@@ -112,7 +107,12 @@ public class FeedReader.feed : GLib.Object {
 		return false;
 	}
 
-	public string getXmlUrl()
+	public string? getIconURL()
+	{
+		return m_iconURL;
+	}
+
+	public string? getXmlUrl()
 	{
 		return m_xmlURL;
 	}

--- a/src/Structs.vala
+++ b/src/Structs.vala
@@ -20,4 +20,64 @@ namespace FeedReader {
         string data;
     }
 
+    private struct ResourceMetadata
+	{
+		private const string CACHE_GROUP = "cache";
+		private const string ETAG_KEY = "etag";
+		private const string LAST_MODIFIED_KEY = "last_modified";
+
+		string? etag;
+		string? last_modified;
+
+		public ResourceMetadata()
+		{
+		}
+
+		public ResourceMetadata.from_file(string filename)
+		{
+			var config = new KeyFile();
+			try
+			{
+				config.load_from_file(filename, KeyFileFlags.NONE);
+				try { this.etag = config.get_string(CACHE_GROUP, ETAG_KEY); }
+				catch (KeyFileError.KEY_NOT_FOUND e) {}
+				catch (KeyFileError.GROUP_NOT_FOUND e) {}
+				try { this.last_modified = config.get_string(CACHE_GROUP, LAST_MODIFIED_KEY); }
+				catch (KeyFileError.KEY_NOT_FOUND e) {}
+				catch (KeyFileError.GROUP_NOT_FOUND e) {}
+			}
+			catch (KeyFileError e)
+			{
+				Logger.warning(@"FaviconMetadata.from_file: Failed to load $filename: " + e.message);
+			}
+			catch (FileError e)
+			{
+				Logger.warning(@"FaviconMetadata.from_file: Failed to load $filename: " + e.message);
+			}
+		}
+
+		public void save_to_file(string filename)
+		{
+			if(this.etag == null && this.last_modified == null)
+			{
+				if(FileUtils.unlink(filename) != 0)
+					Logger.warning(@"FaviconMetadata.save_to_file: Error deleting metadata file $filename");
+			}
+			else
+			{
+				var config = new KeyFile();
+				config.set_string(CACHE_GROUP, ETAG_KEY, this.etag);
+				config.set_string(CACHE_GROUP, LAST_MODIFIED_KEY, this.last_modified);
+				try
+				{
+					config.save_to_file(filename);
+				}
+				catch (FileError e)
+				{
+					Logger.warning(@"FaviconMetadata.save_to_file: Failed to save metadata file $filename: " + e.message);
+				}
+			}
+		}
+	}
+
 }

--- a/src/Structs.vala
+++ b/src/Structs.vala
@@ -78,6 +78,17 @@ namespace FeedReader {
 				}
 			}
 		}
+
+        public GLib.DateTime? lastModifiedDateTime()
+        {
+            if(last_modified == null)
+                return null;
+
+            GLib.Time time = GLib.Time();
+            time.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z");
+
+            return new GLib.DateTime.local(1900 + time.year, 1 + time.month, time.day, time.hour, time.minute, time.second);
+        }
 	}
 
 }

--- a/src/Widgets/FeedList.vala
+++ b/src/Widgets/FeedList.vala
@@ -231,7 +231,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 	private void createFeedlist(ArticleListState state, bool defaultSettings, bool masterCat)
 	{
-		var row_separator1 = new FeedRow(null, 0, false, FeedID.SEPARATOR.to_string(), "-1", 0);
+		var row_separator1 = new FeedRow(null, 0, FeedID.SEPARATOR.to_string(), "-1", 0);
 		var separator1 = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
 		separator1.get_style_context().add_class("fr-sidebar-separator");
 		separator1.margin_top = 8;
@@ -244,7 +244,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			unread = dbUI.get_default().get_marked_total();
 		else
 			unread = dbUI.get_default().get_unread_total();
-		var row_all = new FeedRow(_("All Articles"), unread, false, FeedID.ALL.to_string(), "-1", 0);
+		var row_all = new FeedRow(_("All Articles"), unread, FeedID.ALL.to_string(), "-1", 0);
 		row_all.margin_top = 8;
 		row_all.margin_bottom = 8;
 		m_list.add(row_all);
@@ -252,7 +252,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		row_all.setAsRead.connect(markSelectedRead);
 		row_all.reveal(true);
 
-		var row_separator = new FeedRow(null, 0, false, FeedID.SEPARATOR.to_string(), "-1", 0);
+		var row_separator = new FeedRow(null, 0, FeedID.SEPARATOR.to_string(), "-1", 0);
 		var separator = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
 		separator.get_style_context().add_class("fr-sidebar-separator");
 		separator.margin_bottom = 8;
@@ -290,7 +290,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 							var feedrow = new FeedRow(
 													   item.getTitle(),
 													   item.getUnread(),
-													   item.hasIcon(),
 													   item.getFeedID(),
 									                   tmpRow.getID(),
 									                   tmpRow.getLevel()
@@ -317,7 +316,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 				var feedrow = new FeedRow	(
 												item.getTitle(),
 												item.getUnread(),
-												item.hasIcon(),
 												item.getFeedID(),
 												item.getCatIDs()[0],
 												0

--- a/src/Widgets/FeedRow.vala
+++ b/src/Widgets/FeedRow.vala
@@ -35,7 +35,7 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 	public signal void moveUP();
 	public signal void deselectRow();
 
-	public FeedRow(string? text, uint unread_count, bool has_icon, string feedID, string catID, int level)
+	public FeedRow(string? text, uint unread_count, string feedID, string catID, int level)
 	{
 		m_level = level;
 		m_catID = catID;

--- a/src/dbDaemon.vala
+++ b/src/dbDaemon.vala
@@ -29,7 +29,7 @@ public class FeedReader.dbDaemon : dbBase {
 		return m_dataBase;
     }
 
-    private dbDaemon(string dbFile = "feedreader-04.db")
+    private dbDaemon(string dbFile = "feedreader-%01i.db".printf(Constants.DB_SCHEMA_VERSION))
     {
         base(dbFile);
     }
@@ -173,7 +173,6 @@ public class FeedReader.dbDaemon : dbBase {
         query.insertValuePair("feed_id", "$FEEDID");
         query.insertValuePair("name", "$FEEDNAME");
         query.insertValuePair("url", "$FEEDURL");
-        query.insertValuePair("has_icon", "$HASICON");
         query.insertValuePair("category_id", "$CATID");
         query.insertValuePair("subscribed", "1");
         query.insertValuePair("xmlURL", "$XMLURL");
@@ -192,13 +191,11 @@ public class FeedReader.dbDaemon : dbBase {
         int feedID_pos   = stmt.bind_parameter_index("$FEEDID");
         int feedName_pos = stmt.bind_parameter_index("$FEEDNAME");
         int feedURL_pos  = stmt.bind_parameter_index("$FEEDURL");
-        int hasIcon_pos  = stmt.bind_parameter_index("$HASICON");
         int catID_pos    = stmt.bind_parameter_index("$CATID");
         int xmlURL_pos    = stmt.bind_parameter_index("$XMLURL");
         assert (feedID_pos > 0);
         assert (feedName_pos > 0);
         assert (feedURL_pos > 0);
-        assert (hasIcon_pos > 0);
         assert (catID_pos > 0);
         assert (xmlURL_pos > 0);
 
@@ -215,7 +212,6 @@ public class FeedReader.dbDaemon : dbBase {
             stmt.bind_text(feedID_pos, feed_item.getFeedID());
             stmt.bind_text(feedName_pos, Utils.UTF8fix(feed_item.getTitle()));
             stmt.bind_text(feedURL_pos, feed_item.getURL());
-            stmt.bind_int (hasIcon_pos, feed_item.hasIcon() ? 1 : 0);
             stmt.bind_text(catID_pos, catString);
             stmt.bind_text(xmlURL_pos, feed_item.getXmlUrl());
 

--- a/src/dbUI.vala
+++ b/src/dbUI.vala
@@ -30,7 +30,7 @@ public class FeedReader.dbUI : dbBase {
 		return m_dataBase;
     }
 
-    public dbUI(string dbFile = "feedreader-04.db")
+    public dbUI(string dbFile = "feedreader-%01i.db".printf(Constants.DB_SCHEMA_VERSION))
     {
         base(dbFile);
     }


### PR DESCRIPTION
This rips out all the downloading of favicons from the backends and moves it to one single place in the sync()-function. Backends now only need to provide an url where the icon can be found or null if no such url is available.
This should make it easier to parallel the downloading of icons and at some point make the sync-process cancelable.

This branch also drops the `has_icon` column of the feeds table and bumps the db-scheme version to 5. The column was still around from the very early days where FeedReader was tt-rss exclusive.

Lastly the `last_modified` date is compared against current local time to see if last download was more recent than `REDOWNLOAD_FAVICONS_AFTER_DAYS` in which case a re-download is not even attempted.