### PR TITLE
display possible error after adding a feed

### DIFF
--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -446,7 +446,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		m_connection.send_post_request("rename-tag", msg.get());
 	}
 
-	public void editSubscription(bazquxSubscriptionAction action, string feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(bazquxSubscriptionAction action, string feedID, string? title = null, string? add = null, string? remove = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -476,6 +476,11 @@ public class FeedReader.bazquxAPI : GLib.Object {
 			msg.add("r", remove);
 
 
-		m_connection.send_post_request("subscription/edit", msg.get());
+		var response = m_connection.send_post_request("subscription/edit", msg.get());
+
+		if(response.status == 200)
+			return true;
+
+		return false;
 	}
 }

--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -478,9 +478,6 @@ public class FeedReader.bazquxAPI : GLib.Object {
 
 		var response = m_connection.send_post_request("subscription/edit", msg.get());
 
-		if(response.status == 200)
-			return true;
-
-		return false;
+		return response.status == 200;
 	}
 }

--- a/plugins/backend/bazqux/bazquxInterface.vala
+++ b/plugins/backend/bazqux/bazquxInterface.vala
@@ -175,18 +175,26 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.ping();
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		feedID = "feed/" + feedURL;
+		bool success = false;
+		errmsg = null;
+
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
-			m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/"+feedURL, null, newCatID);
+			success = m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/"+feedURL, null, newCatID);
 		}
 		else
 		{
-			m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/"+feedURL, null, catID);
+			success = m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/"+feedURL, null, catID);
 		}
-		return "feed/" + feedURL;
+
+		if(!success)
+			errmsg = @"bazqux could not subscribe to $feedURL";
+
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/plugins/backend/demo/demoInterface.vala
+++ b/plugins/backend/demo/demoInterface.vala
@@ -310,7 +310,7 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	// "catID": the category the feed should be placed into, "null" otherwise
 	// "newCatName": the name of a new category the feed should be put in, "null" otherwise
 	//--------------------------------------------------------------------------------------
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
 	{
 
 	}

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -186,9 +186,11 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		return;
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
-		return "";
+		feedID = "-98";
+		errmsg = "feedbin backend does not support subcribing to feeds";
+		return false;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/plugins/backend/feedhq/feedhqAPI.vala
+++ b/plugins/backend/feedhq/feedhqAPI.vala
@@ -471,10 +471,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		Logger.debug(msg.get());
 		var response = m_connection.send_post_request("subscription/edit", msg.get());
 
-		if(response.status == 200)
-			return true;
-
-		return false;
+		return response.status == 200;
 	}
 
 	public void import(string opml)

--- a/plugins/backend/feedhq/feedhqAPI.vala
+++ b/plugins/backend/feedhq/feedhqAPI.vala
@@ -437,7 +437,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		m_connection.send_post_request("rename-tag", msg.get());
 	}
 
-	public void editSubscription(FeedHQSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(FeedHQSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
@@ -469,7 +469,12 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 			msg.add("r", remove.replace("_", "/"));
 
 		Logger.debug(msg.get());
-		m_connection.send_post_request("subscription/edit", msg.get());
+		var response = m_connection.send_post_request("subscription/edit", msg.get());
+
+		if(response.status == 200)
+			return true;
+
+		return false;
 	}
 
 	public void import(string opml)

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -192,7 +192,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		}
 
 		if(!success)
-			errmsg = "feedHQ could not subscribe to %s";
+			errmsg = @"feedHQ could not subscribe to $feedURL";
 
 		return success;
 	}

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -175,19 +175,26 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.ping();
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		feedID = "feed/" + feedURL;
+		bool success = false;
+
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
 			Logger.debug(newCatID);
-			m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
+			success = m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
 		}
 		else
 		{
-			m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
+			success = m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
 		}
-		return "feed/" + feedURL;
+
+		if(!success)
+			errmsg = "feedHQ could not subscribe to %s";
+
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -594,7 +594,7 @@ public class FeedReader.FeedlyAPI : Object {
 	}
 
 
