### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Editorconfig is supported by almost every text editor/IDE out there (even Builder)

It's used to avoid having spaces/tabs, or different indentation size
If there's any modification to do, just let me know :)

This helps a lot if you switch text editor, or something else :D 