-	public void addSubscription(string feedURL, string? title = null, string? catIDs = null)
+	public bool addSubscription(string feedURL, string? title = null, string? catIDs = null)
 	{
 		Json.Object object = new Json.Object();
 		object.set_string_member("id", "feed/" + feedURL);
@@ -624,7 +624,12 @@ public class FeedReader.FeedlyAPI : Object {
 		var root = new Json.Node(Json.NodeType.OBJECT);
 		root.set_object(object);
 
-		m_connection.send_post_request_to_feedly("/v3/subscriptions", root);
+		var response = m_connection.send_post_request_to_feedly("/v3/subscriptions", root);
+
+		if(response.status == 200)
+			return true;
+
+		return false;
 	}
 
 	public void moveSubscription(string feedID, string newCatID, string? oldCatID = null)

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -626,10 +626,7 @@ public class FeedReader.FeedlyAPI : Object {
 
 		var response = m_connection.send_post_request_to_feedly("/v3/subscriptions", root);
 
-		if(response.status == 200)
-			return true;
-
-		return false;
+		return response.status == 200;
 	}
 
 	public void moveSubscription(string feedID, string newCatID, string? oldCatID = null)

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -183,19 +183,26 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		return Utils.ping("http://feedly.com/");
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		feedID = "feed/" + feedURL;
+		bool success = false;
+		errmsg = null;
+
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.createCatID(newCatName);
-			m_api.addSubscription(feedURL, null, newCatID);
+			success = m_api.addSubscription(feedURL, null, newCatID);
 		}
 		else
 		{
-			m_api.addSubscription(feedURL, null, catID);
+			success = m_api.addSubscription(feedURL, null, catID);
 		}
 
-		return "feed/" + feedURL;
+		if(!success)
+			errmsg = "feedly could not add %s";
+
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -200,7 +200,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		}
 
 		if(!success)
-			errmsg = "feedly could not add %s";
+			errmsg = @"feedly could not add $feedURL";
 
 		return success;
 	}

--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -343,7 +343,7 @@ public class FeedReader.freshAPI : Object {
 		}
 	}
 
-	public string editStream(
+	public Response editStream(
 							string action,
 							string[]? streamID = null,
 							string? title = null,
@@ -380,7 +380,7 @@ public class FeedReader.freshAPI : Object {
 			Logger.debug(response.status.to_string());
 		}
 
-		return response.data;
+		return response;
 	}
 
 	public string composeTagID(string title)

--- a/plugins/backend/fresh/freshInterface.vala
+++ b/plugins/backend/fresh/freshInterface.vala
@@ -165,8 +165,9 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		errmsg = null;
 		string? cat = null;
 		if(catID != null)
 			cat = catID;
@@ -175,7 +176,15 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 
 		cat = m_api.composeTagID(cat);
 
-		return m_api.editStream("subscribe", {"feed/" + feedURL}, null, cat, null);
+		var response = m_api.editStream("subscribe", {"feed/" + feedURL}, null, cat, null);
+		if(response.status != 200)
+		{
+			errmsg = response.data;
+			return false;
+		}
+
+		feedID = response.data;
+		return true;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -440,7 +440,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		m_connection.send_request("rename-tag", message_string);
 	}
 
-	public void editSubscription(InoSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(InoSubscriptionAction action, string[] feedID, string? title, string? add, string? remove)
 	{
 		var message_string = "ac=";
 
@@ -470,6 +470,11 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 			message_string += "&r=" + remove;
 
 
-		m_connection.send_request("subscription/edit", message_string);
+		if(m_connection.send_request("subscription/edit", message_string).status == 200)
+		{
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -470,11 +470,6 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 			message_string += "&r=" + remove;
 
 
-		if(m_connection.send_request("subscription/edit", message_string).status == 200)
-		{
-			return true;
-		}
-
-		return false;
+		return m_connection.send_request("subscription/edit", message_string).status == 200;
 	}
 }

--- a/plugins/backend/inoreader/InoReaderInterface.vala
+++ b/plugins/backend/inoreader/InoReaderInterface.vala
@@ -176,18 +176,26 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.ping();
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		bool success = false;
+		feedID = "feed/" + feedURL;
+		errmsg = null;
+
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
-			m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
+			success = m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID, null);
 		}
 		else
 		{
-			m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
+			success = m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID, null);
 		}
-		return "feed/" + feedURL;
+
+		if(!success)
+			errmsg = "Inoreader could not add %s";
+
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)
@@ -199,7 +207,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		{
 			if(f.getCatIDs()[0] != cat)
 			{
-				m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, urls, null, cat);
+				m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, urls, null, cat, null);
 				urls = {};
 				cat = f.getCatIDs()[0];
 			}
@@ -207,17 +215,17 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 			urls += "feed/" + f.getXmlUrl();
 		}
 
-		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, urls, null, cat);
+		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, urls, null, cat, null);
 	}
 
 	public void removeFeed(string feedID)
 	{
-		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.UNSUBSCRIBE, {feedID});
+		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.UNSUBSCRIBE, {feedID}, null, null, null);
 	}
 
 	public void renameFeed(string feedID, string title)
 	{
-		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.EDIT, {feedID}, title);
+		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.EDIT, {feedID}, title, null, null);
 	}
 
 	public void moveFeed(string feedID, string newCatID, string? currentCatID)

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -168,7 +168,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		return;
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
 		string[] catIDs = {};
 
@@ -190,7 +190,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 			catIDs += "0";
 		}
 
-		string feedID = "feedID00001";
+		feedID = "feedID00001";
 
 		if(!dbDaemon.get_default().isTableEmpty("feeds"))
 		{
@@ -198,17 +198,17 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		}
 
 		Logger.info(@"addFeed: ID = $feedID");
-		feed? Feed = m_utils.downloadFeed(m_session, feedURL, feedID, catIDs);
+		feed? Feed = m_utils.downloadFeed(m_session, feedURL, feedID, catIDs, out errmsg);
 
 		if(Feed != null)
 		{
 			var list = new Gee.LinkedList<feed>();
 			list.add(Feed);
 			dbDaemon.get_default().write_feeds(list);
-			return feedID;
+			return true;
 		}
 
-		return "";
+		return false;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)
@@ -226,7 +226,8 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 			highestID++;
 
 			Logger.info(@"addFeed: ID = $feedID");
-			feed? Feed = m_utils.downloadFeed(m_session, f.getXmlUrl(), feedID, f.getCatIDs());
+			string? errmsg = null;
+			feed? Feed = m_utils.downloadFeed(m_session, f.getXmlUrl(), feedID, f.getCatIDs(), out errmsg);
 
 			if(Feed != null)
 			{
@@ -330,7 +331,8 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 			if(cancellable != null && cancellable.is_cancelled())
 				return false;
 
-			feed? tmpFeed = m_utils.downloadFeed(m_session, Feed.getXmlUrl(), Feed.getFeedID(), Feed.getCatIDs());
+			string? errmsg = null;
+			feed? tmpFeed = m_utils.downloadFeed(m_session, Feed.getXmlUrl(), Feed.getFeedID(), Feed.getCatIDs(), out errmsg);
 			feeds.add((tmpFeed == null) ? Feed : tmpFeed);
 		}
 

--- a/plugins/backend/local/localUtils.vala
+++ b/plugins/backend/local/localUtils.vala
@@ -20,59 +20,70 @@ public class FeedReader.localUtils : GLib.Object {
 
 	}
 
-	public feed? downloadFeed(Soup.Session session, string xmlURL, string feedID, string[] catIDs)
+	public feed? downloadFeed(Soup.Session session, string xmlURL, string feedID, string[] catIDs, out string? errmsg)
 	{
+		errmsg = null;
+
+		// download
+		Logger.debug(@"Requesting: $xmlURL");
+		var msg = new Soup.Message("GET", xmlURL);
+		if (msg == null)
+		{
+			errmsg = @"Couldn't parse feed URL: $xmlURL";
+			Logger.warning(errmsg);
+			return null;
+		}
+		uint status = session.send_message(msg);
+		if(status != 200)
+		{
+			errmsg = "Could not download feed";
+			Logger.warning(errmsg);
+			return null;
+		}
+		string xml = (string)msg.response_body.flatten().data;
+		string url = "https://google.com";
+
+		// parse
+		Rss.Parser parser = new Rss.Parser();
+
 		try
 		{
-			// download
-			Logger.debug(@"Requesting: $xmlURL");
-			var msg = new Soup.Message("GET", xmlURL);
-			if (msg == null)
-			{
-				Logger.warning(@"Couldn't parse feed URL: $xmlURL");
-				return null;
-			}
-			session.send_message(msg);
-			string xml = (string)msg.response_body.flatten().data;
-			string url = "https://google.com";
-
-			// parse
-			Rss.Parser parser = new Rss.Parser();
 			parser.load_from_data(xml, xml.length);
-			var doc = parser.get_document();
-
-			if(doc.link != null
-			&& doc.link != "")
-				url = doc.link;
-
-			var uri = new Soup.URI(url);
-			string? icon_url = (doc.image_url != "") ? doc.image_url : null;
-			string? title = doc.title;
-			if(title == null)
-			{
-				if(uri == null)
-					title = _("unknown Feed");
-				else
-					title = uri.get_host();
-			}
-
-			var Feed = new feed(
-						feedID,
-						title,
-						url,
-						0,
-						catIDs,
-						icon_url,
-						xmlURL);
-
-			return Feed;
 		}
-		catch(GLib.Error e)
+		catch(Error e)
 		{
-			Logger.error("localInterface - addFeed " + xmlURL + " : " + e.message);
+			errmsg = "Could not parse feed";
+			Logger.warning(errmsg);
+			return null;
 		}
 
-		return null;
+		var doc = parser.get_document();
+
+		if(doc.link != null
+		&& doc.link != "")
+			url = doc.link;
+
+		var uri = new Soup.URI(url);
+		string? icon_url = (doc.image_url != "") ? doc.image_url : null;
+		string? title = doc.title;
+		if(title == null)
+		{
+			if(uri == null)
+				title = _("unknown Feed");
+			else
+				title = uri.get_host();
+		}
+
+		var Feed = new feed(
+					feedID,
+					title,
+					url,
+					0,
+					catIDs,
+					icon_url,
+					xmlURL);
+
+		return Feed;
 	}
 
 	public string? convert(string? text, string? locale)

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -416,7 +416,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		m_connection.send_post_request("rename-tag?output=json", message_string);
 	}
 
-	public void editSubscription(OldreaderSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(OldreaderSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
 	{
 		var message_string = "ac=";
 
@@ -446,6 +446,11 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 			message_string += "&r=" + remove;
 
 
-		m_connection.send_post_request("subscription/edit?output=json", message_string);
+		var response = m_connection.send_post_request("subscription/edit?output=json", message_string);
+
+		if(response.status == 200)
+			return true;
+
+		return false;
 	}
 }

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -448,9 +448,6 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 
 		var response = m_connection.send_post_request("subscription/edit?output=json", message_string);
 
-		if(response.status == 200)
-			return true;
-
-		return false;
+		return response.status == 200;
 	}
 }

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -176,18 +176,26 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.ping();
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		feedID = "feed/" + feedURL;
+		errmsg = null;
+		bool success = false;
+
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
-			m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
+			success = m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
 		}
 		else
 		{
-			m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
+			success = m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
 		}
-		return "feed/" + feedURL;
+
+		if(!success)
+			errmsg = "The old reader could not add %s";
+
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -193,7 +193,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		}
 
 		if(!success)
-			errmsg = "The old reader could not add %s";
+			errmsg = @"The old reader could not add $feedURL";
 
 		return success;
 	}

--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -452,10 +452,10 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		switch(message.getStatusCode())
 		{
 			case 409:
-				errmsg = "Feed already added";
+				errmsg = "Feed already added (409)";
 				return true;
 			case 422:
-				errmsg = "ownCloud can't read the feed";
+				errmsg = "ownCloud can't read the feed (422)";
 				break;
 		}
 

--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -422,7 +422,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		return false;
 	}
 
-	public int64 addFeed(string feedURL, string? catID = null)
+	public bool addFeed(string feedURL, string? catID, out int64 feedID, out string? errmsg)
 	{
 		string url = "/feeds";
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "POST");
@@ -435,7 +435,9 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 			var response = message.get_response_object();
 			if(response.has_member("feeds"))
 			{
-				return response.get_array_member("feeds").get_object_element(0).get_int_member("id");
+				errmsg = null;
+				feedID = response.get_array_member("feeds").get_object_element(0).get_int_member("id");
+				return true;
 			}
 		}
 		else
@@ -443,7 +445,21 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 			Logger.error("OwncloudNewsAPI.addFeed");
 		}
 
-		return 0;
+
+		errmsg = "ownCloud could not add the feed";
+		feedID = 0;
+
+		switch(message.getStatusCode())
+		{
+			case 409:
+				errmsg = "Feed already added";
+				return true;
+			case 422:
+				errmsg = "ownCloud can't read the feed";
+				break;
+		}
+
+		return false;
 	}
 
 	public void removeFeed(string feedID)

--- a/plugins/backend/owncloud/OwncloudNewsInterface.vala
+++ b/plugins/backend/owncloud/OwncloudNewsInterface.vala
@@ -159,22 +159,32 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		return m_api.ping();
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		bool success = false;
+		int64 id = 0;
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.addFolder(newCatName).to_string();
-			return m_api.addFeed(feedURL, newCatID).to_string();
+			success = m_api.addFeed(feedURL, newCatID, out id, out errmsg);
+		}
+		else
+		{
+			success = m_api.addFeed(feedURL, catID, out id, out errmsg);
 		}
 
-		return m_api.addFeed(feedURL, catID).to_string();
+
+		feedID = id.to_string();
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)
 	{
+		int64 id = 0;
+		string? errmsg = null;
 		foreach(feed f in feeds)
 		{
-			m_api.addFeed(f.getXmlUrl(), f.getCatIDs()[0]);
+			m_api.addFeed(f.getXmlUrl(), f.getCatIDs()[0], out id, out errmsg);
 		}
 	}
 

--- a/plugins/backend/owncloud/OwncloudNewsMessage.vala
+++ b/plugins/backend/owncloud/OwncloudNewsMessage.vala
@@ -155,6 +155,11 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 		return ConnectionError.SUCCESS;
 	}
 
+	public uint getStatusCode()
+	{
+		return m_message_soup.status_code;
+	}
+
 	public Json.Object? get_response_object()
 	{
 		return m_root_object;

--- a/plugins/backend/ttrss/ttrssInterface.vala
+++ b/plugins/backend/ttrss/ttrssInterface.vala
@@ -163,26 +163,34 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		m_api.renameLabel(int.parse(tagID), title);
 	}
 
-	public string addFeed(string feedURL, string? catID, string? newCatName)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
+		bool success = false;
 		if(catID == null && newCatName != null)
 		{
 			var newCatID = m_api.createCategory(newCatName);
-			m_api.subscribeToFeed(feedURL, newCatID);
+			success = m_api.subscribeToFeed(feedURL, newCatID, null, null, out errmsg);
 		}
 		else
 		{
-			m_api.subscribeToFeed(feedURL, catID);
+			success = m_api.subscribeToFeed(feedURL, catID, null, null, out errmsg);
 		}
 
-		return (int.parse(dbDaemon.get_default().getHighestFeedID()) + 1).to_string();
+		if(success)
+			feedID = (int.parse(dbDaemon.get_default().getHighestFeedID()) + 1).to_string();
+		else
+			feedID = "-98";
+
+
+		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)
 	{
+		string? errmsg = null;
 		foreach(feed f in feeds)
 		{
-			m_api.subscribeToFeed(f.getXmlUrl(), f.getCatIDs()[0]);
+			m_api.subscribeToFeed(f.getXmlUrl(), f.getCatIDs()[0], null, null, out errmsg);
 		}
 	}
 

--- a/plugins/backend/ttrss/ttrssMessage.vala
+++ b/plugins/backend/ttrss/ttrssMessage.vala
@@ -182,6 +182,11 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		return null;
 	}
 
+	public uint getStatusCode()
+	{
+		return m_message_soup.status_code;
+	}
+
 	public void printMessage()
 	{
 		Logger.debug(m_message_string.str);

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -786,12 +786,12 @@ public class FeedReader.FeedServer : GLib.Object {
 		return m_plugin.serverAvailable();
 	}
 
-	public void addFeed(string feedURL, string? catID = null, string? newCatName = null)
+	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg)
 	{
 		if(!m_pluginLoaded)
-			return;
+			return false;
 
-		m_plugin.addFeed(feedURL, catID, newCatName);
+		return m_plugin.addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)

--- a/src/Backend/FeedServerInterface.vala
+++ b/src/Backend/FeedServerInterface.vala
@@ -81,7 +81,7 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract bool serverAvailable();
 
-	public abstract string addFeed(string feedURL, string? catID = null, string? newCatName = null);
+	public abstract bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string? errmsg);
 
 	public abstract void addFeeds(Gee.List<feed> feeds);
 

--- a/src/DBusConnection.vala
+++ b/src/DBusConnection.vala
@@ -66,7 +66,7 @@ namespace FeedReader {
 		public abstract void renameCategory(string catID, string newName) throws IOError;
 
 		// MANIPULATE FEEDS
-		public abstract void addFeed(string feedURL, string cat, bool isID, bool asynchron = true) throws IOError;
+		public abstract void addFeed(string feedURL, string cat, bool isID, bool asynchron) throws IOError;
 		public abstract void removeFeed(string feedID) throws IOError;
 		public abstract void removeFeedOnlyFromCat(string m_feedID, string m_catID) throws IOError;
 		public abstract void moveFeed(string feedID, string currentCatID, string? newCatID = null) throws IOError;
@@ -86,7 +86,7 @@ namespace FeedReader {
 		public signal void showArticleListOverlay();
 		public signal void setOffline();
 		public signal void setOnline();
-		public signal void feedAdded();
+		public signal void feedAdded(string? errmsg);
 		public signal void opmlImported();
 		public signal void updateSyncProgress(string progress);
 	}
@@ -199,9 +199,11 @@ namespace FeedReader {
 				}
 			});
 
-			m_connection.feedAdded.connect(() => {
+			m_connection.feedAdded.connect((errmsg) => {
 				Logger.debug("DBusConnection: feedAdded");
 				ColumnView.get_default().footerSetReady();
+				if(errmsg != null)
+					ColumnView.get_default().footerShowError(errmsg);
 			});
 
 			m_connection.opmlImported.connect(() => {

--- a/src/FeedReader.vala
+++ b/src/FeedReader.vala
@@ -192,7 +192,7 @@ namespace FeedReader {
 			Logger.debug(@"Adding feed $feedURL");
 			try
 			{
-				DBusConnection.get_default().addFeed(feedURL, "", false);
+				DBusConnection.get_default().addFeed(feedURL, "", false, true);
 			}
 			catch(Error e)
 			{

--- a/src/Widgets/AddPopover.vala
+++ b/src/Widgets/AddPopover.vala
@@ -125,7 +125,8 @@ public class FeedReader.AddPopover : Gtk.Popover {
 
 	private void addFeed()
 	{
-		if(m_urlEntry.text == "" || GLib.Uri.parse_scheme(m_urlEntry.text) == null)
+		if(m_urlEntry.text == ""
+		|| GLib.Uri.parse_scheme(m_urlEntry.text) == null)
 		{
 			m_urlEntry.grab_focus();
 			return;
@@ -143,7 +144,7 @@ public class FeedReader.AddPopover : Gtk.Popover {
 		Logger.debug("addFeed: %s, %s".printf(m_urlEntry.text, (catID == "") ? "null" : catID));
 		try
 		{
-			DBusConnection.get_default().addFeed(m_urlEntry.text, catID, isID);
+			DBusConnection.get_default().addFeed(m_urlEntry.text, catID, isID, true);
 		}
 		catch(Error e)
 		{

--- a/src/Widgets/ColumnView.vala
+++ b/src/Widgets/ColumnView.vala
@@ -456,6 +456,11 @@ public class FeedReader.ColumnView : Gtk.Paned {
 		m_footer.setReady();
 	}
 
+	public void footerShowError(string errmsg)
+	{
+		m_footer.showError(errmsg);
+	}
+
 	public feedList getFeedList()
 	{
 		return m_feedList;

--- a/src/Widgets/FeedListFooter.vala
+++ b/src/Widgets/FeedListFooter.vala
@@ -108,6 +108,16 @@ public class FeedReader.FeedListFooter : Gtk.Box {
 			Logger.error("FeedListFooter.setActive: %s".printf(e.message));
 		}
 	}
+
+	public void showError(string errmsg)
+	{
+		var label = new Gtk.Label(errmsg);
+		label.margin = 20;
+
+		var pop = new Gtk.Popover(m_addStack);
+		pop.add(label);
+		pop.show_all();
+	}
 }
 
 

--- a/src/Widgets/MediaButton.vala
+++ b/src/Widgets/MediaButton.vala
@@ -20,7 +20,6 @@ public class FeedReader.AttachedMediaButton : Gtk.Button {
 	private Gtk.Image m_filesIcon;
 	private Gtk.Spinner m_spinner;
 	private Gtk.Stack m_stack;
-	private bool m_status;
 	private Gee.ArrayList<string> m_media;
 	private Gtk.Popover m_pop;
 	private ulong m_signalID = 0;


### PR DESCRIPTION
This enables the back-ends to specify what went wrong when trying to add a feed and display the error in the UI as a small popover on the '+'-button.
The popover could use some styling. Some of the back-ends could use some more detailed error messages but at least for tt-rss and the local back-end everything seems to work fine.

First step to fix #461 
edit: theoretically similar changes could be made to actions like removing, renaming and moving feeds and categories. But since adding a feed is the most likely action to fail this has to do for now.