### PR TITLE
Add uncrustify config and fix indentation

### DIFF
--- a/WebExtension/webextension.vala
+++ b/WebExtension/webextension.vala
@@ -1,138 +1,138 @@
 [DBus (name = "org.gnome.FeedReader.ArticleView")]
 public class FeedReaderWebExtension : Object {
 
-    private WebKit.DOM.Document m_doc;
-    public signal void onClick(string path, int width, int height, string url);
-    public signal void message(string message);
+	private WebKit.DOM.Document m_doc;
+	public signal void onClick(string path, int width, int height, string url);
+	public signal void message(string message);
 
-    [DBus (visible = false)]
-    public void on_bus_aquired(DBusConnection connection)
-    {
-    	try
-    	{
-        	connection.register_object("/org/gnome/FeedReader/ArticleView", this);
-        }
-        catch(GLib.IOError e)
-        {
-        	warning("Could not register object");
-        }
-    }
+	[DBus (visible = false)]
+	public void on_bus_aquired(DBusConnection connection)
+	{
+		try
+		{
+			connection.register_object("/org/gnome/FeedReader/ArticleView", this);
+		}
+		catch(GLib.IOError e)
+		{
+			warning("Could not register object");
+		}
+	}
 
-    [DBus (visible = false)]
-    public void on_page_created(WebKit.WebExtension extension, WebKit.WebPage page)
-    {
-        page.document_loaded.connect(() => {
-        	onDocLoaded(page);
-        });
-        message("on_page_created");
-    }
+	[DBus (visible = false)]
+	public void on_page_created(WebKit.WebExtension extension, WebKit.WebPage page)
+	{
+		page.document_loaded.connect(() => {
+			onDocLoaded(page);
+		});
+		message("on_page_created");
+	}
 
-    private void onDocLoaded(WebKit.WebPage page)
-    {
-    	m_doc = page.get_dom_document();
-    	message("onDocLoaded");
-    }
+	private void onDocLoaded(WebKit.WebPage page)
+	{
+		m_doc = page.get_dom_document();
+		message("onDocLoaded");
+	}
 
-    public void recalculate()
-    {
-        message("recalculate");
-        var images = m_doc.get_images();
-        ulong count = images.get_length();
+	public void recalculate()
+	{
+		message("recalculate");
+		var images = m_doc.get_images();
+		ulong count = images.get_length();
 
-    	for(ulong i = 0; i < count; i++)
-    	{
-    		var image = (WebKit.DOM.HTMLImageElement)images.item(i);
+		for(ulong i = 0; i < count; i++)
+		{
+			var image = (WebKit.DOM.HTMLImageElement)images.item(i);
 
-            // if image was so huge it had to be replaced with a downscaled version
-            if(image.has_attribute("FR_huge"))
-            {
-                addListener(image);
-                continue;
-            }
-            else if(image.has_attribute("FR_parent"))
-            {
-                addListener(image);
-                continue;
-            }
+			// if image was so huge it had to be replaced with a downscaled version
+			if(image.has_attribute("FR_huge"))
+			{
+				addListener(image);
+				continue;
+			}
+			else if(image.has_attribute("FR_parent"))
+			{
+				addListener(image);
+				continue;
+			}
 
-    		long nHeight = image.get_natural_height();
-    		long nWidth = image.get_natural_width();
-    		long height = image.get_height();
-    		long width = image.get_width();
+			long nHeight = image.get_natural_height();
+			long nWidth = image.get_natural_width();
+			long height = image.get_height();
+			long width = image.get_width();
 
-    		if(nHeight > 250 || nWidth > 250)
-    		{
-    			double hRatio = (double)height / (double)nHeight;
-    			double wRatio = (double)width / (double)nWidth;
-    			double threshold = 0.8;
+			if(nHeight > 250 || nWidth > 250)
+			{
+				double hRatio = (double)height / (double)nHeight;
+				double wRatio = (double)width / (double)nWidth;
+				double threshold = 0.8;
 
-    			if(hRatio <= threshold
-                || wRatio <= threshold)
-    			    addListener(image);
-    			else
-        			removeListener(image);
-    		}
-    	}
-    }
+				if(hRatio <= threshold
+				   || wRatio <= threshold)
+					addListener(image);
+				else
+					removeListener(image);
+			}
+		}
+	}
 
-    [DBus (visible = false)]
-    private void addListener(WebKit.DOM.HTMLImageElement image)
-    {
-        ((WebKit.DOM.EventTarget) image).add_event_listener_with_closure("mouseover", on_enter, false);
-        ((WebKit.DOM.EventTarget) image).add_event_listener_with_closure("mousemove", on_enter, false);
-        ((WebKit.DOM.EventTarget) image).add_event_listener_with_closure("mouseout", on_leave, false);
-        ((WebKit.DOM.EventTarget) image).add_event_listener_with_closure("click", on_click, false);
-    }
+	[DBus (visible = false)]
+	private void addListener(WebKit.DOM.HTMLImageElement image)
+	{
+		((WebKit.DOM.EventTarget)image).add_event_listener_with_closure("mouseover", on_enter, false);
+		((WebKit.DOM.EventTarget)image).add_event_listener_with_closure("mousemove", on_enter, false);
+		((WebKit.DOM.EventTarget)image).add_event_listener_with_closure("mouseout", on_leave, false);
+		((WebKit.DOM.EventTarget)image).add_event_listener_with_closure("click", on_click, false);
+	}
 
-    [DBus (visible = false)]
-    private void removeListener(WebKit.DOM.HTMLImageElement image)
-    {
-        ((WebKit.DOM.EventTarget) image).remove_event_listener_with_closure("mouseover", on_enter, false);
-        ((WebKit.DOM.EventTarget) image).remove_event_listener_with_closure("mousemove", on_enter, false);
-        ((WebKit.DOM.EventTarget) image).remove_event_listener_with_closure("mouseout", on_leave, false);
-        ((WebKit.DOM.EventTarget) image).remove_event_listener_with_closure("click", on_click, false);
+	[DBus (visible = false)]
+	private void removeListener(WebKit.DOM.HTMLImageElement image)
+	{
+		((WebKit.DOM.EventTarget)image).remove_event_listener_with_closure("mouseover", on_enter, false);
+		((WebKit.DOM.EventTarget)image).remove_event_listener_with_closure("mousemove", on_enter, false);
+		((WebKit.DOM.EventTarget)image).remove_event_listener_with_closure("mouseout", on_leave, false);
+		((WebKit.DOM.EventTarget)image).remove_event_listener_with_closure("click", on_click, false);
 
-        try
-        {
-            image.set_attribute("class", "");
-        }
-        catch(GLib.Error e)
-        {
-            stderr.printf("WebExtension.recalculate: %s", e.message);
-        }
-    }
+		try
+		{
+			image.set_attribute("class", "");
+		}
+		catch(GLib.Error e)
+		{
+			stderr.printf("WebExtension.recalculate: %s", e.message);
+		}
+	}
 
-    [DBus (visible = false)]
-    private void on_enter(WebKit.DOM.EventTarget target, WebKit.DOM.Event event)
-    {
-    	try
-    	{
-    		var image = (WebKit.DOM.HTMLImageElement)target;
-    		image.set_attribute("class", "clickable-img-hover");
-    	}
-    	catch(GLib.Error e)
-    	{
+	[DBus (visible = false)]
+	private void on_enter(WebKit.DOM.EventTarget target, WebKit.DOM.Event event)
+	{
+		try
+		{
+			var image = (WebKit.DOM.HTMLImageElement)target;
+			image.set_attribute("class", "clickable-img-hover");
+		}
+		catch(GLib.Error e)
+		{
 
-    	}
-    }
+		}
+	}
 
-    [DBus (visible = false)]
-    private void on_leave(WebKit.DOM.EventTarget target, WebKit.DOM.Event event)
-    {
-    	try
-    	{
-    		var image = (WebKit.DOM.HTMLImageElement)target;
-    		image.set_attribute("class", "");
-    	}
-    	catch(GLib.Error e)
-    	{
+	[DBus (visible = false)]
+	private void on_leave(WebKit.DOM.EventTarget target, WebKit.DOM.Event event)
+	{
+		try
+		{
+			var image = (WebKit.DOM.HTMLImageElement)target;
+			image.set_attribute("class", "");
+		}
+		catch(GLib.Error e)
+		{
 
-    	}
-    }
+		}
+	}
 
-    [DBus (visible = false)]
-    public void on_click(WebKit.DOM.EventTarget target, WebKit.DOM.Event event)
-    {
+	[DBus (visible = false)]
+	public void on_click(WebKit.DOM.EventTarget target, WebKit.DOM.Event event)
+	{
 		event.prevent_default();
 		var image = (WebKit.DOM.HTMLImageElement)target;
 
@@ -141,39 +141,38 @@ public class FeedReaderWebExtension : Object {
 		if(parent.tag_name == "A")
 			url = parent.get_attribute("href");
 
-
-        int height = (int)image.natural_height;
-        int width = (int)image.natural_width;
+		int height = (int)image.natural_height;
+		int width = (int)image.natural_width;
 		string src = image.src;
 		if(src.has_prefix("file://"))
-            src = src.substring("file://".length);
+			src = src.substring("file://".length);
 
-        if(image.has_attribute("FR_huge"))
-        {
-            src = image.get_attribute("FR_huge");
-            Gdk.Pixbuf.get_file_info(src, out width, out height);
-        }
-        else if(image.has_attribute("FR_parent"))
-        {
-            src = image.get_attribute("FR_parent");
-            Gdk.Pixbuf.get_file_info(src, out width, out height);
-        }
+		if(image.has_attribute("FR_huge"))
+		{
+			src = image.get_attribute("FR_huge");
+			Gdk.Pixbuf.get_file_info(src, out width, out height);
+		}
+		else if(image.has_attribute("FR_parent"))
+		{
+			src = image.get_attribute("FR_parent");
+			Gdk.Pixbuf.get_file_info(src, out width, out height);
+		}
 
-    	onClick(src, width, height, url);
-    }
+		onClick(src, width, height, url);
+	}
 }
 
 [DBus (name = "org.gnome.FeedReader.ArticleView")]
 public errordomain FeedReaderWebExtensionError
 {
-    ERROR
+	ERROR
 }
 
 [CCode (cname = "G_MODULE_EXPORT webkit_web_extension_initialize", instance_pos = -1)]
 void webkit_web_extension_initialize(WebKit.WebExtension extension)
 {
-    var server = new FeedReaderWebExtension();
-    extension.page_created.connect(server.on_page_created);
-    Bus.own_name(BusType.SESSION, "org.gnome.FeedReader.ArticleView", BusNameOwnerFlags.NONE,
-        server.on_bus_aquired, null, () => { warning("Could not aquire name"); });
+	var server = new FeedReaderWebExtension();
+	extension.page_created.connect(server.on_page_created);
+	Bus.own_name(BusType.SESSION, "org.gnome.FeedReader.ArticleView", BusNameOwnerFlags.NONE,
+	             server.on_bus_aquired, null, () => { warning("Could not aquire name"); });
 }

--- a/libIvy/Extractor.vala
+++ b/libIvy/Extractor.vala
@@ -30,7 +30,7 @@ namespace Ivy {
 		private string l = "";
 		private string file_line = "";
 		private string func_line = "";
-		private string lib_address ="";
+		private string lib_address = "";
 
 		private static Gee.ArrayList<string> libraries_with_no_info = new Gee.ArrayList<string>();
 
@@ -49,8 +49,8 @@ namespace Ivy {
 
 			int l_sameCounter = 0;
 			while ((l_sameCounter < l_startPathParts.length) &&
-				   (l_sameCounter < l_destinationPathParts.length) &&
-				   l_startPathParts[l_sameCounter] == l_destinationPathParts[l_sameCounter]) {
+			       (l_sameCounter < l_destinationPathParts.length) &&
+			       l_startPathParts[l_sameCounter] == l_destinationPathParts[l_sameCounter]) {
 				l_sameCounter++;
 			}
 
@@ -59,11 +59,11 @@ namespace Ivy {
 			}
 
 			StringBuilder l_builder = new StringBuilder ();
-			for (int i = l_sameCounter ; i < l_startPathParts.length ; i++) {
+			for (int i = l_sameCounter; i < l_startPathParts.length; i++) {
 				l_builder.append ("../");
 			}
 
-			for (int i = l_sameCounter ; i < l_destinationPathParts.length ; i++) {
+			for (int i = l_sameCounter; i < l_destinationPathParts.length; i++) {
 				l_builder.append (l_destinationPathParts[i] + "/");
 			}
 
@@ -78,7 +78,7 @@ namespace Ivy {
 			var path = Environment.get_current_dir ();
 			/*var i = file_path.index_of ( path );
 			   if( i>=0 )
-				return file_path.substring ( path.length, file_path.length - path.length );
+			    return file_path.substring ( path.length, file_path.length - path.length );
 			   return file_path; */
 			var result = get_relative_path (file_path, path);
 			return result;
@@ -92,7 +92,7 @@ namespace Ivy {
 			if (start >= 0) {
 				var end = line.last_index_of (")");
 				if( end > start ) {
-					var text = line.substring (start+3,end-start-3);
+					var text = line.substring (start + 3, end - start - 3);
 					text.scanf("%x",  &result);
 				}
 			}
@@ -138,21 +138,21 @@ namespace Ivy {
 			var addr1_s = "";
 			var lib_addr = "";
 			var cmd2 = "";
-			lib_address ="";
+			lib_address = "";
 			lock( libraries_with_no_info)
-			 {
-				if( libraries_with_no_info.index_of (file_path) == -1 ){
-					 // The library is not on the black list
+			{
+				if( libraries_with_no_info.index_of (file_path) == -1 ) {
+					// The library is not on the black list
 					cmd2 = "nm %s".printf(file_path);
 
-					 addr1_s = execute_command_sync_get_output (cmd2);
-					 if( addr1_s == null || addr1_s == "" )
-					 {
+					addr1_s = execute_command_sync_get_output (cmd2);
+					if( addr1_s == null || addr1_s == "" )
+					{
 						// stdout.printf( "ADDED TO NO INFO: '%s'\n", file_path);
 						libraries_with_no_info.add (file_path);
 						has_info = false;
 
-					 }
+					}
 				}
 				else
 					has_info = false;
@@ -160,15 +160,15 @@ namespace Ivy {
 			if( has_info && func != "" )
 			{
 				MatchInfo info;
-				var expression = "\\n[^ ]* T "+func;
+				var expression = "\\n[^ ]* T " + func;
 				try {
 
 					Regex regex = new Regex (expression);
 					int count = 0;
 					string matches = "";
 					if( regex.match (addr1_s, 0, out info) )
-					 {
-						while( info.matches() ){
+					{
+						while( info.matches() ) {
 							var lll = info.fetch(0);
 							// stdout.printf ( "lll '%s'\n", lll );
 							lib_addr = lll.substring(0, lll.index_of(" "));
@@ -178,9 +178,9 @@ namespace Ivy {
 						}
 						if( count >1 )
 						{
-						   stdout.printf ("  XX %d matches for '%s'. Command: '%s'. Matches: '%s'\n", count, func, cmd2, matches);
+							stdout.printf ("  XX %d matches for '%s'. Command: '%s'. Matches: '%s'\n", count, func, cmd2, matches);
 						}
-						 // stdout.printf ("  YY %d matches for '%s'. Command: '%s'. Matches: '%s'\n", count, func, cmd2, matches);
+						// stdout.printf ("  YY %d matches for '%s'. Command: '%s'. Matches: '%s'\n", count, func, cmd2, matches);
 					}
 
 				} catch (RegexError e)
@@ -192,7 +192,7 @@ namespace Ivy {
 				lib_addr.scanf("%x",  &addr1);
 				if( addr1 != 0 ) {
 					int addr2 = extract_base_address (str);
-					string addr3 = "%#08x".printf (addr1+addr2);
+					string addr3 = "%#08x".printf (addr1 + addr2);
 					lib_address = addr3;
 					// stdout.printf ("lib_address : %s\n", lib_address);
 					var new_full_line = process_line (file_path, addr3);
@@ -233,8 +233,8 @@ namespace Ivy {
 			if (str == "")
 				return "";
 			/*if( str.index_of("??") >= 0)
-				//result = result.substring (4, line.length - 4 );
-				stdout.printf ("ERR2?? : %s\n", str ) ; */
+			    //result = result.substring (4, line.length - 4 );
+			    stdout.printf ("ERR2?? : %s\n", str ) ; */
 			var start = str.index_of ("(");
 			if (start >= 0) {
 				return str.substring (0, start).strip ();
@@ -305,7 +305,7 @@ namespace Ivy {
 
 			}
 			catch (Error e) {
-				print ("Error while executing '%s': %s\n".printf(cmd,e.message));
+				print ("Error while executing '%s': %s\n".printf(cmd, e.message));
 			}
 			return "";
 		}
@@ -322,17 +322,17 @@ namespace Ivy {
 			return result;
 		}
 
-	/**
-	 * Populates the stacktrace with frames
-	 *
-	 * The frames are extracted from ``Linux.Backtrace`` and enriched
-	 * via calls to unix tools ``nm`` and ``addr2line``.
-	 *
-	 * ''Warning:'' because this methods calls synchronously other applications (nm and addr2line), it
-	 * can have a significant impact on performance.
-	 *
-	 * @param trace the stacktrace
-	 */
+		/**
+		 * Populates the stacktrace with frames
+		 *
+		 * The frames are extracted from ``Linux.Backtrace`` and enriched
+		 * via calls to unix tools ``nm`` and ``addr2line``.
+		 *
+		 * ''Warning:'' because this methods calls synchronously other applications (nm and addr2line), it
+		 * can have a significant impact on performance.
+		 *
+		 * @param trace the stacktrace
+		 */
 		public void create_stacktrace (Stacktrace trace) {
 			int frame_count = 100;
 			int skipped_frames_count = 5;
@@ -362,11 +362,11 @@ namespace Ivy {
 			int[] addresses = (int[])array;
 			string module = get_module_name ();
 			// First ones are the handler
-			for (int i = skipped_frames_count ; i < size ; i++) {
+			for (int i = skipped_frames_count; i < size; i++) {
 				int address = addresses[i];
 				string str = strings[i];
 				var addr = extract_address (str);
-				lib_address ="";
+				lib_address = "";
 				//stdout.printf ("9 '%s'. Addr: '%s' \n", func, addr);
 				var full_line = process_line (module, addr);
 				//stdout.printf ("10 '%s'\n", func);
@@ -397,7 +397,7 @@ namespace Ivy {
 				if( show_debug_frames )
 				{
 					stdout.printf ("\nFrame %d \n--------\n  . addr: [%s]\n  . full_line: '%s'\n  . file_line: '%s'\n  . func_line: '%s'\n  . str : '%s'\n  . func: '%s'\n  . file: '%s'\n  . line: '%s'\n  . address: '%#08x'\n  . lib_address: '%s'\n",
-					i, addr, full_line, file_line, func_line, str, func, file_path, l, address, lib_address);
+					               i, addr, full_line, file_line, func_line, str, func, file_path, l, address, lib_address);
 				}
 				if (func != "" && file_path.has_suffix (".vala") && trace.is_all_function_name_blank)
 					trace.is_all_function_name_blank = false;

--- a/libIvy/Frame.vala
+++ b/libIvy/Frame.vala
@@ -33,7 +33,7 @@ namespace Ivy {
 		 *
 		 * Ex: ``0x309``
 		 **/
-		public string address  { get;private set;default = "";}
+		public string address  { get; private set; default = "";}
 
 		/**
 		 * Line of code of the frame
@@ -44,7 +44,7 @@ namespace Ivy {
 		 *
 		 * Ex:
 		 **/
-		public string line { get;private set;default = "";}
+		public string line { get; private set; default = "";}
 
 		/**
 		 * Line number in the code file.
@@ -53,7 +53,7 @@ namespace Ivy {
 		 *
 		 * Ex: ``25``
 		 **/
-		public string line_number { get;private set;default = "";}
+		public string line_number { get; private set; default = "";}
 
 		/**
 		 * Full path to the code file as it was stored on the building machine
@@ -64,7 +64,7 @@ namespace Ivy {
 		 *
 		 * Ex: ``/lib/x86_64-linux-gnu/libc.so.6`` if no code information is available
 		 **/
-		public string file_path { get;private set;default = "";}
+		public string file_path { get; private set; default = "";}
 
 		/**
 		 * Path the code file relative to the current path
@@ -73,7 +73,7 @@ namespace Ivy {
 		 *
 		 * Ex: ``/stuff/to/stuff/``
 		 **/
-		public string file_short_path { get;private set;default = "";}
+		public string file_short_path { get; private set; default = "";}
 
 		/**
 		 * C function name
@@ -85,7 +85,7 @@ namespace Ivy {
 		 *
 		 * Ex: ``namespace_someclass_method``
 		 **/
-		public string function { get;private set;default = "";}
+		public string function { get; private set; default = "";}
 
 		public Frame (string address, string line, string function, string file_path, string file_short_path, string line_number) {
 			this._address = address;

--- a/libIvy/Printer.vala
+++ b/libIvy/Printer.vala
@@ -27,7 +27,7 @@ namespace Ivy {
 
 		private Stacktrace stacktrace;
 
-	   private string get_reset_code () {
+		private string get_reset_code () {
 			// return get_color_code (Style.RESET, Colors.WHITE, Colors.BLACK);
 			return "\x1b[0m";
 		}
@@ -150,7 +150,7 @@ namespace Ivy {
 			this.stacktrace = trace;
 			background_color = stacktrace.error_background;
 			var header = "%s%s\n".printf (get_printable_title (),
-										  get_reset_code ());
+			                              get_reset_code ());
 			var first_vala = trace.first_vala;
 
 			if (trace.first_vala != null) {
@@ -160,8 +160,8 @@ namespace Ivy {
 					get_printable_line_number (first_vala, false),
 					get_printable_function (first_vala) + get_reset_code ());
 				title_length += first_vala.line_number.length +
-								first_vala.function.length +
-								first_vala.file_short_path.length;
+				                first_vala.function.length +
+				                first_vala.file_short_path.length;
 			}
 			stdout.printf (header);
 			background_color = Color.BLACK;

--- a/libIvy/Stacktrace.vala
+++ b/libIvy/Stacktrace.vala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
- /**
-  * Provides services to display vala stacktraces
-  */
+/**
+ * Provides services to display vala stacktraces
+ */
 namespace Ivy {
 
 	internal enum Style {
@@ -128,7 +128,7 @@ namespace Ivy {
 		 *
 		 * Default is ``true``
 		 */
-		public static bool enabled { get;set;default = true;}
+		public static bool enabled { get; set; default = true;}
 
 		/**
 		 * Hides frames located in external system libraries (like ``libgc``) without
@@ -243,7 +243,7 @@ namespace Ivy {
 		 *         at /home/cran/Documents/Projects/i-hate-farms/app/exocron/build/src/Application.c:304
 		 * }}}
 		 */
-		public static bool hide_installed_libraries { get;set;default = true;}
+		public static bool hide_installed_libraries { get; set; default = true;}
 
 		/**
 		 * Sets the default higlighted text color for stacktrace that are created
@@ -251,7 +251,7 @@ namespace Ivy {
 		 *
 		 * Default is ``Color.WHITE``
 		 */
-		public static Color default_highlight_color { get;set;default = Color.WHITE;}
+		public static Color default_highlight_color { get; set; default = Color.WHITE;}
 
 		/**
 		 * Sets the default background color for stacktrace that are created
@@ -259,21 +259,21 @@ namespace Ivy {
 		 *
 		 * Default is ``Color.RED``
 		 */
-		 public static Color default_error_background { get;set;default = Color.RED;}
+		public static Color default_error_background { get; set; default = Color.RED;}
 
 		/**
 		 * Sets the stacktrace higlighted text color when printed on ``stdout``
 		 *
 		 * Default is ``Color.WHITE``
 		 */
-		 public Color highlight_color { get;set;default = Color.WHITE;}
+		public Color highlight_color { get; set; default = Color.WHITE;}
 
 		/**
 		 * Sets the stacktrace background color when printed on ``stdout``
 		 *
 		 * Default is ``Color.RED``
 		 */
-		public Color error_background { get;set;default = Color.RED;}
+		public Color error_background { get; set; default = Color.RED;}
 
 		/**
 		 * Collection of frames
@@ -332,7 +332,7 @@ namespace Ivy {
 		 *
 		 */
 		public void print () {
-		   printer.print (this);
+			printer.print (this);
 		}
 
 		/**
@@ -372,18 +372,18 @@ namespace Ivy {
 		 *
 		 * Default is ``CriticalHandler.PRINT_STACKTRACE``.
 		 */
-		public static CriticalHandler critical_handling  { get;set;default = CriticalHandler.PRINT_STACKTRACE;}
+		public static CriticalHandler critical_handling  { get; set; default = CriticalHandler.PRINT_STACKTRACE;}
 
 		/*{
-			set {
-				_critical_handling = value;
-				if( value == CriticalHandler.CRASH )
-				//var variables = Environ.get ();
-				//Environ.set_variable (variables, "G_DEBUG", "fatal-criticals" );
-				Log.set_always_fatal (LogLevelFlags.LEVEL_CRITICAL);
-			}
-			get {
-			}
+		    set {
+		        _critical_handling = value;
+		        if( value == CriticalHandler.CRASH )
+		        //var variables = Environ.get ();
+		        //Environ.set_variable (variables, "G_DEBUG", "fatal-criticals" );
+		        Log.set_always_fatal (LogLevelFlags.LEVEL_CRITICAL);
+		    }
+		    get {
+		    }
 
 		   }*/
 
@@ -393,7 +393,7 @@ namespace Ivy {
 			Stacktrace stack = new Stacktrace ((ProcessSignal) sig);
 			stack.print ();
 			if (sig != ProcessSignal.TRAP ||
-				(sig == ProcessSignal.TRAP && critical_handling == CriticalHandler.CRASH))
+			    (sig == ProcessSignal.TRAP && critical_handling == CriticalHandler.CRASH))
 				Process.exit (1);
 		}
 

--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -115,7 +115,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
+			string ? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -136,14 +136,14 @@ public class FeedReader.bazquxAPI : GLib.Object {
 			}
 			feeds.add(
 				new feed (
-						feedID,
-						title,
-						url,
-						0,
-						categories,
-						icon_url
+					feedID,
+					title,
+					url,
+					0,
+					categories,
+					icon_url
 					)
-			);
+				);
 		}
 		return true;
 	}
@@ -192,8 +192,8 @@ public class FeedReader.bazquxAPI : GLib.Object {
 							orderID,
 							CategoryID.MASTER.to_string(),
 							1
-						)
-					);
+							)
+						);
 					++orderID;
 				}
 				else
@@ -203,14 +203,13 @@ public class FeedReader.bazquxAPI : GLib.Object {
 							id,
 							title,
 							dbDaemon.get_default().getTagColor()
-						)
-					);
+							)
+						);
 				}
 			}
 		}
 		return true;
 	}
-
 
 	public int getTotalUnread()
 	{
@@ -251,8 +250,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		return count;
 	}
 
-
-	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
+	public string ? updateArticles(Gee.List<string> ids, int count, string ? continuation = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -293,7 +291,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string ? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string ? continuation = null, string ? tagID = null, string ? feed_id = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -338,7 +336,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		{
 			Json.Object object = array.get_object_element(i);
 			string id = object.get_string_member("id");
-			id = id.substring(id.last_index_of_char('/')+1);
+			id = id.substring(id.last_index_of_char('/') + 1);
 			string tagString = "";
 			bool marked = false;
 			bool read = false;
@@ -369,7 +367,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 				{
 					var attachment = attachments.get_object_element(j);
 					if(attachment.get_string_member("type").contains("audio")
-					|| attachment.get_string_member("type").contains("video"))
+					   || attachment.get_string_member("type").contains("video"))
 					{
 						mediaString = mediaString + attachment.get_string_member("href") + ",";
 					}
@@ -377,21 +375,21 @@ public class FeedReader.bazquxAPI : GLib.Object {
 			}
 
 			articles.add(new article(
-									id,
-									object.get_string_member("title"),
-									object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
-									object.get_object_member("origin").get_string_member("streamId"),
-									read ? ArticleStatus.READ : ArticleStatus.UNREAD,
-									marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-									object.get_object_member("summary").get_string_member("content"),
-									"",
-									(object.get_string_member("author") == "") ? null : object.get_string_member("author"),
-									new DateTime.from_unix_local(object.get_int_member("published")),
-									-1,
-									tagString,
-									mediaString
-							)
-						);
+							 id,
+							 object.get_string_member("title"),
+							 object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
+							 object.get_object_member("origin").get_string_member("streamId"),
+							 read ? ArticleStatus.READ : ArticleStatus.UNREAD,
+							 marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+							 object.get_object_member("summary").get_string_member("content"),
+							 "",
+							 (object.get_string_member("author") == "") ? null : object.get_string_member("author"),
+							 new DateTime.from_unix_local(object.get_int_member("published")),
+							 -1,
+							 tagString,
+							 mediaString
+							 )
+			             );
 		}
 
 		if(root.has_member("continuation") && root.get_string_member("continuation") != "")
@@ -399,7 +397,6 @@ public class FeedReader.bazquxAPI : GLib.Object {
 
 		return null;
 	}
-
 
 	public void edidTag(string articleID, string tagID, bool add = true)
 	{
@@ -415,7 +412,7 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		m_connection.send_post_request("edit-tag", msg.get());
 	}
 
-	public void markAsRead(string? streamID = null)
+	public void markAsRead(string ? streamID = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
@@ -446,22 +443,22 @@ public class FeedReader.bazquxAPI : GLib.Object {
 		m_connection.send_post_request("rename-tag", msg.get());
 	}
 
-	public bool editSubscription(bazquxSubscriptionAction action, string feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(bazquxSubscriptionAction action, string feedID, string ? title = null, string ? add = null, string ? remove = null)
 	{
 		var msg = new bazquxMessage();
 		msg.add("output", "json");
 
 		switch(action)
 		{
-			case bazquxSubscriptionAction.EDIT:
-				msg.add("ac", "edit");
-				break;
-			case bazquxSubscriptionAction.SUBSCRIBE:
-				msg.add("ac", "subscribe");
-				break;
-			case bazquxSubscriptionAction.UNSUBSCRIBE:
-				msg.add("ac", "unsubscribe");
-				break;
+		case bazquxSubscriptionAction.EDIT:
+			msg.add("ac", "edit");
+			break;
+		case bazquxSubscriptionAction.SUBSCRIBE:
+			msg.add("ac", "subscribe");
+			break;
+		case bazquxSubscriptionAction.UNSUBSCRIBE:
+			msg.add("ac", "unsubscribe");
+			break;
 		}
 
 		msg.add("s", feedID);
@@ -474,7 +471,6 @@ public class FeedReader.bazquxAPI : GLib.Object {
 
 		if(remove != null)
 			msg.add("r", remove);
-
 
 		var response = m_connection.send_post_request("subscription/edit", msg.get());
 

--- a/plugins/backend/bazqux/bazquxConnection.vala
+++ b/plugins/backend/bazqux/bazquxConnection.vala
@@ -52,8 +52,8 @@ public class FeedReader.bazquxConnection {
 			if(regex.match(response))
 			{
 				Logger.error("Regex bazqux - %s".printf(response));
-				string split = regex.replace( response, -1,0,"");
-				Logger.error("authcode"+split);
+				string split = regex.replace( response, -1, 0, "");
+				Logger.error("authcode" + split);
 				m_utils.setAccessToken(split.strip());
 				return LoginResponse.SUCCESS;
 			}
@@ -71,17 +71,17 @@ public class FeedReader.bazquxConnection {
 		}
 	}
 
-	public Response send_get_request(string path, string? message_string = null)
+	public Response send_get_request(string path, string ? message_string = null)
 	{
 		return send_request(path, "GET", message_string);
 	}
 
-	public Response send_post_request(string path, string? message_string = null)
+	public Response send_post_request(string path, string ? message_string = null)
 	{
 		return send_request(path, "POST", message_string);
 	}
 
-	private Response send_request(string path, string type, string? message_string = null)
+	private Response send_request(string path, string type, string ? message_string = null)
 	{
 
 		var message = new Soup.Message(type, bazquxSecret.base_uri + path);
@@ -95,8 +95,8 @@ public class FeedReader.bazquxConnection {
 		m_session.send_message(message);
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 

--- a/plugins/backend/bazqux/bazquxInterface.vala
+++ b/plugins/backend/bazqux/bazquxInterface.vala
@@ -175,7 +175,7 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.ping();
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		feedID = "feed/" + feedURL;
 		bool success = false;
@@ -184,11 +184,11 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
-			success = m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/"+feedURL, null, newCatID);
+			success = m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/" + feedURL, null, newCatID);
 		}
 		else
 		{
-			success = m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/"+feedURL, null, catID);
+			success = m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.SUBSCRIBE, "feed/" + feedURL, null, catID);
 		}
 
 		if(!success)
@@ -212,12 +212,12 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.EDIT, feedID, title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.editSubscription(bazquxAPI.bazquxSubscriptionAction.EDIT, feedID, null, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.composeTagID(title);
 	}
@@ -248,7 +248,7 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getFeeds(feeds))
 		{
@@ -266,7 +266,7 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{
@@ -275,8 +275,8 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		else if(whatToGet == ArticleStatus.ALL)
 		{
 			var unreadIDs = new Gee.LinkedList<string>();
-			string? continuation = null;
-			int left = 4*count;
+			string ? continuation = null;
+			int left = 4 * count;
 
 			while(left > 0)
 			{
@@ -298,10 +298,10 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		}
 
 		var articles = new Gee.LinkedList<article>();
-		string? continuation = null;
+		string ? continuation = null;
 		int left = count;
-		string? bazqux_feedID = (isTagID) ? null : feedID;
-		string? bazqux_tagID = (isTagID) ? feedID : null;
+		string ? bazqux_feedID = (isTagID) ? null : feedID;
+		string ? bazqux_tagID = (isTagID) ? feedID : null;
 
 		while(left > 0)
 		{

--- a/plugins/backend/bazqux/bazquxLoginWidget.vala
+++ b/plugins/backend/bazqux/bazquxLoginWidget.vala
@@ -15,7 +15,6 @@
 
 public class FeedReader.bazquxLoginWidget : Peas.ExtensionBase, LoginInterface {
 
-
 	private Gtk.Entry m_userEntry;
 	private Gtk.Entry m_passwordEntry;
 	private bazquxUtils m_utils;
@@ -55,7 +54,7 @@ public class FeedReader.bazquxLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var user_label = new Gtk.Label(_("Username:"));
 		var password_label = new Gtk.Label(_("Password:"));
@@ -139,7 +138,6 @@ public class FeedReader.bazquxLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return false;
 	}
 }
-
 
 [ModuleInit]
 public void peas_register_types(GLib.TypeModule module)

--- a/plugins/backend/bazqux/bazquxUtils.vala
+++ b/plugins/backend/bazqux/bazquxUtils.vala
@@ -14,7 +14,7 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.bazquxSecret {
-	 const string base_uri        = "https://www.bazqux.com/reader/api/0/";
+	const string base_uri        = "https://www.bazqux.com/reader/api/0/";
 }
 
 public class FeedReader.bazquxUtils : GLib.Object {
@@ -67,10 +67,10 @@ public class FeedReader.bazquxUtils : GLib.Object {
 		                                  "type", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["type"] = "BazQux";
 		attributes["Username"] = getUser();
-		string? passwd = "";
+		string ? passwd = "";
 
 		try
 		{
@@ -93,9 +93,9 @@ public class FeedReader.bazquxUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.bazqux", Secret.SchemaFlags.NONE,
-										  "type", Secret.SchemaAttributeType.STRING,
-										  "Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "type", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["type"] = "BazQux";
 		attributes["Username"] = getUser();
 		try

--- a/plugins/backend/demo/demoInterface.vala
+++ b/plugins/backend/demo/demoInterface.vala
@@ -15,7 +15,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Does the service you are implementing support tags?
 	// If so return "true", otherwise return "false".
@@ -24,7 +23,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// If the daemon should to an initial sync after logging in.
@@ -36,7 +34,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// What is the symbolic icon-name of the service-logo?
 	// Return a string with the name, not the complete path.
@@ -46,7 +43,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Return a name the account of the user can be identified with.
@@ -58,7 +54,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// If the service can be self-hosted or has multiple providers
 	// you can return the URL of the server here. Preferably without "http://www."
@@ -67,7 +62,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Many services have different ways of telling if a feed is uncategorized.
@@ -80,7 +74,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Sone services have special categories that should not be visible when empty
@@ -109,7 +102,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Does the service allow categories as children of other categories?
 	// If so return "true", otherwise return "false".
@@ -119,7 +111,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Can one feed be part of more than one category?
 	// If so return "true", otherwise return "false".
@@ -128,7 +119,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Does changing the name of a tag also change it's ID?
@@ -142,7 +132,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Delete all passwords, keys and user-information.
 	// Do not delete feeds or articles from the data-base.
@@ -151,7 +140,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// State wheater the service syncs articles based on a maximum count
@@ -186,7 +174,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// If it is possible to log out of the account of the service, do so here.
 	// If not, do nothing and return "true".
@@ -196,7 +183,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Check if the service is reachable.
 	// You can use the method Utils.ping() if the service doesn't provide anything.
@@ -205,7 +191,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Method to set the state of articles to read or unread
@@ -217,7 +202,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Method to set the state of articles to marked or unmarked
 	// "articleID": single articleID
@@ -228,7 +212,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Mark all articles of the feed as read
 	//--------------------------------------------------------------------------------------
@@ -236,7 +219,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Mark all articles of the feeds that are part of the category as read
@@ -246,7 +228,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Mark ALL articles as read
 	//--------------------------------------------------------------------------------------
@@ -254,7 +235,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Add an existing tag to the article
@@ -264,7 +244,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Remove an existing tag from the article
 	//--------------------------------------------------------------------------------------
@@ -272,7 +251,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Create a new tag with the title of "caption" and return the id of the
@@ -286,7 +264,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Delete a tag completely
 	//--------------------------------------------------------------------------------------
@@ -294,7 +271,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Rename the tag with the id "tagID" to the new name "title"
@@ -304,17 +280,15 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Subscribe to the URL "feedURL"
 	// "catID": the category the feed should be placed into, "null" otherwise
 	// "newCatName": the name of a new category the feed should be put in, "null" otherwise
 	//--------------------------------------------------------------------------------------
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Remove the feed with the id "feedID" completely
@@ -324,7 +298,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Rename the feed with the id "feedID" to "title"
 	//--------------------------------------------------------------------------------------
@@ -333,17 +306,15 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Move the feed with the id "feedID" from its current category
 	// to any other category. "currentCatID" is only needed if the
 	// feed can be part of multiple categories at once.
 	//--------------------------------------------------------------------------------------
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Create a new category
@@ -353,11 +324,10 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	// on the fly when movin feeds over to them. In this case just compose the categoryID
 	// following the schema tha service uses and return it.
 	//--------------------------------------------------------------------------------------
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Rename the category with the id "catID" to "title"
@@ -366,7 +336,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Move the category with the id "catID" into another category
@@ -378,7 +347,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Delete the category with the id "catID"
 	//--------------------------------------------------------------------------------------
@@ -386,7 +354,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Rename the feed with the id "feedID" from the category with the id "catID"
@@ -398,7 +365,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Import the content of "opml"
 	// If the service doesn't provide API to import OPML you can use the
@@ -409,17 +375,15 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Get all feeds, categories and tags from the service
 	// Fill up the emtpy LinkedList's that are provided with instances of the
 	// model-classes category, feed and article
 	//--------------------------------------------------------------------------------------
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Return the total count of unread articles on the server
@@ -428,7 +392,6 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Get the requested articles and write them to the data-base
@@ -445,13 +408,12 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	// But if the API suggests a different approach you can everything on your
 	// own (see ttrss-backend).
 	//--------------------------------------------------------------------------------------
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 
 	}
 
 }
-
 
 //--------------------------------------------------------------------------------------
 // Boilerplate code for the plugin. Replace "demoInterface" with the name

--- a/plugins/backend/demo/demoLoginWidget.vala
+++ b/plugins/backend/demo/demoLoginWidget.vala
@@ -17,7 +17,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Return the the website/homepage of the project
 	//--------------------------------------------------------------------------------------
@@ -25,7 +24,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Return an unique id for the backend. Basically a short form of the name:
@@ -36,7 +34,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Return flags describing the type of Service
@@ -54,16 +51,14 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Return the login UI inside a Gtk.Box (username- and password-entries)
 	// Return 'null' if use web-login
 	//--------------------------------------------------------------------------------------
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Return the name of the service-icon (non-symbolic).
@@ -73,7 +68,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Return the name of the service as displayed to the user
 	//--------------------------------------------------------------------------------------
@@ -82,7 +76,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Return wheather the plugin needs a webview to log in via oauth.
 	//--------------------------------------------------------------------------------------
@@ -90,7 +83,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Only important for self-hosted services.
@@ -112,7 +104,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 
 	}
 
-
 	//--------------------------------------------------------------------------------------
 	// Do stuff after a successful login
 	//--------------------------------------------------------------------------------------
@@ -120,7 +111,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Only needed if "needWebLogin()" retruned true. Return URL that should be
@@ -130,7 +120,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 	{
 
 	}
-
 
 	//--------------------------------------------------------------------------------------
 	// Extract access-key from redirect-URL from webview after loggin in with
@@ -142,7 +131,6 @@ public class FeedReader.demoLoginWidget : Peas.ExtensionBase, LoginInterface {
 
 	}
 }
-
 
 //--------------------------------------------------------------------------------------
 // Boilerplate code for the plugin. Replace "demoLoginWidget" with the name

--- a/plugins/backend/feedbin/feedbinAPI.vala
+++ b/plugins/backend/feedbin/feedbinAPI.vala
@@ -88,7 +88,7 @@ public class FeedReader.feedbinAPI : Object {
 					{ "0" },
 					null,
 					xmlURL)
-			);
+				);
 		}
 
 		return true;
@@ -122,7 +122,7 @@ public class FeedReader.feedbinAPI : Object {
 			string name = object.get_string_member("name");
 			string feedID = object.get_int_member("feed_id").to_string();
 
-			string? id2 = m_utils.catExists(categories, name);
+			string ? id2 = m_utils.catExists(categories, name);
 
 			if(id2 == null)
 			{
@@ -131,11 +131,11 @@ public class FeedReader.feedbinAPI : Object {
 						id,
 						name,
 						0,
-						i+1,
+						i + 1,
 						CategoryID.MASTER.to_string(),
 						1
-					)
-				);
+						)
+					);
 
 				m_utils.addFeedToCat(feeds, feedID, id);
 			}
@@ -144,15 +144,12 @@ public class FeedReader.feedbinAPI : Object {
 				m_utils.addFeedToCat(feeds, feedID, id2);
 			}
 
-
 		}
 
 		return true;
 	}
 
-
-
-	public Gee.List<article> getEntries(int page, bool onlyStarred, Gee.Set<string> unreadIDs, Gee.Set<string> starredIDs, DateTime? timestamp, string? feedID = null)
+	public Gee.List<article> getEntries(int page, bool onlyStarred, Gee.Set<string> unreadIDs, Gee.Set<string> starredIDs, DateTime ? timestamp, string ? feedID = null)
 	{
 		Gee.List<article> articles = new Gee.ArrayList<article>();
 		string request = "entries.json?per_page=100";
@@ -215,19 +212,19 @@ public class FeedReader.feedbinAPI : Object {
 			}
 
 			var article = new article(
-					id,
-					object.get_string_member("title") == null ? "" : object.get_string_member("title"),
-					object.get_string_member("url"),
-					object.get_int_member("feed_id").to_string(),
-					unreadIDs.contains(id) ? ArticleStatus.UNREAD : ArticleStatus.READ,
-					starredIDs.contains(id) ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-					object.get_string_member("content") == null ? "" : object.get_string_member("content"),
-					object.get_string_member("summary"),
-					object.get_string_member("author"),
-					time,
-					-1,
-					"",
-					""
+				id,
+				object.get_string_member("title") == null ? "" : object.get_string_member("title"),
+				object.get_string_member("url"),
+				object.get_int_member("feed_id").to_string(),
+				unreadIDs.contains(id) ? ArticleStatus.UNREAD : ArticleStatus.READ,
+				starredIDs.contains(id) ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+				object.get_string_member("content") == null ? "" : object.get_string_member("content"),
+				object.get_string_member("summary"),
+				object.get_string_member("author"),
+				time,
+				-1,
+				"",
+				""
 				);
 			if(article != null)
 				articles.add(article);
@@ -245,7 +242,7 @@ public class FeedReader.feedbinAPI : Object {
 	public Gee.List<string> unreadEntries()
 	{
 		string response = m_connection.getRequest("unread_entries.json").data;
-		response = response.substring(1, response.length-2);
+		response = response.substring(1, response.length - 2);
 		var a = response.split(",");
 		var ids = new Gee.LinkedList<string>();
 
@@ -260,7 +257,7 @@ public class FeedReader.feedbinAPI : Object {
 	public Gee.List<string> starredEntries()
 	{
 		string response = m_connection.getRequest("starred_entries.json").data;
-		response = response.substring(1, response.length-2);
+		response = response.substring(1, response.length - 2);
 		var a = response.split(",");
 		var ids = new Gee.LinkedList<string>();
 

--- a/plugins/backend/feedbin/feedbinConnection.vala
+++ b/plugins/backend/feedbin/feedbinConnection.vala
@@ -33,9 +33,9 @@ public class FeedReader.feedbinConnection {
 		});
 	}
 
-	public Response request(string method, string path, string? input = null)
+	public Response request(string method, string path, string ? input = null)
 	{
-		var message = new Soup.Message(method, BASE_URI+path);
+		var message = new Soup.Message(method, BASE_URI + path);
 		if(m_settingsTweaks.get_boolean("do-not-track"))
 			message.request_headers.append("DNT", "1");
 
@@ -48,8 +48,8 @@ public class FeedReader.feedbinConnection {
 		m_session.send_message(message);
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 
@@ -58,7 +58,7 @@ public class FeedReader.feedbinConnection {
 		return request("POST", path, input);
 	}
 
-	public Response deleteRequest(string path, string? input = null)
+	public Response deleteRequest(string path, string ? input = null)
 	{
 		return request("DELETE", path, input);
 	}

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -186,7 +186,7 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		return;
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		feedID = "-98";
 		errmsg = "feedbin backend does not support subcribing to feeds";
@@ -208,12 +208,12 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		//m_api.renameFeed(feedID, title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return "";
 	}
@@ -243,7 +243,7 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getSubscriptionList(feeds))
 		{
@@ -262,7 +262,7 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		return m_api.unreadEntries().size;
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{
@@ -270,11 +270,11 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		}
 
 		var settings_state = new GLib.Settings("org.gnome.feedreader.saved-state");
-		DateTime? time = null;
+		DateTime ? time = null;
 		if(!dbDaemon.get_default().isTableEmpty("articles"))
 			time = new DateTime.from_unix_utc(settings_state.get_int("last-sync"));
 
-		string? fID = isTagID ? null : feedID;
+		string ? fID = isTagID ? null : feedID;
 		bool onlyStarred = (whatToGet == ArticleStatus.MARKED);
 
 		// The Feedbin API doesn't include read/unread/starred status in the entries.json
@@ -284,7 +284,7 @@ public class FeedReader.feedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		var starredIDs = new Gee.HashSet<string>();
 		starredIDs.add_all(m_api.starredEntries());
 
-		for(int page = 1; ; ++page)
+		for(int page = 1;; ++page)
 		{
 			if(cancellable != null && cancellable.is_cancelled())
 				return;

--- a/plugins/backend/feedbin/feedbinLoginWidget.vala
+++ b/plugins/backend/feedbin/feedbinLoginWidget.vala
@@ -54,7 +54,7 @@ public class FeedReader.feedbinLoginWidget : Peas.ExtensionBase, LoginInterface 
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var user_label = new Gtk.Label(_("Username:"));
 		var password_label = new Gtk.Label(_("Password:"));
@@ -98,7 +98,6 @@ public class FeedReader.feedbinLoginWidget : Peas.ExtensionBase, LoginInterface 
 		loginButton.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 		loginButton.clicked.connect(() => { login(); });
 
-
 		var box = new Gtk.Box(Gtk.Orientation.VERTICAL, 10);
 		box.valign = Gtk.Align.CENTER;
 		box.halign = Gtk.Align.CENTER;
@@ -139,7 +138,6 @@ public class FeedReader.feedbinLoginWidget : Peas.ExtensionBase, LoginInterface 
 		return "";
 	}
 }
-
 
 [ModuleInit]
 public void peas_register_types(GLib.TypeModule module)

--- a/plugins/backend/feedbin/feedbinUtils.vala
+++ b/plugins/backend/feedbin/feedbinUtils.vala
@@ -38,7 +38,7 @@ public class FeedReader.feedbinUtils : GLib.Object {
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = "feedbin.com";
 		attributes["Username"] = getUser();
 
@@ -47,7 +47,7 @@ public class FeedReader.feedbinUtils : GLib.Object {
 		try{
 			passwd = Secret.password_lookupv_sync(pwSchema, attributes, null);
 		}
-		catch(GLib.Error e){
+		catch(GLib.Error e) {
 			Logger.error(e.message);
 		}
 
@@ -62,9 +62,9 @@ public class FeedReader.feedbinUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										  "URL", Secret.SchemaAttributeType.STRING,
-										  "Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = "feedbin.com";
 		attributes["Username"] = getUser();
 		try
@@ -87,26 +87,26 @@ public class FeedReader.feedbinUtils : GLib.Object {
 	{
 		bool removed = false;
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										"URL", Secret.SchemaAttributeType.STRING,
-										"Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = "feedbin.com";
 		attributes["Username"] = getUser();
 
 		Secret.password_clearv.begin (pwSchema, attributes, null, (obj, async_res) => {
 			try
 			{
-				removed = Secret.password_clearv.end(async_res);
+			    removed = Secret.password_clearv.end(async_res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("feedbinUtils.deletePassword: %s".printf(e.message));
+			    Logger.error("feedbinUtils.deletePassword: %s".printf(e.message));
 			}
 		});
 		return removed;
 	}
 
-	public string? catExists(Gee.List<category> categories, string name)
+	public string ? catExists(Gee.List<category> categories, string name)
 	{
 		foreach(category cat in categories)
 		{

--- a/plugins/backend/feedhq/feedhqAPI.vala
+++ b/plugins/backend/feedhq/feedhqAPI.vala
@@ -31,7 +31,6 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		m_utils = new FeedHQUtils();
 	}
 
-
 	public LoginResponse login()
 	{
 		Logger.debug("FeedHQ Login");
@@ -117,7 +116,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id").replace("/", "_");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string? icon_url = object.has_member("iconUrl") ? "https:"+object.get_string_member("iconUrl") : null;
+			string ? icon_url = object.has_member("iconUrl") ? "https:" + object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -138,14 +137,14 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 			}
 			feeds.add(
 				new feed (
-						feedID,
-						title,
-						url,
-						0,
-						categories,
-						icon_url
+					feedID,
+					title,
+					url,
+					0,
+					categories,
+					icon_url
 					)
-			);
+				);
 		}
 		return true;
 	}
@@ -184,14 +183,14 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 
 			if(id.contains("/label/"))
 			{
-					categories.add(
-						new category(
-							id.replace("/", "_"),
-							title,
-							0,
-							orderID,
-							CategoryID.MASTER.to_string(),
-							1
+				categories.add(
+					new category(
+						id.replace("/", "_"),
+						title,
+						0,
+						orderID,
+						CategoryID.MASTER.to_string(),
+						1
 						)
 					);
 				++orderID;
@@ -199,7 +198,6 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		}
 		return true;
 	}
-
 
 	public int getTotalUnread()
 	{
@@ -235,8 +233,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		return count;
 	}
 
-
-	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
+	public string ? updateArticles(Gee.List<string> ids, int count, string ? continuation = null)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
@@ -284,7 +281,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string ? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string ? continuation = null, string ? tagID = null, string ? feed_id = null)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
@@ -359,7 +356,7 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 				{
 					var attachment = attachments.get_object_element(j);
 					if(attachment.get_string_member("type").contains("audio")
-					|| attachment.get_string_member("type").contains("video"))
+					   || attachment.get_string_member("type").contains("video"))
 					{
 						mediaString = mediaString + attachment.get_string_member("href") + ",";
 					}
@@ -367,21 +364,21 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 			}
 
 			articles.add(new article(
-									id,
-									object.get_string_member("title"),
-									object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
-									object.get_object_member("origin").get_string_member("streamId").replace("/", "_"),
-									read ? ArticleStatus.READ : ArticleStatus.UNREAD,
-									marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-									"",
-									"",
-									"",
-									new DateTime.from_unix_local(object.get_int_member("published")),
-									-1,
-									tagString,
-									mediaString
-							)
-						);
+							 id,
+							 object.get_string_member("title"),
+							 object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
+							 object.get_object_member("origin").get_string_member("streamId").replace("/", "_"),
+							 read ? ArticleStatus.READ : ArticleStatus.UNREAD,
+							 marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+							 "",
+							 "",
+							 "",
+							 new DateTime.from_unix_local(object.get_int_member("published")),
+							 -1,
+							 tagString,
+							 mediaString
+							 )
+			             );
 		}
 
 		if(root.has_member("continuation") && root.get_string_member("continuation") != "")
@@ -389,7 +386,6 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 
 		return null;
 	}
-
 
 	public void edidTag(string articleID, string tagID, bool add = true)
 	{
@@ -437,22 +433,22 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 		m_connection.send_post_request("rename-tag", msg.get());
 	}
 
-	public bool editSubscription(FeedHQSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(FeedHQSubscriptionAction action, string[] feedID, string ? title = null, string ? add = null, string ? remove = null)
 	{
 		var msg = new feedhqMessage();
 		msg.add("output", "json");
 
 		switch(action)
 		{
-			case FeedHQSubscriptionAction.EDIT:
-				msg.add("ac", "edit");
-				break;
-			case FeedHQSubscriptionAction.SUBSCRIBE:
-				msg.add("ac", "subscribe");
-				break;
-			case FeedHQSubscriptionAction.UNSUBSCRIBE:
-				msg.add("ac", "unsubscribe");
-				break;
+		case FeedHQSubscriptionAction.EDIT:
+			msg.add("ac", "edit");
+			break;
+		case FeedHQSubscriptionAction.SUBSCRIBE:
+			msg.add("ac", "subscribe");
+			break;
+		case FeedHQSubscriptionAction.UNSUBSCRIBE:
+			msg.add("ac", "unsubscribe");
+			break;
 		}
 
 		foreach(string s in feedID)
@@ -463,7 +459,6 @@ public class FeedReader.FeedHQAPI : GLib.Object {
 
 		if(add != null && add != "")
 			msg.add("a", add.replace("_", "/"));
-
 
 		if(remove != null && remove != "")
 			msg.add("r", remove.replace("_", "/"));

--- a/plugins/backend/feedhq/feedhqConnection.vala
+++ b/plugins/backend/feedhq/feedhqConnection.vala
@@ -51,7 +51,7 @@ public class FeedReader.FeedHQConnection {
 			var regex = new Regex(".*\\w\\s.*\\w\\sAuth=");
 			if(regex.match(response))
 			{
-				string split = regex.replace(response, -1,0,"");
+				string split = regex.replace(response, -1, 0, "");
 				Logger.debug("FeedHQ Authcode : " + split);
 				m_utils.setAccessToken(split.strip());
 				return LoginResponse.SUCCESS;
@@ -69,7 +69,6 @@ public class FeedReader.FeedHQConnection {
 			return LoginResponse.UNKNOWN_ERROR;
 		}
 	}
-
 
 	public bool postToken()
 	{
@@ -94,19 +93,17 @@ public class FeedReader.FeedHQConnection {
 		return true;
 
 	}
-	public Response send_get_request(string path, string? message_string = null)
+	public Response send_get_request(string path, string ? message_string = null)
 	{
 		return send_request(path, "GET", message_string);
 	}
 
-	public Response send_post_request(string path, string? message_string = null)
+	public Response send_post_request(string path, string ? message_string = null)
 	{
 		return send_request(path, "POST", message_string);
 	}
 
-
-
-	private Response send_request(string path, string type, string? message_string = null)
+	private Response send_request(string path, string type, string ? message_string = null)
 	{
 		var message = new Soup.Message(type, FeedHQSecret.base_uri + path);
 
@@ -131,13 +128,12 @@ public class FeedReader.FeedHQConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 
 }
-
 
 public class FeedReader.feedhqMessage {
 

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -175,7 +175,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.ping();
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		feedID = "feed/" + feedURL;
 		bool success = false;
@@ -184,11 +184,11 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		{
 			string newCatID = m_api.composeTagID(newCatName);
 			Logger.debug(newCatID);
-			success = m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
+			success = m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/" + feedURL}, null, newCatID);
 		}
 		else
 		{
-			success = m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
+			success = m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.SUBSCRIBE, {"feed/" + feedURL}, null, catID);
 		}
 
 		if(!success)
@@ -212,12 +212,12 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.EDIT, {feedID}, title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.editSubscription(FeedHQAPI.FeedHQSubscriptionAction.EDIT, {feedID}, null, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.composeTagID(title);
 	}
@@ -247,7 +247,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.import(opml);
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getFeeds(feeds))
 		{
@@ -266,7 +266,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{
@@ -275,7 +275,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		else if(whatToGet == ArticleStatus.ALL)
 		{
 			var unreadIDs = new Gee.LinkedList<string>();
-			string? continuation = null;
+			string ? continuation = null;
 
 			do
 			{
@@ -289,9 +289,9 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		}
 
 		var articles = new Gee.LinkedList<article>();
-		string? continuation = null;
-		string? FeedHQ_feedID = (isTagID) ? null : feedID;
-		string? FeedHQ_tagID = (isTagID) ? feedID : null;
+		string ? continuation = null;
+		string ? FeedHQ_feedID = (isTagID) ? null : feedID;
+		string ? FeedHQ_tagID = (isTagID) ? feedID : null;
 
 		do
 		{

--- a/plugins/backend/feedhq/feedhqLoginWidget.vala
+++ b/plugins/backend/feedhq/feedhqLoginWidget.vala
@@ -15,7 +15,6 @@
 
 public class FeedReader.FeedHQLoginWidget : Peas.ExtensionBase, LoginInterface {
 
-
 	private Gtk.Entry m_userEntry;
 	private Gtk.Entry m_passwordEntry;
 	private FeedHQUtils m_utils;
@@ -55,7 +54,7 @@ public class FeedReader.FeedHQLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var user_label = new Gtk.Label(_("Username:"));
 		var password_label = new Gtk.Label(_("Password:"));
@@ -124,7 +123,6 @@ public class FeedReader.FeedHQLoginWidget : Peas.ExtensionBase, LoginInterface {
 		m_utils.setPassword(m_passwordEntry.get_text());
 	}
 
-
 	public async void postLoginAction()
 	{
 		return;
@@ -140,7 +138,6 @@ public class FeedReader.FeedHQLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return "";
 	}
 }
-
 
 [ModuleInit]
 public void peas_register_types(GLib.TypeModule module)

--- a/plugins/backend/feedhq/feedhqUtils.vala
+++ b/plugins/backend/feedhq/feedhqUtils.vala
@@ -14,7 +14,7 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.FeedHQSecret {
-	 const string base_uri        = "https://feedhq.org/reader/api/0/";
+	const string base_uri        = "https://feedhq.org/reader/api/0/";
 }
 
 public class FeedReader.FeedHQUtils : GLib.Object {
@@ -98,10 +98,10 @@ public class FeedReader.FeedHQUtils : GLib.Object {
 		                                  "type", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["type"] = "FeedHQ";
 		attributes["Username"] = getUser();
-		string? passwd = "";
+		string ? passwd = "";
 
 		try
 		{
@@ -124,10 +124,10 @@ public class FeedReader.FeedHQUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.feedhq", Secret.SchemaFlags.NONE,
-										  "type", Secret.SchemaAttributeType.STRING,
-										  "Username", Secret.SchemaAttributeType.STRING);
+		                                  "type", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["type"] = "FeedHQ";
 		attributes["Username"] = getUser();
 		try

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -144,7 +144,6 @@ public class FeedReader.FeedlyAPI : Object {
 		return ConnectionError.SUCCESS;
 	}
 
-
 	public bool getCategories(Gee.List<category> categories)
 	{
 		var response = m_connection.send_get_request_to_feedly ("/v3/categories/");
@@ -171,7 +170,7 @@ public class FeedReader.FeedlyAPI : Object {
 			string categorieID = object.get_string_member("id");
 
 			if(categorieID.has_suffix("global.all")
-			|| categorieID.has_suffix("global.uncategorized"))
+			   || categorieID.has_suffix("global.uncategorized"))
 				continue;
 
 			categories.add(
@@ -179,16 +178,15 @@ public class FeedReader.FeedlyAPI : Object {
 					categorieID,
 					object.get_string_member("label"),
 					getUnreadCountforID(categorieID),
-					i+1,
+					i + 1,
 					CategoryID.MASTER.to_string(),
 					1
-				)
-			);
+					)
+				);
 		}
 
 		return true;
 	}
-
 
 	public bool getFeeds(Gee.List<feed> feeds)
 	{
@@ -214,10 +212,9 @@ public class FeedReader.FeedlyAPI : Object {
 		for (uint i = 0; i < length; i++) {
 			Json.Object object = array.get_object_element(i);
 
-
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("website") ? object.get_string_member("website") : "";
-			string? icon_url = null;
+			string ? icon_url = null;
 			if(object.has_member("iconUrl"))
 				icon_url = object.get_string_member("iconUrl");
 			else if(object.has_member("visualUrl"))
@@ -241,7 +238,7 @@ public class FeedReader.FeedlyAPI : Object {
 				string categorieID = object.get_array_member("categories").get_object_element(j).get_string_member("id");
 
 				if(categorieID.has_suffix("global.all")
-				|| categorieID.has_suffix("global.uncategorized"))
+				   || categorieID.has_suffix("global.uncategorized"))
 					continue;
 
 				categories += categorieID;
@@ -249,19 +246,18 @@ public class FeedReader.FeedlyAPI : Object {
 
 			feeds.add(
 				new feed (
-						feedID,
-						title,
-						url,
-						getUnreadCountforID(object.get_string_member("id")),
-						categories,
-						icon_url
+					feedID,
+					title,
+					url,
+					getUnreadCountforID(object.get_string_member("id")),
+					categories,
+					icon_url
 					)
-			);
+				);
 		}
 
 		return true;
 	}
-
 
 	public bool getTags(Gee.List<tag> tags)
 	{
@@ -290,16 +286,14 @@ public class FeedReader.FeedlyAPI : Object {
 					object.get_string_member("id"),
 					object.has_member("label") ? object.get_string_member("label") : "",
 					dbDaemon.get_default().getTagColor()
-				)
-			);
+					)
+				);
 		}
 
 		return true;
 	}
 
-
-
-	public string? getArticles(Gee.List<article> articles, int count, string? continuation = null, ArticleStatus whatToGet = ArticleStatus.ALL, string tagID = "", string feed_id = "")
+	public string ? getArticles(Gee.List<article> articles, int count, string ? continuation = null, ArticleStatus whatToGet = ArticleStatus.ALL, string tagID = "", string feed_id = "")
 	{
 		string steamID = "user/" + m_userID + "/category/global.all";
 		string onlyUnread = "false";
@@ -309,7 +303,6 @@ public class FeedReader.FeedlyAPI : Object {
 			steamID = marked_tag;
 		else if(whatToGet == ArticleStatus.UNREAD)
 			onlyUnread = "true";
-
 
 		if(tagID != "" && whatToGet == ArticleStatus.ALL)
 			steamID = tagID;
@@ -341,7 +334,7 @@ public class FeedReader.FeedlyAPI : Object {
 
 		string cont = root.get_string_member("continuation");
 
-		var response = m_connection.send_post_string_request_to_feedly("/v3/entries/.mget", entry_id_response.data,"application/json");
+		var response = m_connection.send_post_string_request_to_feedly("/v3/entries/.mget", entry_id_response.data, "application/json");
 
 		if(response.status != 200)
 			return null;
@@ -362,7 +355,7 @@ public class FeedReader.FeedlyAPI : Object {
 			Json.Object object = array.get_object_element(i);
 			string id = object.get_string_member("id");
 			string title = object.has_member("title") ? object.get_string_member("title") : "No title specified";
-			string? author = object.has_member("author") ? object.get_string_member("author") : null;
+			string ? author = object.has_member("author") ? object.get_string_member("author") : null;
 			string summaryContent = object.has_member("summary") ? object.get_object_member("summary").get_string_member("content") : "";
 			string content = object.has_member("content") ? object.get_object_member("content").get_string_member("content") : summaryContent;
 			bool unread = object.get_boolean_member("unread");
@@ -372,15 +365,15 @@ public class FeedReader.FeedlyAPI : Object {
 			DateTime date = new DateTime.now_local();
 			if(object.has_member("updated") && object.get_int_member("updated") > 0)
 			{
-				date = new DateTime.from_unix_local(object.get_int_member("updated")/1000);
+				date = new DateTime.from_unix_local(object.get_int_member("updated") / 1000);
 			}
 			else if(object.has_member("published") && object.get_int_member("published") > 0)
 			{
-				date = new DateTime.from_unix_local(object.get_int_member("published")/1000);
+				date = new DateTime.from_unix_local(object.get_int_member("published") / 1000);
 			}
 			else if(object.has_member("crawled") && object.get_int_member("crawled") > 0)
 			{
-				date = new DateTime.from_unix_local(object.get_int_member("crawled")/1000);
+				date = new DateTime.from_unix_local(object.get_int_member("crawled") / 1000);
 			}
 
 			string tagString = "";
@@ -417,7 +410,7 @@ public class FeedReader.FeedlyAPI : Object {
 				{
 					var attachment = attachments.get_object_element(j);
 					if(attachment.get_string_member("type").contains("audio")
-					|| attachment.get_string_member("type").contains("video"))
+					   || attachment.get_string_member("type").contains("video"))
 					{
 						mediaString = mediaString + attachment.get_string_member("href") + ",";
 					}
@@ -425,21 +418,21 @@ public class FeedReader.FeedlyAPI : Object {
 			}
 
 			var Article = new article(
-								id,
-								title,
-								url,
-								feedID,
-								(unread) ? ArticleStatus.UNREAD : ArticleStatus.READ,
-								marked,
-								content,
-								//summaryContent,
-								"",
-								author,
-								date, // timestamp includes msecs so divide by 1000 to get rid of them
-								-1,
-								tagString,
-								mediaString
-						);
+				id,
+				title,
+				url,
+				feedID,
+				(unread) ? ArticleStatus.UNREAD : ArticleStatus.READ,
+				marked,
+				content,
+				//summaryContent,
+				"",
+				author,
+				date,                 // timestamp includes msecs so divide by 1000 to get rid of them
+				-1,
+				tagString,
+				mediaString
+				);
 			articles.add(Article);
 		}
 
@@ -499,7 +492,6 @@ public class FeedReader.FeedlyAPI : Object {
 		return getUnreadCountforID("user/" + m_userID + "/category/global.all");
 	}
 
-
 	public void mark_as_read(string ids_string, string type, ArticleStatus read)
 	{
 		var id_array = ids_string.split(",");
@@ -540,10 +532,10 @@ public class FeedReader.FeedlyAPI : Object {
 		object.set_array_member(type_id_identificator, ids);
 
 		if(type == "feeds"
-		|| type == "categories")
+		   || type == "categories")
 		{
 			var now = new DateTime.now_local();
-			object.set_int_member("asOf", now.to_unix()*1000);
+			object.set_int_member("asOf", now.to_unix() * 1000);
 		}
 
 		var root = new Json.Node(Json.NodeType.OBJECT);
@@ -593,8 +585,7 @@ public class FeedReader.FeedlyAPI : Object {
 		m_connection.send_delete_request_to_feedly("/v3/tags/" + GLib.Uri.escape_string(tagID));
 	}
 
-
-	public bool addSubscription(string feedURL, string? title = null, string? catIDs = null)
+	public bool addSubscription(string feedURL, string ? title = null, string ? catIDs = null)
 	{
 		Json.Object object = new Json.Object();
 		object.set_string_member("id", "feed/" + feedURL);
@@ -629,14 +620,13 @@ public class FeedReader.FeedlyAPI : Object {
 		return response.status == 200;
 	}
 
-	public void moveSubscription(string feedID, string newCatID, string? oldCatID = null)
+	public void moveSubscription(string feedID, string newCatID, string ? oldCatID = null)
 	{
 		var Feed = dbDaemon.get_default().read_feed(feedID);
 
 		Json.Object object = new Json.Object();
 		object.set_string_member("id", feedID);
 		object.set_string_member("title", Feed.getTitle());
-
 
 		var catArray = Feed.getCatIDs();
 		Json.Array cats = new Json.Array();

--- a/plugins/backend/feedly/feedlyConnection.vala
+++ b/plugins/backend/feedly/feedlyConnection.vala
@@ -29,13 +29,13 @@ public class FeedReader.FeedlyConnection {
 
 	public LoginResponse getToken()
 	{
-		var message = new Soup.Message("POST", FeedlySecret.base_uri+"/v3/auth/token");
+		var message = new Soup.Message("POST", FeedlySecret.base_uri + "/v3/auth/token");
 		string message_string = "code=" + m_utils.getApiCode()
-								+ "&client_id=" + FeedlySecret.apiClientId
-								+ "&client_secret=" + FeedlySecret.apiClientSecret
-								+ "&redirect_uri=" + FeedlySecret.apiRedirectUri
-								+ "&grant_type=authorization_code"
-								+ "&state=getting_token";
+		                        + "&client_id=" + FeedlySecret.apiClientId
+		                        + "&client_secret=" + FeedlySecret.apiClientSecret
+		                        + "&redirect_uri=" + FeedlySecret.apiRedirectUri
+		                        + "&grant_type=authorization_code"
+		                        + "&state=getting_token";
 
 		message.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message_string.data);
 		m_session.send_message(message);
@@ -80,18 +80,17 @@ public class FeedReader.FeedlyConnection {
 		return LoginResponse.UNKNOWN_ERROR;
 	}
 
-
 	public LoginResponse refreshToken()
 	{
-		var message = new Soup.Message("POST", FeedlySecret.base_uri+"/v3/auth/token");
+		var message = new Soup.Message("POST", FeedlySecret.base_uri + "/v3/auth/token");
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
 		string message_string = "refresh_token=" + m_utils.getRefreshToken()
-								+ "&client_id=" + FeedlySecret.apiClientId
-								+ "&client_secret=" + FeedlySecret.apiClientSecret
-								+ "&grant_type=refresh_token";
+		                        + "&client_id=" + FeedlySecret.apiClientId
+		                        + "&client_secret=" + FeedlySecret.apiClientSecret
+		                        + "&grant_type=refresh_token";
 
 		message.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message_string.data);
 		m_session.send_message(message);
@@ -136,7 +135,6 @@ public class FeedReader.FeedlyConnection {
 		return LoginResponse.UNKNOWN_ERROR;
 	}
 
-
 	public Response send_get_request_to_feedly(string path)
 	{
 		return send_request(path, "GET");
@@ -147,14 +145,14 @@ public class FeedReader.FeedlyConnection {
 		if(!m_utils.accessTokenValid())
 			refreshToken();
 
-		var message = new Soup.Message("PUT", FeedlySecret.base_uri+path);
+		var message = new Soup.Message("PUT", FeedlySecret.base_uri + path);
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
 		var gen = new Json.Generator();
 		gen.set_root(root);
-		message.request_headers.append("Authorization","OAuth %s".printf(m_utils.getAccessToken()));
+		message.request_headers.append("Authorization", "OAuth %s".printf(m_utils.getAccessToken()));
 
 		size_t length;
 		string json;
@@ -168,8 +166,8 @@ public class FeedReader.FeedlyConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 
@@ -178,14 +176,14 @@ public class FeedReader.FeedlyConnection {
 		if(!m_utils.accessTokenValid())
 			refreshToken();
 
-		var message = new Soup.Message("POST", FeedlySecret.base_uri+path);
+		var message = new Soup.Message("POST", FeedlySecret.base_uri + path);
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
 		var gen = new Json.Generator();
 		gen.set_root(root);
-		message.request_headers.append("Authorization","OAuth %s".printf(m_utils.getAccessToken()));
+		message.request_headers.append("Authorization", "OAuth %s".printf(m_utils.getAccessToken()));
 
 		size_t length;
 		string json;
@@ -201,8 +199,8 @@ public class FeedReader.FeedlyConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 
@@ -211,12 +209,12 @@ public class FeedReader.FeedlyConnection {
 		if(!m_utils.accessTokenValid())
 			refreshToken();
 
-		var message = new Soup.Message("POST", FeedlySecret.base_uri+path);
+		var message = new Soup.Message("POST", FeedlySecret.base_uri + path);
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
-		message.request_headers.append("Authorization","OAuth %s".printf(m_utils.getAccessToken()));
+		message.request_headers.append("Authorization", "OAuth %s".printf(m_utils.getAccessToken()));
 		message.request_headers.append("Content-Type", type);
 
 		message.request_body.append_take(input.data);
@@ -228,8 +226,8 @@ public class FeedReader.FeedlyConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 
@@ -243,11 +241,11 @@ public class FeedReader.FeedlyConnection {
 		if(!m_utils.accessTokenValid())
 			refreshToken();
 
-		var message = new Soup.Message(type, FeedlySecret.base_uri+path);
-		message.request_headers.append("Authorization","OAuth %s".printf(m_utils.getAccessToken()));
+		var message = new Soup.Message(type, FeedlySecret.base_uri + path);
+		message.request_headers.append("Authorization", "OAuth %s".printf(m_utils.getAccessToken()));
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
 		m_session.send_message(message);
 
@@ -257,8 +255,8 @@ public class FeedReader.FeedlyConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 }

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -149,8 +149,8 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 			feedArray += Feed.getFeedID() + ",";
 		}
 
-		m_api.mark_as_read(catArray.substring(0, catArray.length-1), "categories", ArticleStatus.READ);
-		m_api.mark_as_read(feedArray.substring(0, feedArray.length-1), "feeds", ArticleStatus.READ);
+		m_api.mark_as_read(catArray.substring(0, catArray.length - 1), "categories", ArticleStatus.READ);
+		m_api.mark_as_read(feedArray.substring(0, feedArray.length - 1), "feeds", ArticleStatus.READ);
 	}
 
 	public void tagArticle(string articleID, string tagID)
@@ -183,7 +183,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		return Utils.ping("http://feedly.com/");
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		feedID = "feed/" + feedURL;
 		bool success = false;
@@ -224,12 +224,12 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.addSubscription(feed.getFeedID(), title, feed.getCatString());
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID )
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID )
 	{
 		m_api.moveSubscription(feedID, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.createCatID(title);
 	}
@@ -260,7 +260,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		m_api.importOPML(opml);
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		m_api.getUnreadCounts();
 
@@ -287,7 +287,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		string continuation = null;
 		string feedly_tagID = "";

--- a/plugins/backend/feedly/feedlyLoginWidget.vala
+++ b/plugins/backend/feedly/feedlyLoginWidget.vala
@@ -52,7 +52,7 @@ public class FeedReader.feedlyLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return true;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		return null;
 	}
@@ -76,9 +76,9 @@ public class FeedReader.feedlyLoginWidget : Peas.ExtensionBase, LoginInterface {
 	{
 		if(redirectURL.has_prefix(FeedlySecret.apiRedirectUri))
 		{
-			int start = redirectURL.index_of("=")+1;
+			int start = redirectURL.index_of("=") + 1;
 			int end = redirectURL.index_of("&");
-			string code = redirectURL.substring(start, end-start);
+			string code = redirectURL.substring(start, end - start);
 			m_utils.setApiCode(code);
 			Logger.debug("feedlyLoginWidget: set feedly-api-code: " + code);
 			GLib.Thread.usleep(500000);
@@ -91,7 +91,7 @@ public class FeedReader.feedlyLoginWidget : Peas.ExtensionBase, LoginInterface {
 	public string buildLoginURL()
 	{
 		return FeedlySecret.base_uri + "/v3/auth/auth" + "?client_secret=" + FeedlySecret.apiClientSecret + "&client_id=" + FeedlySecret.apiClientId
-					+ "&redirect_uri=" + FeedlySecret.apiRedirectUri + "&scope=" + FeedlySecret.apiAuthScope + "&response_type=code&state=getting_code";
+		       + "&redirect_uri=" + FeedlySecret.apiRedirectUri + "&scope=" + FeedlySecret.apiAuthScope + "&response_type=code&state=getting_code";
 	}
 }
 

--- a/plugins/backend/feedly/feedlyUtils.vala
+++ b/plugins/backend/feedly/feedlyUtils.vala
@@ -14,11 +14,11 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.FeedlySecret {
-	 const string base_uri        = "http://cloud.feedly.com";
-	 const string apiClientId     = "boutroue";
-	 const string apiClientSecret = "FE012EGICU4ZOBDRBEOVAJA1JZYH";
-	 const string apiRedirectUri  = "http://localhost";
-	 const string apiAuthScope    = "https://cloud.feedly.com/subscriptions";
+	const string base_uri        = "http://cloud.feedly.com";
+	const string apiClientId     = "boutroue";
+	const string apiClientSecret = "FE012EGICU4ZOBDRBEOVAJA1JZYH";
+	const string apiRedirectUri  = "http://localhost";
+	const string apiAuthScope    = "https://cloud.feedly.com/subscriptions";
 }
 
 public class FeedReader.FeedlyUtils : Object {

--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -73,7 +73,7 @@ public class FeedReader.freshAPI : Object {
 				title = Utils.URLtoFeedName(url);
 			}
 
-			string? icon_url = null;
+			string ? icon_url = null;
 			if(object.has_member("iconUrl"))
 				icon_url = object.get_string_member("iconUrl");
 
@@ -86,7 +86,7 @@ public class FeedReader.freshAPI : Object {
 					{ catID },
 					icon_url,
 					xmlURL)
-			);
+				);
 		}
 
 		return true;
@@ -118,7 +118,6 @@ public class FeedReader.freshAPI : Object {
 			Json.Object object = array.get_object_element(i);
 			string categorieID = object.get_string_member("id");
 
-
 			if(!categorieID.has_prefix(prefix))
 				continue;
 
@@ -127,11 +126,11 @@ public class FeedReader.freshAPI : Object {
 					categorieID,
 					categorieID.substring(prefix.length),
 					0,
-					i+1,
+					i + 1,
 					CategoryID.MASTER.to_string(),
 					1
-				)
-			);
+					)
+				);
 		}
 
 		return true;
@@ -170,15 +169,15 @@ public class FeedReader.freshAPI : Object {
 		return count;
 	}
 
-	public string? getStreamContents(
-										Gee.LinkedList<article> articles,
-										string? feedID = null,
-										string? labelID = null,
-										string? exclude = null,
-										int count = 400,
-										string order = "d",
-										string? checkpoint = null
-								)
+	public string ? getStreamContents(
+		Gee.LinkedList<article> articles,
+		string ? feedID = null,
+		string ? labelID = null,
+		string ? exclude = null,
+		int count = 400,
+		string order = "d",
+		string ? checkpoint = null
+		)
 	{
 		var now = new DateTime.now_local();
 		string path = "reader/api/0/stream/contents";
@@ -187,7 +186,6 @@ public class FeedReader.freshAPI : Object {
 			path += "/" + feedID;
 		else if(labelID != null)
 			path += "/" + labelID;
-
 
 		var msg = new freshMessage();
 		msg.add("output", "json");
@@ -257,7 +255,7 @@ public class FeedReader.freshAPI : Object {
 					if(attachment.has_member("type"))
 					{
 						if(attachment.get_string_member("type").contains("audio")
-						|| attachment.get_string_member("type").contains("video"))
+						   || attachment.get_string_member("type").contains("video"))
 						{
 							mediaString = mediaString + attachment.get_string_member("href") + ",";
 						}
@@ -265,31 +263,29 @@ public class FeedReader.freshAPI : Object {
 				}
 			}
 
-			string? author = null;
+			string ? author = null;
 			if(object.has_member("author"))
 			{
 				author = (object.get_string_member("author") == "") ? null : object.get_string_member("author");
 			}
 
-
 			articles.add(new article(
-									id,
-									object.get_string_member("title"),
-									object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
-									object.get_object_member("origin").get_string_member("streamId"),
-									read ? ArticleStatus.READ : ArticleStatus.UNREAD,
-									marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-									object.get_object_member("summary").get_string_member("content"),
-									"",
-									author,
-									new DateTime.from_unix_local(object.get_int_member("published")),
-									-1,
-									"",
-									mediaString
-							)
-						);
+							 id,
+							 object.get_string_member("title"),
+							 object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
+							 object.get_object_member("origin").get_string_member("streamId"),
+							 read ? ArticleStatus.READ : ArticleStatus.UNREAD,
+							 marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+							 object.get_object_member("summary").get_string_member("content"),
+							 "",
+							 author,
+							 new DateTime.from_unix_local(object.get_int_member("published")),
+							 -1,
+							 "",
+							 mediaString
+							 )
+			             );
 		}
-
 
 		if(root.has_member("continuation") && root.get_string_member("continuation") != "")
 			return root.get_string_member("continuation");
@@ -297,7 +293,7 @@ public class FeedReader.freshAPI : Object {
 		return null;
 	}
 
-	public void editTags(string articleIDs, string? addTag = null, string? removeTag = null)
+	public void editTags(string articleIDs, string ? addTag = null, string ? removeTag = null)
 	{
 		string path = "reader/api/0/edit-tag";
 		string[] arrayID = articleIDs.split(",");
@@ -344,12 +340,12 @@ public class FeedReader.freshAPI : Object {
 	}
 
 	public Response editStream(
-							string action,
-							string[]? streamID = null,
-							string? title = null,
-							string? add = null,
-							string? remove = null
-						)
+		string action,
+		string[] ? streamID = null,
+		string ? title = null,
+		string ? add = null,
+		string ? remove = null
+		)
 	{
 		string path = "reader/api/0/subscription/edit";
 
@@ -398,7 +394,6 @@ public class FeedReader.freshAPI : Object {
 		msg.add("dest", composeTagID(title));
 
 		var response = m_connection.postRequest(path, msg.get(), "application/x-www-form-urlencoded");
-
 
 		if(response.status != 200)
 		{

--- a/plugins/backend/fresh/freshConnection.vala
+++ b/plugins/backend/fresh/freshConnection.vala
@@ -28,18 +28,18 @@ public class FeedReader.freshConnection {
 		m_session.authenticate.connect((msg, auth, retrying) => {
 			if(m_utils.getHtaccessUser() == "")
 			{
-				Logger.error("fresh Session: need Authentication");
+			    Logger.error("fresh Session: need Authentication");
 			}
 			else if(!retrying)
 			{
-				auth.authenticate(m_utils.getHtaccessUser(), m_utils.getHtaccessPasswd());
+			    auth.authenticate(m_utils.getHtaccessUser(), m_utils.getHtaccessPasswd());
 			}
 		});
 	}
 
 	public LoginResponse getSID()
 	{
-		var message = new Soup.Message("POST", m_utils.getURL()+"accounts/ClientLogin");
+		var message = new Soup.Message("POST", m_utils.getURL() + "accounts/ClientLogin");
 
 		var msg = new freshMessage();
 		msg.add("Email", m_utils.getUser());
@@ -65,9 +65,9 @@ public class FeedReader.freshConnection {
 		}
 		else
 		{
-			int start = response.index_of("=")+1;
+			int start = response.index_of("=") + 1;
 			int end = response.index_of("\n");
-			string token = response.substring(start, end-start);
+			string token = response.substring(start, end - start);
 			Logger.debug("Token: " + token);
 			m_utils.setToken(token);
 			return LoginResponse.SUCCESS;
@@ -81,12 +81,12 @@ public class FeedReader.freshConnection {
 
 	public Response postRequest(string path, string input, string type)
 	{
-		var message = new Soup.Message("POST", m_utils.getURL()+path);
+		var message = new Soup.Message("POST", m_utils.getURL() + path);
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
-		message.request_headers.append("Authorization","GoogleLogin auth=%s".printf(m_utils.getToken()));
+		message.request_headers.append("Authorization", "GoogleLogin auth=%s".printf(m_utils.getToken()));
 		message.request_headers.append("Content-Type", type);
 
 		message.request_body.append_take(input.data);
@@ -98,18 +98,18 @@ public class FeedReader.freshConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 
 	public Response getRequest(string path)
 	{
-		var message = new Soup.Message("GET", m_utils.getURL()+path);
-		message.request_headers.append("Authorization","GoogleLogin auth=%s".printf(m_utils.getToken()));
+		var message = new Soup.Message("GET", m_utils.getURL() + path);
+		message.request_headers.append("Authorization", "GoogleLogin auth=%s".printf(m_utils.getToken()));
 
 		if(m_settingsTweaks.get_boolean("do-not-track"))
-				message.request_headers.append("DNT", "1");
+			message.request_headers.append("DNT", "1");
 
 		m_session.send_message(message);
 
@@ -119,12 +119,11 @@ public class FeedReader.freshConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 }
-
 
 public class FeedReader.freshMessage {
 

--- a/plugins/backend/fresh/freshInterface.vala
+++ b/plugins/backend/fresh/freshInterface.vala
@@ -165,10 +165,10 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		errmsg = "";
-		string? cat = null;
+		string ? cat = null;
 		if(catID != null)
 			cat = catID;
 		else if(newCatName != null)
@@ -217,12 +217,12 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		m_api.editStream("edit", {feedID}, title, null, null);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.editStream("edit", {feedID}, null, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.composeTagID(title);
 	}
@@ -253,7 +253,7 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getSubscriptionList(feeds))
 		{
@@ -272,7 +272,7 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		return m_api.getUnreadCounts();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{
@@ -280,9 +280,9 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		}
 
 		var articles = new Gee.LinkedList<article>();
-		string? continuation = null;
-		string? exclude = null;
-		string? labelID = null;
+		string ? continuation = null;
+		string ? exclude = null;
+		string ? labelID = null;
 		int left = count;
 		if(whatToGet == ArticleStatus.ALL)
 		{
@@ -297,7 +297,6 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 			labelID = "user/-/state/com.google/reading-list";
 			exclude = "user/-/state/com.google/read";
 		}
-
 
 		while(left > 0)
 		{

--- a/plugins/backend/fresh/freshLoginWidget.vala
+++ b/plugins/backend/fresh/freshLoginWidget.vala
@@ -59,7 +59,7 @@ public class FeedReader.freshLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var url_label = new Gtk.Label(_("freshRSS URL:"));
 		var user_label = new Gtk.Label(_("Username:"));
@@ -96,7 +96,6 @@ public class FeedReader.freshLoginWidget : Peas.ExtensionBase, LoginInterface {
 		grid.attach(m_userEntry, 1, 1, 1, 1);
 		grid.attach(password_label, 0, 2, 1, 1);
 		grid.attach(m_passwordEntry, 1, 2, 1, 1);
-
 
 		// http auth stuff ----------------------------------------------------
 		var auth_user_label = new Gtk.Label(_("Username:"));
@@ -196,7 +195,6 @@ public class FeedReader.freshLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return "";
 	}
 }
-
 
 [ModuleInit]
 public void peas_register_types(GLib.TypeModule module)

--- a/plugins/backend/fresh/freshUtils.vala
+++ b/plugins/backend/fresh/freshUtils.vala
@@ -34,7 +34,7 @@ public class FeedReader.freshUtils : GLib.Object {
 				tmp_url = tmp_url + "api/greader.php/";
 
 			if(!tmp_url.has_prefix("http://") && !tmp_url.has_prefix("https://"))
-					tmp_url = "https://" + tmp_url;
+				tmp_url = "https://" + tmp_url;
 		}
 
 		return tmp_url;
@@ -86,11 +86,11 @@ public class FeedReader.freshUtils : GLib.Object {
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 
-		string? passwd = "";
+		string ? passwd = "";
 
 		try
 		{
@@ -113,9 +113,9 @@ public class FeedReader.freshUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										  "URL", Secret.SchemaAttributeType.STRING,
-										  "Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 		try
@@ -138,20 +138,20 @@ public class FeedReader.freshUtils : GLib.Object {
 	{
 		bool removed = false;
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										"URL", Secret.SchemaAttributeType.STRING,
-										"Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 
 		Secret.password_clearv.begin (pwSchema, attributes, null, (obj, async_res) => {
 			try
 			{
-				removed = Secret.password_clearv.end(async_res);
+			    removed = Secret.password_clearv.end(async_res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("freshUtils.deletePassword: %s".printf(e.message));
+			    Logger.error("freshUtils.deletePassword: %s".printf(e.message));
 			}
 		});
 		return removed;
@@ -162,14 +162,14 @@ public class FeedReader.freshUtils : GLib.Object {
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING,
-										  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
+		                                  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getHtaccessUser();
 		attributes["htaccess"] = "true";
 
-		string? passwd = "";
+		string ? passwd = "";
 
 		try
 		{
@@ -192,21 +192,21 @@ public class FeedReader.freshUtils : GLib.Object {
 	public void setHtAccessPassword(string passwd)
 	{
 		var pwAuthSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-											  "URL", Secret.SchemaAttributeType.STRING,
-											  "Username", Secret.SchemaAttributeType.STRING,
-											  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
-		var authAttributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                      "URL", Secret.SchemaAttributeType.STRING,
+		                                      "Username", Secret.SchemaAttributeType.STRING,
+		                                      "htaccess", Secret.SchemaAttributeType.BOOLEAN);
+		var authAttributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		authAttributes["URL"] = getURL();
 		authAttributes["Username"] = getHtaccessUser();
 		authAttributes["htaccess"] = "true";
 		try
 		{
 			Secret.password_storev_sync(pwAuthSchema,
-										authAttributes,
-										Secret.COLLECTION_DEFAULT,
-										"FeedReader: freshRSS htaccess Authentication",
-										passwd,
-										null);
+			                            authAttributes,
+			                            Secret.COLLECTION_DEFAULT,
+			                            "FeedReader: freshRSS htaccess Authentication",
+			                            passwd,
+			                            null);
 		}
 		catch(GLib.Error e)
 		{

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -31,7 +31,6 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		m_utils = new InoReaderUtils();
 	}
 
-
 	public LoginResponse login()
 	{
 		if(m_utils.getAccessToken() == "")
@@ -117,7 +116,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
+			string ? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -139,14 +138,14 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 
 			feeds.add(
 				new feed (
-						feedID,
-						title,
-						url,
-						0,
-						categories,
-						icon_url
+					feedID,
+					title,
+					url,
+					0,
+					categories,
+					icon_url
 					)
-			);
+				);
 		}
 
 		return true;
@@ -192,8 +191,8 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 							orderID,
 							CategoryID.MASTER.to_string(),
 							1
-						)
-					);
+							)
+						);
 				}
 				else
 				{
@@ -202,8 +201,8 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 							id,
 							title,
 							dbDaemon.get_default().getTagColor()
-						)
-					);
+							)
+						);
 				}
 
 				++orderID;
@@ -211,7 +210,6 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		}
 		return true;
 	}
-
 
 	public int getTotalUnread()
 	{
@@ -248,8 +246,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		return count;
 	}
 
-
-	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
+	public string ? updateArticles(Gee.List<string> ids, int count, string ? continuation = null)
 	{
 		var message_string = "n=" + count.to_string();
 		message_string += "&xt=user/-/state/com.google/read";
@@ -289,7 +286,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string ? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string ? continuation = null, string ? tagID = null, string ? feed_id = null)
 	{
 		var message_string = "n=" + count.to_string();
 
@@ -302,7 +299,6 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 
 		if(continuation != null)
 			message_string += "&c=" + continuation;
-
 
 		string api_endpoint = "stream/contents";
 		if(feed_id != null)
@@ -333,7 +329,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		{
 			Json.Object object = array.get_object_element(i);
 			string id = object.get_string_member("id");
-			id = id.substring(id.last_index_of_char('/')+1);
+			id = id.substring(id.last_index_of_char('/') + 1);
 			string tagString = "";
 			bool marked = false;
 			bool read = false;
@@ -364,7 +360,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 				{
 					var attachment = attachments.get_object_element(j);
 					if(attachment.get_string_member("type").contains("audio")
-					|| attachment.get_string_member("type").contains("video"))
+					   || attachment.get_string_member("type").contains("video"))
 					{
 						mediaString = mediaString + attachment.get_string_member("href") + ",";
 					}
@@ -372,21 +368,21 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 			}
 
 			articles.add(new article(
-									id,
-									object.get_string_member("title"),
-									object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
-									object.get_object_member("origin").get_string_member("streamId"),
-									read ? ArticleStatus.READ : ArticleStatus.UNREAD,
-									marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-									object.get_object_member("summary").get_string_member("content"),
-									"",
-									(object.get_string_member("author") == "") ? null : object.get_string_member("author"),
-									new DateTime.from_unix_local(object.get_int_member("published")),
-									-1,
-									tagString,
-									mediaString
-							)
-						);
+							 id,
+							 object.get_string_member("title"),
+							 object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
+							 object.get_object_member("origin").get_string_member("streamId"),
+							 read ? ArticleStatus.READ : ArticleStatus.UNREAD,
+							 marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+							 object.get_object_member("summary").get_string_member("content"),
+							 "",
+							 (object.get_string_member("author") == "") ? null : object.get_string_member("author"),
+							 new DateTime.from_unix_local(object.get_int_member("published")),
+							 -1,
+							 tagString,
+							 mediaString
+							 )
+			             );
 		}
 
 		if(root.has_member("continuation") && root.get_string_member("continuation") != "")
@@ -394,7 +390,6 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 
 		return null;
 	}
-
 
 	public void edidTag(string articleIDs, string tagID, bool add = true)
 	{
@@ -414,7 +409,7 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		m_connection.send_request("edit-tag", message_string);
 	}
 
-	public void markAsRead(string? streamID = null)
+	public void markAsRead(string ? streamID = null)
 	{
 		var settingsState = new GLib.Settings("org.gnome.feedreader.saved-state");
 		string message_string = "s=%s&ts=%i".printf(streamID, settingsState.get_int("last-sync"));
@@ -440,21 +435,21 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 		m_connection.send_request("rename-tag", message_string);
 	}
 
-	public bool editSubscription(InoSubscriptionAction action, string[] feedID, string? title, string? add, string? remove)
+	public bool editSubscription(InoSubscriptionAction action, string[] feedID, string ? title, string ? add, string ? remove)
 	{
 		var message_string = "ac=";
 
 		switch(action)
 		{
-			case InoSubscriptionAction.EDIT:
-				message_string += "edit";
-				break;
-			case InoSubscriptionAction.SUBSCRIBE:
-				message_string += "subscribe";
-				break;
-			case InoSubscriptionAction.UNSUBSCRIBE:
-				message_string += "unsubscribe";
-				break;
+		case InoSubscriptionAction.EDIT:
+			message_string += "edit";
+			break;
+		case InoSubscriptionAction.SUBSCRIBE:
+			message_string += "subscribe";
+			break;
+		case InoSubscriptionAction.UNSUBSCRIBE:
+			message_string += "unsubscribe";
+			break;
 		}
 
 		foreach(string s in feedID)
@@ -468,7 +463,6 @@ public class FeedReader.InoReaderAPI : GLib.Object {
 
 		if(remove != null)
 			message_string += "&r=" + remove;
-
 
 		return m_connection.send_request("subscription/edit", message_string).status == 200;
 	}

--- a/plugins/backend/inoreader/InoReaderConnection.vala
+++ b/plugins/backend/inoreader/InoReaderConnection.vala
@@ -34,11 +34,11 @@ public class FeedReader.InoReaderConnection {
 
 		var message = new Soup.Message("POST", "https://www.inoreader.com/oauth2/token");
 		string message_string = "code=" + m_utils.getApiCode()
-								+ "&redirect_uri=" + InoReaderSecret.apiRedirectUri
-								+ "&client_id=" + InoReaderSecret.apiClientId
-								+ "&client_secret=" + InoReaderSecret.apiClientSecret
-								+ "&scope="
-								+ "&grant_type=authorization_code";
+		                        + "&redirect_uri=" + InoReaderSecret.apiRedirectUri
+		                        + "&client_id=" + InoReaderSecret.apiClientId
+		                        + "&client_secret=" + InoReaderSecret.apiClientSecret
+		                        + "&scope="
+		                        + "&grant_type=authorization_code";
 		message.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message_string.data);
 		m_session.send_message(message);
 
@@ -83,9 +83,9 @@ public class FeedReader.InoReaderConnection {
 
 		var message = new Soup.Message("POST", "https://www.inoreader.com/oauth2/token");
 		string message_string = "client_id=" + InoReaderSecret.apiClientId
-								+ "&client_secret=" + InoReaderSecret.apiClientSecret
-								+ "&grant_type=refresh_token"
-								+ "&refresh_token=" + m_utils.getRefreshToken();
+		                        + "&client_secret=" + InoReaderSecret.apiClientSecret
+		                        + "&grant_type=refresh_token"
+		                        + "&refresh_token=" + m_utils.getRefreshToken();
 
 		message.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message_string.data);
 		m_session.send_message(message);
@@ -128,12 +128,12 @@ public class FeedReader.InoReaderConnection {
 		return LoginResponse.SUCCESS;
 	}
 
-	public Response send_request(string path, string? message_string = null)
+	public Response send_request(string path, string ? message_string = null)
 	{
 		return send_post_request(path, "POST", message_string);
 	}
 
-	private Response send_post_request(string path, string type, string? message_string = null)
+	private Response send_post_request(string path, string type, string ? message_string = null)
 	{
 		if(!m_utils.accessTokenValid())
 			refreshToken();
@@ -155,8 +155,8 @@ public class FeedReader.InoReaderConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 

--- a/plugins/backend/inoreader/InoReaderInterface.vala
+++ b/plugins/backend/inoreader/InoReaderInterface.vala
@@ -176,7 +176,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.ping();
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		bool success = false;
 		feedID = "feed/" + feedURL;
@@ -185,11 +185,11 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
-			success = m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID, null);
+			success = m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/" + feedURL}, null, newCatID, null);
 		}
 		else
 		{
-			success = m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID, null);
+			success = m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.SUBSCRIBE, {"feed/" + feedURL}, null, catID, null);
 		}
 
 		if(!success)
@@ -228,12 +228,12 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.EDIT, {feedID}, title, null, null);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.editSubscription(InoReaderAPI.InoSubscriptionAction.EDIT, {feedID}, null, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.composeTagID(title);
 	}
@@ -264,7 +264,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getFeeds(feeds))
 		{
@@ -283,7 +283,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{
@@ -292,8 +292,8 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		else if(whatToGet == ArticleStatus.ALL)
 		{
 			var unreadIDs = new Gee.LinkedList<string>();
-			string? continuation = null;
-			int left = 4*count;
+			string ? continuation = null;
+			int left = 4 * count;
 
 			while(left > 0)
 			{
@@ -316,10 +316,10 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		}
 
 		var articles = new Gee.LinkedList<article>();
-		string? continuation = null;
+		string ? continuation = null;
 		int left = count;
-		string? inoreader_feedID = (isTagID) ? null : feedID;
-		string? inoreader_tagID = (isTagID) ? feedID : null;
+		string ? inoreader_feedID = (isTagID) ? null : feedID;
+		string ? inoreader_tagID = (isTagID) ? feedID : null;
 
 		while(left > 0)
 		{

--- a/plugins/backend/inoreader/InoReaderLoginWidget.vala
+++ b/plugins/backend/inoreader/InoReaderLoginWidget.vala
@@ -62,15 +62,15 @@ public class FeedReader.InoReaderLoginWidget : Peas.ExtensionBase, LoginInterfac
 		if(redirectURL.has_prefix(InoReaderSecret.apiRedirectUri))
 		{
 			Logger.debug(redirectURL);
-			int csrf_start = redirectURL.index_of("state=")+6;
+			int csrf_start = redirectURL.index_of("state=") + 6;
 			string csrf_code = redirectURL.substring(csrf_start);
 			Logger.debug("InoReaderLoginWidget: csrf_code: " + csrf_code);
 
 			if(csrf_code == InoReaderSecret.csrf_protection)
 			{
-				int start = redirectURL.index_of("code=")+5;
+				int start = redirectURL.index_of("code=") + 5;
 				int end = redirectURL.index_of("&", start);
-				string code = redirectURL.substring(start, end-start);
+				string code = redirectURL.substring(start, end - start);
 				m_utils.setApiCode(code);
 				Logger.debug("InoReaderLoginWidget: set inoreader-api-code: " + code);
 				GLib.Thread.usleep(500000);
@@ -90,11 +90,11 @@ public class FeedReader.InoReaderLoginWidget : Peas.ExtensionBase, LoginInterfac
 	public string buildLoginURL()
 	{
 		return "https://www.inoreader.com/oauth2/auth"
-			+ "?client_id=" + InoReaderSecret.apiClientId
-			+ "&redirect_uri=" + InoReaderSecret.apiRedirectUri
-			+ "&response_type=code"
-			+ "&scope=read+write"
-			+ "&state=" + InoReaderSecret.csrf_protection;
+		       + "?client_id=" + InoReaderSecret.apiClientId
+		       + "&redirect_uri=" + InoReaderSecret.apiRedirectUri
+		       + "&response_type=code"
+		       + "&scope=read+write"
+		       + "&state=" + InoReaderSecret.csrf_protection;
 	}
 
 	public bool needWebLogin()
@@ -102,7 +102,7 @@ public class FeedReader.InoReaderLoginWidget : Peas.ExtensionBase, LoginInterfac
 		return true;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		return null;
 	}

--- a/plugins/backend/inoreader/InoReaderUtils.vala
+++ b/plugins/backend/inoreader/InoReaderUtils.vala
@@ -14,11 +14,11 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.InoReaderSecret {
-	 const string base_uri        = "https://www.inoreader.com/reader/api/0/";
-	 const string apiClientId     = "1000001384";
-	 const string apiClientSecret = "3AA9IyNTFL_Mgu77WPpWbawx9loERRdf";
-	 const string apiRedirectUri  = "http://localhost";
-	 const string csrf_protection = "123456";
+	const string base_uri        = "https://www.inoreader.com/reader/api/0/";
+	const string apiClientId     = "1000001384";
+	const string apiClientSecret = "3AA9IyNTFL_Mgu77WPpWbawx9loERRdf";
+	const string apiRedirectUri  = "http://localhost";
+	const string csrf_protection = "123456";
 }
 
 public class FeedReader.InoReaderUtils : GLib.Object {

--- a/plugins/backend/local/SuggestedFeedRow.vala
+++ b/plugins/backend/local/SuggestedFeedRow.vala
@@ -64,31 +64,31 @@ public class FeedReader.SuggestedFeedRow : Gtk.ListBoxRow {
 		var uri = new Soup.URI(url);
 		Utils.downloadIcon.begin(uri.get_host(), uri.get_scheme() + "://" + uri.get_host(), null, "/tmp/", (obj, res) => {
 			bool success = Utils.downloadIcon.end(res);
-			Gtk.Image? icon = null;
+			Gtk.Image ? icon = null;
 
 			if(success)
 			{
-				try
-				{
-					string filename = "/tmp/" + uri.get_host().replace("/", "_").replace(".", "_") + ".ico";
-					Logger.debug("load icon %s".printf(filename));
-					var tmp_icon = new Gdk.Pixbuf.from_file_at_scale(filename, 24, 24, true);
-					icon = new Gtk.Image.from_pixbuf(tmp_icon);
+			    try
+			    {
+			        string filename = "/tmp/" + uri.get_host().replace("/", "_").replace(".", "_") + ".ico";
+			        Logger.debug("load icon %s".printf(filename));
+			        var tmp_icon = new Gdk.Pixbuf.from_file_at_scale(filename, 24, 24, true);
+			        icon = new Gtk.Image.from_pixbuf(tmp_icon);
 				}
-				catch(GLib.Error e)
-				{
-					Logger.error("SuggestedFeedRow.constructor: %s".printf(e.message));
-					icon = new Gtk.Image.from_icon_name("feed-rss-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+			    catch(GLib.Error e)
+			    {
+			        Logger.error("SuggestedFeedRow.constructor: %s".printf(e.message));
+			        icon = new Gtk.Image.from_icon_name("feed-rss-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
 				}
 			}
 			else
 			{
-				icon = new Gtk.Image.from_icon_name("feed-rss-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+			    icon = new Gtk.Image.from_icon_name("feed-rss-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
 			}
 
 			iconStack.add_named(icon, "icon");
-   			show_all();
-   			iconStack.set_visible_child_name("icon");
+			show_all();
+			iconStack.set_visible_child_name("icon");
 		});
 	}
 

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -26,7 +26,6 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		m_session.timeout = 5;
 	}
 
-
 	public bool supportTags()
 	{
 		return true;
@@ -168,7 +167,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		return;
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		string[] catIDs = {};
 
@@ -198,7 +197,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		}
 
 		Logger.info(@"addFeed: ID = $feedID");
-		feed? Feed = m_utils.downloadFeed(m_session, feedURL, feedID, catIDs, out errmsg);
+		feed ? Feed = m_utils.downloadFeed(m_session, feedURL, feedID, catIDs, out errmsg);
 
 		if(Feed != null)
 		{
@@ -227,7 +226,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 
 			Logger.info(@"addFeed: ID = $feedID");
 			string errmsg = "";
-			feed? Feed = m_utils.downloadFeed(m_session, f.getXmlUrl(), feedID, f.getCatIDs(), out errmsg);
+			feed ? Feed = m_utils.downloadFeed(m_session, f.getXmlUrl(), feedID, f.getCatIDs(), out errmsg);
 
 			if(Feed != null)
 			{
@@ -259,18 +258,18 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		return;
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		return;
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		string catID = "catID00001";
 
 		if(!dbDaemon.get_default().isTableEmpty("categories"))
 		{
-			string? id = dbDaemon.get_default().getCategoryID(title);
+			string ? id = dbDaemon.get_default().getCategoryID(title);
 			if(id == null)
 			{
 				catID = "catID%05d".printf(int.parse(dbDaemon.get_default().getMaxID("categories", "categorieID").substring(5)) + 1);
@@ -311,7 +310,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		var cats = dbDaemon.get_default().read_categories();
 		foreach(category cat in cats)
@@ -332,7 +331,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 				return false;
 
 			string errmsg = "";
-			feed? tmpFeed = m_utils.downloadFeed(m_session, Feed.getXmlUrl(), Feed.getFeedID(), Feed.getCatIDs(), out errmsg);
+			feed ? tmpFeed = m_utils.downloadFeed(m_session, Feed.getXmlUrl(), Feed.getFeedID(), Feed.getCatIDs(), out errmsg);
 			if(tmpFeed != null)
 			{
 				Feed.setIconURL(tmpFeed.getIconURL());
@@ -349,7 +348,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		return 0;
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		var f = dbDaemon.get_default().read_feeds();
 		var articleArray = new Gee.LinkedList<article>();
@@ -383,9 +382,9 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 				Logger.error("localInterface.getArticles: %s".printf(e.message));
 			}
 			var doc = parser.get_document();
-			string? locale = null;
+			string ? locale = null;
 			if(doc.encoding != null
-			&& doc.encoding != "")
+			   && doc.encoding != "")
 			{
 				locale = doc.encoding;
 			}
@@ -393,7 +392,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 			var articles = doc.get_items();
 			foreach(Rss.Item item in articles)
 			{
-				string? articleID = item.guid;
+				string ? articleID = item.guid;
 
 				if(articleID != null)
 					articleID = articleID.replace(":", "_").replace("/", "_").replace(" ", "").replace(",", "_");
@@ -409,7 +408,6 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 					articleID = item.link;
 				}
 
-
 				var date = new GLib.DateTime.now_local();
 
 				if(item.pub_date != null)
@@ -421,7 +419,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 					if(date == null)
 						date = new GLib.DateTime.now_local();
 				}
-				string? content = m_utils.convert(item.description, locale);
+				string ? content = m_utils.convert(item.description, locale);
 
 				if(content == null)
 					content = _("Nothing to read here.");
@@ -438,28 +436,28 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 					Logger.debug(item.title);
 
 				var Article = new article
-				(
-									articleID,
-									(item.title != null) ? m_utils.convert(item.title, locale) : "No Title :(",
-									articleURL,
-									Feed.getFeedID(),
-									ArticleStatus.UNREAD,
-									ArticleStatus.UNMARKED,
-									content,
-									Utils.UTF8fix(content, true),
-									m_utils.convert(item.author, locale),
-									date,
-									0,
-									"",
-									media
-				);
+					          (
+					articleID,
+					(item.title != null) ? m_utils.convert(item.title, locale) : "No Title :(",
+					articleURL,
+					Feed.getFeedID(),
+					ArticleStatus.UNREAD,
+					ArticleStatus.UNMARKED,
+					content,
+					Utils.UTF8fix(content, true),
+					m_utils.convert(item.author, locale),
+					date,
+					0,
+					"",
+					media
+				              );
 
 				articleArray.add(Article);
 			}
 		}
 
 		articleArray.sort((a, b) => {
-				return strcmp(a.getArticleID(), b.getArticleID());
+			return strcmp(a.getArticleID(), b.getArticleID());
 		});
 
 		if(articleArray.size > 0)

--- a/plugins/backend/local/localLoginWidget.vala
+++ b/plugins/backend/local/localLoginWidget.vala
@@ -52,7 +52,7 @@ public class FeedReader.localLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var doneLabel = new Gtk.Label(_("Done"));
 		var waitingLabel = new Gtk.Label(_("Adding Feeds"));
@@ -114,7 +114,7 @@ public class FeedReader.localLoginWidget : Peas.ExtensionBase, LoginInterface {
 						object.get_string_member("description"),
 						object.get_string_member("language")
 						)
-				);
+					);
 			}
 		}
 		catch(GLib.Error e)
@@ -157,16 +157,16 @@ public class FeedReader.localLoginWidget : Peas.ExtensionBase, LoginInterface {
 			var children = m_feedlist.get_children();
 			foreach(var r in children)
 			{
-				var row = r as SuggestedFeedRow;
-				if(row.checked())
-				{
-					try
-					{
-						DBusConnection.get_default().addFeed(row.getURL(), row.getCategory(), false, false);
+			    var row = r as SuggestedFeedRow;
+			    if(row.checked())
+			    {
+			        try
+			        {
+			            DBusConnection.get_default().addFeed(row.getURL(), row.getCategory(), false, false);
 					}
-					catch(GLib.Error e)
-					{
-						Logger.error("localLoginWidget.postLoginAction: %s".printf(e.message));
+			        catch(GLib.Error e)
+			        {
+			            Logger.error("localLoginWidget.postLoginAction: %s".printf(e.message));
 					}
 				}
 			}
@@ -203,7 +203,7 @@ public class FeedReader.localLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return name1.collate(name2);
 	}
 
-	private void headerFunc(Gtk.ListBoxRow row, Gtk.ListBoxRow? before)
+	private void headerFunc(Gtk.ListBoxRow row, Gtk.ListBoxRow ? before)
 	{
 		var r1 = row as SuggestedFeedRow;
 		string cat1 = r1.getCategory();
@@ -231,7 +231,6 @@ public class FeedReader.localLoginWidget : Peas.ExtensionBase, LoginInterface {
 			row.set_header(box);
 	}
 }
-
 
 //--------------------------------------------------------------------------------------
 // Boilerplate code for the plugin. Replace "demoLoginWidget" with the name

--- a/plugins/backend/local/localUtils.vala
+++ b/plugins/backend/local/localUtils.vala
@@ -20,7 +20,7 @@ public class FeedReader.localUtils : GLib.Object {
 
 	}
 
-	public feed? downloadFeed(Soup.Session session, string xmlURL, string feedID, string[] catIDs, out string errmsg)
+	public feed ? downloadFeed(Soup.Session session, string xmlURL, string feedID, string[] catIDs, out string errmsg)
 	{
 		errmsg = "";
 
@@ -60,12 +60,12 @@ public class FeedReader.localUtils : GLib.Object {
 		var doc = parser.get_document();
 
 		if(doc.link != null
-		&& doc.link != "")
+		   && doc.link != "")
 			url = doc.link;
 
 		var uri = new Soup.URI(url);
-		string? icon_url = (doc.image_url != "") ? doc.image_url : null;
-		string? title = doc.title;
+		string ? icon_url = (doc.image_url != "") ? doc.image_url : null;
+		string ? title = doc.title;
 		if(title == null)
 		{
 			if(uri == null)
@@ -75,18 +75,18 @@ public class FeedReader.localUtils : GLib.Object {
 		}
 
 		var Feed = new feed(
-					feedID,
-					title,
-					url,
-					0,
-					catIDs,
-					icon_url,
-					xmlURL);
+			feedID,
+			title,
+			url,
+			0,
+			catIDs,
+			icon_url,
+			xmlURL);
 
 		return Feed;
 	}
 
-	public string? convert(string? text, string? locale)
+	public string ? convert(string ? text, string ? locale)
 	{
 		if(text == null)
 			return null;

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -112,7 +112,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 
 			string feedID = object.get_string_member("id");
 			string url = object.has_member("htmlUrl") ? object.get_string_member("htmlUrl") : object.get_string_member("url");
-			string? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
+			string ? icon_url = object.has_member("iconUrl") ? object.get_string_member("iconUrl") : null;
 
 			string title = "No Title";
 			if(object.has_member("title"))
@@ -133,14 +133,14 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 			}
 			feeds.add(
 				new feed (
-						feedID,
-						title,
-						url,
-						0,
-						categories,
-						icon_url
+					feedID,
+					title,
+					url,
+					0,
+					categories,
+					icon_url
 					)
-			);
+				);
 		}
 		return true;
 	}
@@ -177,14 +177,14 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 
 			if(id.contains("/label/"))
 			{
-					categories.add(
-						new category(
-							id,
-							title,
-							0,
-							orderID,
-							CategoryID.MASTER.to_string(),
-							1
+				categories.add(
+					new category(
+						id,
+						title,
+						0,
+						orderID,
+						CategoryID.MASTER.to_string(),
+						1
 						)
 					);
 				++orderID;
@@ -192,7 +192,6 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		}
 		return true;
 	}
-
 
 	public int getTotalUnread()
 	{
@@ -231,15 +230,14 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		return count;
 	}
 
-
-	public string? updateArticles(Gee.List<string> ids, int count, string? continuation = null)
+	public string ? updateArticles(Gee.List<string> ids, int count, string ? continuation = null)
 	{
 		var message_string = "n=" + count.to_string();
 		message_string += "&xt=user/-/state/com.google/read";
 		if(continuation != null)
 			message_string += "&c=" + continuation;
 
-		var response = m_connection.send_get_request("stream/items/ids?output=json&"+message_string);
+		var response = m_connection.send_get_request("stream/items/ids?output=json&" + message_string);
 
 		if(response.status != 200)
 			return null;
@@ -272,7 +270,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		return null;
 	}
 
-	public string? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? continuation = null, string? tagID = null, string? feed_id = null)
+	public string ? getArticles(Gee.List<article> articles, int count, ArticleStatus whatToGet = ArticleStatus.ALL, string ? continuation = null, string ? tagID = null, string ? feed_id = null)
 	{
 		var message_string = "n=" + count.to_string();
 
@@ -283,15 +281,14 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		else if(whatToGet == ArticleStatus.MARKED)
 			message_string += "&s=user/-/state/com.google/starred";
 
-			message_string += "&c=" + continuation;
-
+		message_string += "&c=" + continuation;
 
 		string api_endpoint = "stream/contents";
 		if(feed_id != null)
 			api_endpoint += "/" + GLib.Uri.escape_string(feed_id);
 		else if(tagID != null)
 			api_endpoint += "/" + GLib.Uri.escape_string(tagID);
-		var response = m_connection.send_get_request(api_endpoint+"?output=json&"+message_string);
+		var response = m_connection.send_get_request(api_endpoint + "?output=json&" + message_string);
 
 		if(response.status != 200)
 			return null;
@@ -315,7 +312,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		{
 			Json.Object object = array.get_object_element(i);
 			string id = object.get_string_member("id");
-			id = id.substring(id.last_index_of_char('/')+1);
+			id = id.substring(id.last_index_of_char('/') + 1);
 			string tagString = "";
 			bool marked = false;
 			bool read = false;
@@ -346,7 +343,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 				{
 					var attachment = attachments.get_object_element(j);
 					if(attachment.get_string_member("type").contains("audio")
-					|| attachment.get_string_member("type").contains("video"))
+					   || attachment.get_string_member("type").contains("video"))
 					{
 						mediaString = mediaString + attachment.get_string_member("href") + ",";
 					}
@@ -354,21 +351,21 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 			}
 
 			articles.add(new article(
-									id,
-									object.get_string_member("title"),
-									object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
-									object.get_object_member("origin").get_string_member("streamId"),
-									read ? ArticleStatus.READ : ArticleStatus.UNREAD,
-									marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-									object.get_object_member("summary").get_string_member("content"),
-									"",
-									(object.get_string_member("author") == "") ? null : object.get_string_member("author"),
-									new DateTime.from_unix_local(object.get_int_member("published")),
-									-1,
-									tagString,
-									mediaString
-							)
-						);
+							 id,
+							 object.get_string_member("title"),
+							 object.get_array_member("alternate").get_object_element(0).get_string_member("href"),
+							 object.get_object_member("origin").get_string_member("streamId"),
+							 read ? ArticleStatus.READ : ArticleStatus.UNREAD,
+							 marked ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+							 object.get_object_member("summary").get_string_member("content"),
+							 "",
+							 (object.get_string_member("author") == "") ? null : object.get_string_member("author"),
+							 new DateTime.from_unix_local(object.get_int_member("published")),
+							 -1,
+							 tagString,
+							 mediaString
+							 )
+			             );
 		}
 
 		if(root.has_member("continuation") && root.get_string_member("continuation") != "")
@@ -376,7 +373,6 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 
 		return null;
 	}
-
 
 	public void edidTag(string articleID, string tagID, bool add = true)
 	{
@@ -391,7 +387,7 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		m_connection.send_post_request("edit-tag?output=json", message_string);
 	}
 
-	public void markAsRead(string? streamID = null)
+	public void markAsRead(string ? streamID = null)
 	{
 		var settingsState = new GLib.Settings("org.gnome.feedreader.saved-state");
 		string message_string = "s=%s&ts=%i000000".printf(streamID, settingsState.get_int("last-sync"));
@@ -416,21 +412,21 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 		m_connection.send_post_request("rename-tag?output=json", message_string);
 	}
 
-	public bool editSubscription(OldreaderSubscriptionAction action, string[] feedID, string? title = null, string? add = null, string? remove = null)
+	public bool editSubscription(OldreaderSubscriptionAction action, string[] feedID, string ? title = null, string ? add = null, string ? remove = null)
 	{
 		var message_string = "ac=";
 
 		switch(action)
 		{
-			case OldreaderSubscriptionAction.EDIT:
-				message_string += "edit";
-				break;
-			case OldreaderSubscriptionAction.SUBSCRIBE:
-				message_string += "subscribe";
-				break;
-			case OldreaderSubscriptionAction.UNSUBSCRIBE:
-				message_string += "unsubscribe";
-				break;
+		case OldreaderSubscriptionAction.EDIT:
+			message_string += "edit";
+			break;
+		case OldreaderSubscriptionAction.SUBSCRIBE:
+			message_string += "subscribe";
+			break;
+		case OldreaderSubscriptionAction.UNSUBSCRIBE:
+			message_string += "unsubscribe";
+			break;
 		}
 
 		foreach(string s in feedID)
@@ -444,7 +440,6 @@ public class FeedReader.OldReaderAPI : GLib.Object {
 
 		if(remove != null)
 			message_string += "&r=" + remove;
-
 
 		var response = m_connection.send_post_request("subscription/edit?output=json", message_string);
 

--- a/plugins/backend/oldreader/oldreaderConnection.vala
+++ b/plugins/backend/oldreader/oldreaderConnection.vala
@@ -36,10 +36,10 @@ public class FeedReader.OldReaderConnection {
 
 		var message = new Soup.Message("POST", "https://theoldreader.com/accounts/ClientLogin/");
 		string message_string = "Email=" + m_api_username
-								+ "&Passwd=" + m_passwd
-								+ "&service=reader"
-								+ "&accountType=HOSTED_OR_GOOGLE"
-								+ "&client=FeedReader";
+		                        + "&Passwd=" + m_passwd
+		                        + "&service=reader"
+		                        + "&accountType=HOSTED_OR_GOOGLE"
+		                        + "&client=FeedReader";
 		message.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message_string.data);
 		m_session.send_message(message);
 
@@ -53,7 +53,7 @@ public class FeedReader.OldReaderConnection {
 			if(regex.match(response))
 			{
 				Logger.debug(@"Regex oldreader - $response");
-				string split = regex.replace( response, -1,0,"");
+				string split = regex.replace( response, -1, 0, "");
 				Logger.debug(@"authcode: $split");
 				m_utils.setAccessToken(split.strip());
 				return LoginResponse.SUCCESS;
@@ -73,17 +73,17 @@ public class FeedReader.OldReaderConnection {
 		}
 	}
 
-	public Response send_get_request(string path, string? message_string = null)
+	public Response send_get_request(string path, string ? message_string = null)
 	{
 		return send_request(path, "GET", message_string);
 	}
 
-	public Response send_post_request(string path, string? message_string = null)
+	public Response send_post_request(string path, string ? message_string = null)
 	{
 		return send_request(path, "POST", message_string);
 	}
 
-	private Response send_request(string path, string type, string? message_string = null)
+	private Response send_request(string path, string type, string ? message_string = null)
 	{
 		var message = new Soup.Message(type, OldReaderSecret.base_uri + path);
 
@@ -101,8 +101,8 @@ public class FeedReader.OldReaderConnection {
 		}
 
 		return Response() {
-			status = message.status_code,
-			data = (string)message.response_body.flatten().data
+				   status = message.status_code,
+				   data = (string)message.response_body.flatten().data
 		};
 	}
 

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -176,7 +176,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.ping();
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		feedID = "feed/" + feedURL;
 		errmsg = "";
@@ -185,11 +185,11 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		if(catID == null && newCatName != null)
 		{
 			string newCatID = m_api.composeTagID(newCatName);
-			success = m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, newCatID);
+			success = m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/" + feedURL}, null, newCatID);
 		}
 		else
 		{
-			success = m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/"+feedURL}, null, catID);
+			success = m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, {"feed/" + feedURL}, null, catID);
 		}
 
 		if(!success)
@@ -218,7 +218,6 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.SUBSCRIBE, urls, null, cat);
 	}
 
-
 	public void removeFeed(string feedID)
 	{
 		m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.UNSUBSCRIBE, {feedID});
@@ -229,12 +228,12 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.EDIT, {feedID}, title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.editSubscription(OldReaderAPI.OldreaderSubscriptionAction.EDIT, {feedID}, null, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.composeTagID(title);
 	}
@@ -265,7 +264,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getFeeds(feeds))
 		{
@@ -284,7 +283,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{
@@ -293,8 +292,8 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		else if(whatToGet == ArticleStatus.ALL)
 		{
 			var unreadIDs = new Gee.LinkedList<string>();
-			string? continuation = null;
-			int left = 4*count;
+			string ? continuation = null;
+			int left = 4 * count;
 
 			while(left > 0)
 			{
@@ -317,10 +316,10 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		}
 
 		var articles = new Gee.LinkedList<article>();
-		string? continuation = null;
+		string ? continuation = null;
 		int left = count;
-		string? OldReader_feedID = (isTagID) ? null : feedID;
-		string? OldReader_tagID = (isTagID) ? feedID : null;
+		string ? OldReader_feedID = (isTagID) ? null : feedID;
+		string ? OldReader_tagID = (isTagID) ? feedID : null;
 
 		while(left > 0)
 		{

--- a/plugins/backend/oldreader/oldreaderLoginWidget.vala
+++ b/plugins/backend/oldreader/oldreaderLoginWidget.vala
@@ -15,7 +15,6 @@
 
 public class FeedReader.oldreaderLoginWidget : Peas.ExtensionBase, LoginInterface {
 
-
 	private Gtk.Entry m_userEntry;
 	private Gtk.Entry m_passwordEntry;
 	private OldReaderUtils m_utils;
@@ -55,7 +54,7 @@ public class FeedReader.oldreaderLoginWidget : Peas.ExtensionBase, LoginInterfac
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var user_label = new Gtk.Label(_("Username:"));
 		var password_label = new Gtk.Label(_("Password:"));

--- a/plugins/backend/oldreader/oldreaderUtils.vala
+++ b/plugins/backend/oldreader/oldreaderUtils.vala
@@ -14,7 +14,7 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.OldReaderSecret {
-	 const string base_uri        = "https://theoldreader.com/reader/api/0/";
+	const string base_uri        = "https://theoldreader.com/reader/api/0/";
 }
 
 public class FeedReader.OldReaderUtils : GLib.Object {
@@ -67,9 +67,9 @@ public class FeedReader.OldReaderUtils : GLib.Object {
 		                                  "type", "oldreader",
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["Username"] = getUser();
-		string? passwd = "";
+		string ? passwd = "";
 
 		try
 		{
@@ -92,9 +92,9 @@ public class FeedReader.OldReaderUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.oldreader", Secret.SchemaFlags.NONE,
-										  "type", "oldreader",
-										  "Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "type", "oldreader",
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["Username"] = getUser();
 		try
 		{

--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -40,11 +40,11 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		m_session.authenticate.connect((msg, auth, retrying) => {
 			if(m_utils.getHtaccessUser() == "")
 			{
-				Logger.error("ownCloud Session: need Authentication");
+			    Logger.error("ownCloud Session: need Authentication");
 			}
 			else if(!retrying)
 			{
-				auth.authenticate(m_utils.getHtaccessUser(), m_utils.getHtaccessPasswd());
+			    auth.authenticate(m_utils.getHtaccessUser(), m_utils.getHtaccessPasswd());
 			}
 		});
 	}
@@ -56,7 +56,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		m_password = m_utils.getPasswd();
 		m_OwnCloudURL = m_utils.getURL();
 
-		if(m_OwnCloudURL == "" && m_username == "" && m_password == ""){
+		if(m_OwnCloudURL == "" && m_username == "" && m_password == "") {
 			m_OwnCloudURL = "example-host/owncloud";
 			return LoginResponse.ALL_EMPTY;
 		}
@@ -99,7 +99,6 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		return LoginResponse.UNKNOWN_ERROR;
 	}
 
-
 	public bool isloggedin()
 	{
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + "version", m_username, m_password, "GET");
@@ -132,18 +131,18 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 					{
 						var feed_node = feed_array.get_object_element(i);
 						string feed_id = feed_node.get_int_member("id").to_string();
-						string? icon_url = feed_node.has_member("faviconLink") ? feed_node.get_string_member("faviconLink") : null;
+						string ? icon_url = feed_node.has_member("faviconLink") ? feed_node.get_string_member("faviconLink") : null;
 
 						feeds.add(
 							new feed (
-									feed_id,
-									feed_node.get_string_member("title"),
-									feed_node.get_string_member("link"),
-									(int)feed_node.get_int_member("unreadCount"),
-									{ feed_node.get_int_member("folderId").to_string() },
-									icon_url
+								feed_id,
+								feed_node.get_string_member("title"),
+								feed_node.get_string_member("link"),
+								(int)feed_node.get_int_member("unreadCount"),
+								{ feed_node.get_int_member("folderId").to_string() },
+								icon_url
 								)
-						);
+							);
 					}
 
 					return true;
@@ -161,7 +160,6 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 		return false;
 	}
-
 
 	public bool getCategories(Gee.List<category> categories, Gee.List<feed> feeds)
 	{
@@ -194,8 +192,8 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 								orderID,
 								CategoryID.MASTER.to_string(),
 								1
-							)
-						);
+								)
+							);
 					}
 					return true;
 				}
@@ -211,7 +209,6 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		}
 		return false;
 	}
-
 
 	public void getNewArticles(Gee.List<article> articles, int lastModified, OwnCloudType type, int id)
 	{
@@ -237,34 +234,34 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 					ArticleStatus unread = article_node.get_boolean_member("unread") ? ArticleStatus.UNREAD : ArticleStatus.READ;
 					ArticleStatus marked = article_node.get_boolean_member("starred") ? ArticleStatus.MARKED : ArticleStatus.UNMARKED;
-					string? author = article_node.has_member("author") ? article_node.get_string_member("author") : null;
+					string ? author = article_node.has_member("author") ? article_node.get_string_member("author") : null;
 					string media = "";
 
 					if(article_node.has_member("enclosureLink") && article_node.get_string_member("enclosureLink") != null
-					&& article_node.has_member("enclosureMime") && article_node.get_string_member("enclosureMime") != null)
+					   && article_node.has_member("enclosureMime") && article_node.get_string_member("enclosureMime") != null)
 					{
 						if(article_node.get_string_member("enclosureMime").contains("audio")
-						|| article_node.get_string_member("enclosureMime").contains("video"))
+						   || article_node.get_string_member("enclosureMime").contains("video"))
 						{
 							media = article_node.get_string_member("enclosureLink");
 						}
 					}
 
-					var Article = new article(	article_node.get_int_member("id").to_string(),
-												article_node.get_string_member("title"),
-												article_node.get_string_member("url"),
-												article_node.get_int_member("feedId").to_string(),
-												unread,
-												marked,
-												article_node.get_string_member("body"),
-												"",
-												author,
-												new DateTime.from_unix_local(article_node.get_int_member("pubDate")),
-												-1,
-												"", // tags
-												media, // media
-												article_node.get_string_member("guidHash"),
-												(int)article_node.get_int_member("lastModified"));
+					var Article = new article(  article_node.get_int_member("id").to_string(),
+					                            article_node.get_string_member("title"),
+					                            article_node.get_string_member("url"),
+					                            article_node.get_int_member("feedId").to_string(),
+					                            unread,
+					                            marked,
+					                            article_node.get_string_member("body"),
+					                            "",
+					                            author,
+					                            new DateTime.from_unix_local(article_node.get_int_member("pubDate")),
+					                            -1,
+					                            "", // tags
+					                            media, // media
+					                            article_node.get_string_member("guidHash"),
+					                            (int)article_node.get_int_member("lastModified"));
 
 					articles.add(Article);
 				}
@@ -279,8 +276,6 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 			Logger.error("OwncloudNewsAPI.getNewArticles");
 		}
 	}
-
-
 
 	public void getArticles(Gee.List<article> articles, int skip, int count, bool read, OwnCloudType type, int id)
 	{
@@ -308,34 +303,34 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 					ArticleStatus unread = article_node.get_boolean_member("unread") ? ArticleStatus.UNREAD : ArticleStatus.READ;
 					ArticleStatus marked = article_node.get_boolean_member("starred") ? ArticleStatus.MARKED : ArticleStatus.UNMARKED;
-					string? author = article_node.has_member("author") ? article_node.get_string_member("author") : null;
+					string ? author = article_node.has_member("author") ? article_node.get_string_member("author") : null;
 					string media = "";
 
 					if(article_node.has_member("enclosureLink") && article_node.get_string_member("enclosureLink") != null
-					&& article_node.has_member("enclosureMime") && article_node.get_string_member("enclosureMime") != null)
+					   && article_node.has_member("enclosureMime") && article_node.get_string_member("enclosureMime") != null)
 					{
 						if(article_node.get_string_member("enclosureMime").contains("audio")
-						|| article_node.get_string_member("enclosureMime").contains("video"))
+						   || article_node.get_string_member("enclosureMime").contains("video"))
 						{
 							media = article_node.get_string_member("enclosureLink");
 						}
 					}
 
-					var Article = new article(	article_node.get_int_member("id").to_string(),
-												article_node.get_string_member("title"),
-												article_node.get_string_member("url"),
-												article_node.get_int_member("feedId").to_string(),
-												unread,
-												marked,
-												article_node.get_string_member("body"),
-												"",
-												author,
-												new DateTime.from_unix_local(article_node.get_int_member("pubDate")),
-												-1,
-												"", // tags
-												media,
-												article_node.get_string_member("guidHash"),
-												(int)article_node.get_int_member("lastModified"));
+					var Article = new article(  article_node.get_int_member("id").to_string(),
+					                            article_node.get_string_member("title"),
+					                            article_node.get_string_member("url"),
+					                            article_node.get_int_member("feedId").to_string(),
+					                            unread,
+					                            marked,
+					                            article_node.get_string_member("body"),
+					                            "",
+					                            author,
+					                            new DateTime.from_unix_local(article_node.get_int_member("pubDate")),
+					                            -1,
+					                            "", // tags
+					                            media,
+					                            article_node.get_string_member("guidHash"),
+					                            (int)article_node.get_int_member("lastModified"));
 
 					articles.add(Article);
 				}
@@ -351,7 +346,6 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		}
 	}
 
-
 	public bool markFeedRead(string feedID, bool isCatID)
 	{
 		string url = "%s/%s/read".printf((isCatID) ? "folders" : "feeds", feedID);
@@ -360,7 +354,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		int error = message.send();
 
 		if(error == ConnectionError.SUCCESS)
-		    return true;
+			return true;
 
 		Logger.error("OwncloudNewsAPI.markFeedRead");
 		return false;
@@ -374,12 +368,11 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		int error = message.send();
 
 		if(error == ConnectionError.SUCCESS)
-		    return true;
+			return true;
 
 		Logger.error("OwncloudNewsAPI.markAllItemsRead");
 		return false;
 	}
-
 
 	public bool updateArticleUnread(string articleIDs, ArticleStatus unread)
 	{
@@ -395,12 +388,11 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		int error = message.send();
 
 		if(error == ConnectionError.SUCCESS)
-		    return true;
+			return true;
 
 		Logger.error("OwncloudNewsAPI.updateArticleUnread");
 		return false;
 	}
-
 
 	public bool updateArticleMarked(string articleID, ArticleStatus marked)
 	{
@@ -416,13 +408,13 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		int error = message.send();
 
 		if(error == ConnectionError.SUCCESS)
-		    return true;
+			return true;
 
 		Logger.error("OwncloudNewsAPI.updateArticleMarked");
 		return false;
 	}
 
-	public bool addFeed(string feedURL, string? catID, out int64 feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, out int64 feedID, out string errmsg)
 	{
 		string url = "/feeds";
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "POST");
@@ -445,18 +437,17 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 			Logger.error("OwncloudNewsAPI.addFeed");
 		}
 
-
 		errmsg = "ownCloud could not add the feed";
 		feedID = 0;
 
 		switch(message.getStatusCode())
 		{
-			case 409:
-				errmsg = "Feed already added (409)";
-				return true;
-			case 422:
-				errmsg = "ownCloud can't read the feed (422)";
-				break;
+		case 409:
+			errmsg = "Feed already added (409)";
+			return true;
+		case 422:
+			errmsg = "ownCloud can't read the feed (422)";
+			break;
 		}
 
 		return false;
@@ -487,7 +478,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		}
 	}
 
-	public void moveFeed(string feedID, string? newCatID = null)
+	public void moveFeed(string feedID, string ? newCatID = null)
 	{
 		string url = "/feeds/%s/move".printf(feedID);
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
@@ -531,7 +522,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		int error = message.send();
 
 		if(error == ConnectionError.SUCCESS)
-		    return true;
+			return true;
 
 		Logger.error("OwncloudNewsAPI.removeFolder");
 		return false;

--- a/plugins/backend/owncloud/OwncloudNewsInterface.vala
+++ b/plugins/backend/owncloud/OwncloudNewsInterface.vala
@@ -159,7 +159,7 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		return m_api.ping();
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		bool success = false;
 		int64 id = 0;
@@ -172,7 +172,6 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		{
 			success = m_api.addFeed(feedURL, catID, out id, out errmsg);
 		}
-
 
 		feedID = id.to_string();
 		return success;
@@ -198,12 +197,12 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		m_api.renameFeed(feedID, title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.moveFeed(feedID, newCatID);
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		return m_api.addFolder(title).to_string();
 	}
@@ -234,7 +233,7 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getFeeds(feeds))
 		{
@@ -253,7 +252,7 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		return (int)dbDaemon.get_default().get_unread_total();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		var type = OwncloudNewsAPI.OwnCloudType.ALL;
 		bool read = true;
@@ -261,14 +260,14 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 
 		switch(whatToGet)
 		{
-			case ArticleStatus.ALL:
-				break;
-			case ArticleStatus.UNREAD:
-				read = false;
-				break;
-			case ArticleStatus.MARKED:
-				type = OwncloudNewsAPI.OwnCloudType.STARRED;
-				break;
+		case ArticleStatus.ALL:
+			break;
+		case ArticleStatus.UNREAD:
+			read = false;
+			break;
+		case ArticleStatus.MARKED:
+			type = OwncloudNewsAPI.OwnCloudType.STARRED;
+			break;
 		}
 
 		if(feedID != null)

--- a/plugins/backend/owncloud/OwncloudNewsLoginWidget.vala
+++ b/plugins/backend/owncloud/OwncloudNewsLoginWidget.vala
@@ -81,7 +81,7 @@ public class FeedReader.OwnCloudNewsLoginWidget : Peas.ExtensionBase, LoginInter
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var urlLabel = new Gtk.Label(_("OwnCloud URL:"));
 		var userLabel = new Gtk.Label(_("Username:"));
@@ -177,7 +177,6 @@ public class FeedReader.OwnCloudNewsLoginWidget : Peas.ExtensionBase, LoginInter
 		box.pack_start(grid, true, true, 10);
 		box.pack_start(m_revealer, true, true, 10);
 		box.pack_end(loginButton, false, false, 20);
-
 
 		m_urlEntry.set_text(m_utils.getUnmodifiedURL());
 		m_userEntry.set_text(m_utils.getUser());

--- a/plugins/backend/owncloud/OwncloudNewsMessage.vala
+++ b/plugins/backend/owncloud/OwncloudNewsMessage.vala
@@ -34,7 +34,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 		m_destination = destination;
 
 		if(method == "GET")
-		    m_contenttype = "application/x-www-form-urlencoded";
+			m_contenttype = "application/x-www-form-urlencoded";
 		else
 			m_contenttype = "application/json";
 
@@ -43,7 +43,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 
 		string credentials = username + ":" + password;
 		string base64 = GLib.Base64.encode(credentials.data);
-		m_message_soup.request_headers.append("Authorization","Basic %s".printf(base64));
+		m_message_soup.request_headers.append("Authorization", "Basic %s".printf(base64));
 	}
 
 	public void add_int(string type, int val)
@@ -64,7 +64,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 		if(m_method == "GET")
 			Logger.warning("OwnCloudNewsMessage.add_int_array: this should not happen");
 		else
-		    m_message_string.append(",\"" + type + "\":[" + values + "]");
+			m_message_string.append(",\"" + type + "\":[" + values + "]");
 	}
 
 	public void add_bool(string type, bool val)
@@ -90,7 +90,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 			m_message_string.append(type + "=" + val);
 		}
 		else
-		    m_message_string.append(",\"" + type + "\":\"" + val + "\"");
+			m_message_string.append(",\"" + type + "\":\"" + val + "\"");
 	}
 
 	public ConnectionError send(bool ping = false)
@@ -112,7 +112,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 		}
 
 		if(settingsTweaks.get_boolean("do-not-track"))
-				m_message_soup.request_headers.append("DNT", "1");
+			m_message_soup.request_headers.append("DNT", "1");
 
 		var status = m_session.send_message(m_message_soup);
 
@@ -160,7 +160,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 		return m_message_soup.status_code;
 	}
 
-	public Json.Object? get_response_object()
+	public Json.Object ? get_response_object()
 	{
 		return m_root_object;
 	}

--- a/plugins/backend/owncloud/OwncloudNewsUtils.vala
+++ b/plugins/backend/owncloud/OwncloudNewsUtils.vala
@@ -25,7 +25,7 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 	public string getURL()
 	{
 		string tmp_url = Utils.gsettingReadString(m_settings, "url");
-		if(tmp_url != ""){
+		if(tmp_url != "") {
 			if(!tmp_url.has_suffix("/"))
 				tmp_url = tmp_url + "/";
 
@@ -33,7 +33,7 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 				tmp_url = tmp_url + "index.php/apps/news/api/v1-2/";
 
 			if(!tmp_url.has_prefix("http://") && !tmp_url.has_prefix("https://"))
-					tmp_url = "https://" + tmp_url;
+				tmp_url = "https://" + tmp_url;
 		}
 
 		Logger.debug("OwnCloud URL: " + tmp_url);
@@ -77,11 +77,11 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 
-		string? passwd = "";
+		string ? passwd = "";
 		try
 		{
 			passwd = Secret.password_lookupv_sync(pwSchema, attributes, null);
@@ -103,9 +103,9 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										  "URL", Secret.SchemaAttributeType.STRING,
-										  "Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 		try
@@ -128,20 +128,20 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 	{
 		bool removed = false;
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										"URL", Secret.SchemaAttributeType.STRING,
-										"Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 
 		Secret.password_clearv.begin (pwSchema, attributes, null, (obj, async_res) => {
 			try
 			{
-				removed = Secret.password_clearv.end(async_res);
+			    removed = Secret.password_clearv.end(async_res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("OwncloudNewsUtils.deletePassword: %s".printf(e.message));
+			    Logger.error("OwncloudNewsUtils.deletePassword: %s".printf(e.message));
 			}
 		});
 		return removed;
@@ -152,14 +152,14 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING,
-										  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
+		                                  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getHtaccessUser();
 		attributes["Username"] = "true";
 
-		string? passwd = "";
+		string ? passwd = "";
 		try
 		{
 			passwd = Secret.password_lookupv_sync(pwSchema, attributes, null);
@@ -181,21 +181,21 @@ public class FeedReader.OwncloudNewsUtils : GLib.Object {
 	public void setHtAccessPassword(string passwd)
 	{
 		var pwAuthSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-											  "URL", Secret.SchemaAttributeType.STRING,
-											  "Username", Secret.SchemaAttributeType.STRING,
-											  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
-		var authAttributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                      "URL", Secret.SchemaAttributeType.STRING,
+		                                      "Username", Secret.SchemaAttributeType.STRING,
+		                                      "htaccess", Secret.SchemaAttributeType.BOOLEAN);
+		var authAttributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		authAttributes["URL"] = getURL();
 		authAttributes["Username"] = getHtaccessUser();
 		authAttributes["htaccess"] = "true";
 		try
 		{
 			Secret.password_storev_sync(pwAuthSchema,
-										authAttributes,
-										Secret.COLLECTION_DEFAULT,
-										"FeedReader: ownCloud htaccess Authentication",
-										passwd,
-										null);
+			                            authAttributes,
+			                            Secret.COLLECTION_DEFAULT,
+			                            "FeedReader: ownCloud htaccess Authentication",
+			                            passwd,
+			                            null);
 		}
 		catch(GLib.Error e)
 		{

--- a/plugins/backend/ttrss/ttrssAPI.vala
+++ b/plugins/backend/ttrss/ttrssAPI.vala
@@ -20,7 +20,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 	private string m_ttrss_sessionid;
 	private uint64 m_ttrss_apilevel;
 	private Json.Parser m_parser;
-	private string? m_iconDir = null;
+	private string ? m_iconDir = null;
 	private Soup.Session m_session;
 
 	public ttrssAPI ()
@@ -33,15 +33,14 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		m_session.authenticate.connect((msg, auth, retrying) => {
 			if(m_utils.getHtaccessUser() == "")
 			{
-				Logger.error("TTRSS Session: need Authentication");
+			    Logger.error("TTRSS Session: need Authentication");
 			}
 			else if(!retrying)
 			{
-				auth.authenticate(m_utils.getHtaccessUser(), m_utils.getHtaccessPasswd());
+			    auth.authenticate(m_utils.getHtaccessUser(), m_utils.getHtaccessPasswd());
 			}
 		});
 	}
-
 
 	public LoginResponse login()
 	{
@@ -61,7 +60,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 			return LoginResponse.INVALID_URL;
 		if(passwd == "")
 			return LoginResponse.MISSING_PASSWD;
-
 
 		var message = new ttrssMessage(m_session, m_ttrss_url);
 		message.add_string("op", "login");
@@ -130,7 +128,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return false;
 	}
 
-
 	public bool isloggedin()
 	{
 		var message = new ttrssMessage(m_session, m_ttrss_url);
@@ -171,7 +168,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return false;
 	}
 
-
 	public int getUnreadCount()
 	{
 		int unread = 0;
@@ -189,7 +185,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 
 		return unread;
 	}
-
 
 	public bool getFeeds(Gee.List<feed> feeds, Gee.List<category> categories)
 	{
@@ -212,18 +207,18 @@ public class FeedReader.ttrssAPI : GLib.Object {
 					{
 						var feed_node = response.get_object_element(i);
 						string feed_id = feed_node.get_int_member("id").to_string();
-						string? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir+feed_id+".ico" : null;
+						string ? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir + feed_id + ".ico" : null;
 
 						feeds.add(
 							new feed (
-									feed_id,
-									feed_node.get_string_member("title"),
-									feed_node.get_string_member("feed_url"),
-									(int)feed_node.get_int_member("unread"),
-									{ feed_node.get_int_member("cat_id").to_string() },
-									icon_url
+								feed_id,
+								feed_node.get_string_member("title"),
+								feed_node.get_string_member("feed_url"),
+								(int)feed_node.get_int_member("unread"),
+								{ feed_node.get_int_member("cat_id").to_string() },
+								icon_url
 								)
-						);
+							);
 					}
 				}
 				else
@@ -234,7 +229,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		}
 		return true;
 	}
-
 
 	public bool getUncategorizedFeeds(Gee.List<feed> feeds)
 	{
@@ -253,18 +247,18 @@ public class FeedReader.ttrssAPI : GLib.Object {
 			{
 				var feed_node = response.get_object_element(i);
 				string feed_id = feed_node.get_int_member("id").to_string();
-				string? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir+feed_id+".ico" : null;
+				string ? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir + feed_id + ".ico" : null;
 
 				feeds.add(
 					new feed (
-							feed_id,
-							feed_node.get_string_member("title"),
-							feed_node.get_string_member("feed_url"),
-							(int)feed_node.get_int_member("unread"),
-							{ feed_node.get_int_member("cat_id").to_string() },
-							icon_url
+						feed_id,
+						feed_node.get_string_member("title"),
+						feed_node.get_string_member("feed_url"),
+						(int)feed_node.get_int_member("unread"),
+						{ feed_node.get_int_member("cat_id").to_string() },
+						icon_url
 						)
-				);
+					);
 			}
 			return true;
 		}
@@ -292,8 +286,8 @@ public class FeedReader.ttrssAPI : GLib.Object {
 						tag_node.get_int_member("id").to_string(),
 						tag_node.get_string_member("caption"),
 						dbDaemon.get_default().getTagColor()
-					)
-				);
+						)
+					);
 			}
 
 			return true;
@@ -302,8 +296,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return false;
 	}
 
-
-	public string? getIconDir()
+	public string ? getIconDir()
 	{
 		var message = new ttrssMessage(m_session, m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -318,7 +311,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 
 		return null;
 	}
-
 
 	public bool getCategories(Gee.List<category> categories)
 	{
@@ -340,7 +332,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		}
 		return false;
 	}
-
 
 	private void getSubCategories(Gee.List<category> categories, Json.Object categorie, int level, string parent)
 	{
@@ -375,15 +366,14 @@ public class FeedReader.ttrssAPI : GLib.Object {
 							orderID,
 							parent,
 							level
-						)
-					);
+							)
+						);
 				}
 
 				getSubCategories(categories, categorie_node, level, categorieID);
 			}
 		}
 	}
-
 
 	private int getUncategorizedUnread()
 	{
@@ -417,7 +407,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return 0;
 	}
 
-
 	public void getHeadlines(Gee.List<article> articles, int skip, int limit, ArticleStatus whatToGet, int feedID)
 	{
 		var message = new ttrssMessage(m_session, m_ttrss_url);
@@ -429,17 +418,17 @@ public class FeedReader.ttrssAPI : GLib.Object {
 
 		switch(whatToGet)
 		{
-			case ArticleStatus.ALL:
-				message.add_string("view_mode", "all_articles");
-				break;
+		case ArticleStatus.ALL:
+			message.add_string("view_mode", "all_articles");
+			break;
 
-			case ArticleStatus.UNREAD:
-				message.add_string("view_mode", "unread");
-				break;
+		case ArticleStatus.UNREAD:
+			message.add_string("view_mode", "unread");
+			break;
 
-			case ArticleStatus.MARKED:
-				message.add_string("view_mode", "marked");
-				break;
+		case ArticleStatus.MARKED:
+			message.add_string("view_mode", "marked");
+			break;
 		}
 
 		int error = message.send();
@@ -482,7 +471,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 					{
 						var attachment = attachments.get_object_element(j);
 						if(attachment.get_string_member("content_type").contains("audio")
-						|| attachment.get_string_member("content_type").contains("video"))
+						   || attachment.get_string_member("content_type").contains("video"))
 						{
 							mediaString = mediaString + attachment.get_string_member("content_url") + ",";
 						}
@@ -490,20 +479,20 @@ public class FeedReader.ttrssAPI : GLib.Object {
 				}
 
 				var Article = new article(
-										headline_node.get_int_member("id").to_string(),
-										headline_node.get_string_member("title"),
-										headline_node.get_string_member("link"),
-										headline_node.get_string_member("feed_id"),
-										(headline_node.get_boolean_member("unread")) ? ArticleStatus.UNREAD : ArticleStatus.READ,
-										(headline_node.get_boolean_member("marked")) ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-										"",
-										"",
-										(headline_node.get_string_member("author") == "") ? null : headline_node.get_string_member("author"),
-										new DateTime.from_unix_local(headline_node.get_int_member("updated")),
-										-1,
-										tagString,
-										mediaString
-								);
+					headline_node.get_int_member("id").to_string(),
+					headline_node.get_string_member("title"),
+					headline_node.get_string_member("link"),
+					headline_node.get_string_member("feed_id"),
+					(headline_node.get_boolean_member("unread")) ? ArticleStatus.UNREAD : ArticleStatus.READ,
+					(headline_node.get_boolean_member("marked")) ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+					"",
+					"",
+					(headline_node.get_string_member("author") == "") ? null : headline_node.get_string_member("author"),
+					new DateTime.from_unix_local(headline_node.get_int_member("updated")),
+					-1,
+					tagString,
+					mediaString
+					);
 
 				articles.add(Article);
 			}
@@ -543,7 +532,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		}
 		return null;
 	}
-
 
 	public void getArticles(string articleIDs, Gee.List<article> articles)
 	{
@@ -592,7 +580,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 					{
 						var attachment = attachments.get_object_element(j);
 						if(attachment.get_string_member("content_type").contains("audio")
-						|| attachment.get_string_member("content_type").contains("video"))
+						   || attachment.get_string_member("content_type").contains("video"))
 						{
 							mediaString = mediaString + attachment.get_string_member("content_url") + ",";
 						}
@@ -600,20 +588,20 @@ public class FeedReader.ttrssAPI : GLib.Object {
 				}
 
 				var Article = new article(
-										article_node.get_string_member("id"),
-										article_node.get_string_member("title"),
-										article_node.get_string_member("link"),
-										article_node.get_string_member("feed_id"),
-										(article_node.get_boolean_member("unread")) ? ArticleStatus.UNREAD : ArticleStatus.READ,
-										(article_node.get_boolean_member("marked")) ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
-										article_node.get_string_member("content"),
-										"",
-										(article_node.get_string_member("author") == "") ? null : article_node.get_string_member("author"),
-										new DateTime.from_unix_local(article_node.get_int_member("updated")),
-										-1,
-										tagString,
-										mediaString
-								);
+					article_node.get_string_member("id"),
+					article_node.get_string_member("title"),
+					article_node.get_string_member("link"),
+					article_node.get_string_member("feed_id"),
+					(article_node.get_boolean_member("unread")) ? ArticleStatus.UNREAD : ArticleStatus.READ,
+					(article_node.get_boolean_member("marked")) ? ArticleStatus.MARKED : ArticleStatus.UNMARKED,
+					article_node.get_string_member("content"),
+					"",
+					(article_node.get_string_member("author") == "") ? null : article_node.get_string_member("author"),
+					new DateTime.from_unix_local(article_node.get_int_member("updated")),
+					-1,
+					tagString,
+					mediaString
+					);
 
 				articles.add(Article);
 			}
@@ -667,7 +655,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return return_value;
 	}
 
-
 	public bool updateArticleMarked(int articleID, ArticleStatus marked)
 	{
 		bool return_value = false;
@@ -706,7 +693,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		{
 			var response = message.get_response_object();
 			if(response.get_string_member("status") == "OK")
-			return true;
+				return true;
 		}
 
 		return false;
@@ -761,8 +748,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return false;
 	}
 
-
-	public bool subscribeToFeed(string feedURL, string? catID, string? username, string? password, out string errmsg)
+	public bool subscribeToFeed(string feedURL, string ? catID, string ? username, string ? password, out string errmsg)
 	{
 		errmsg = "";
 		var message = new ttrssMessage(m_session, m_ttrss_url);
@@ -793,30 +779,30 @@ public class FeedReader.ttrssAPI : GLib.Object {
 				{
 					switch(status.get_int_member("code"))
 					{
-						case 0:
-						case 1:
-							return true;
-						case 2:
-							errmsg = _("Invalid URL");
-							return false;
-						case 3:
-							errmsg = _("URL content is HTML, no feeds available");
-							return false;
-						case 4:
-							errmsg = _("URL content is HTML which contains multiple feeds.");
-							return false;
-						case 5:
-							errmsg = _("Couldn't download the URL content.");
-							return false;
-						case 6:
-							errmsg = _("Content is an invalid XML.");
-							return false;
-						default:
-							if(status.has_member("message"))
-								errmsg = status.get_string_member("message");
-							else
-								errmsg = "ttrss error";
-							return false;
+					case 0:
+					case 1:
+						return true;
+					case 2:
+						errmsg = _("Invalid URL");
+						return false;
+					case 3:
+						errmsg = _("URL content is HTML, no feeds available");
+						return false;
+					case 4:
+						errmsg = _("URL content is HTML which contains multiple feeds.");
+						return false;
+					case 5:
+						errmsg = _("Couldn't download the URL content.");
+						return false;
+					case 6:
+						errmsg = _("Content is an invalid XML.");
+						return false;
+					default:
+						if(status.has_member("message"))
+							errmsg = status.get_string_member("message");
+						else
+							errmsg = "ttrss error";
+						return false;
 					}
 				}
 			}
@@ -842,7 +828,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 		return false;
 	}
 
-	public string? createCategory(string title, int? parentID = null)
+	public string ? createCategory(string title, int ? parentID = null)
 	{
 		var message = new ttrssMessage(m_session, m_ttrss_url);
 		message.add_string("sid", m_ttrss_sessionid);
@@ -852,7 +838,6 @@ public class FeedReader.ttrssAPI : GLib.Object {
 			message.add_int("parent_id", parentID);
 		int error = message.send();
 		message.printMessage();
-
 
 		if(error == ConnectionError.SUCCESS)
 		{

--- a/plugins/backend/ttrss/ttrssInterface.vala
+++ b/plugins/backend/ttrss/ttrssInterface.vala
@@ -163,7 +163,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		m_api.renameLabel(int.parse(tagID), title);
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		bool success = false;
 		if(catID == null && newCatName != null)
@@ -181,13 +181,12 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		else
 			feedID = "-98";
 
-
 		return success;
 	}
 
 	public void addFeeds(Gee.List<feed> feeds)
 	{
-		string? errmsg = null;
+		string ? errmsg = null;
 		foreach(feed f in feeds)
 		{
 			m_api.subscribeToFeed(f.getXmlUrl(), f.getCatIDs()[0], null, null, out errmsg);
@@ -204,12 +203,12 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		m_api.renameFeed(int.parse(feedID), title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID)
 	{
 		m_api.moveFeed(int.parse(feedID), int.parse(newCatID));
 	}
 
-	public string createCategory(string title, string? parentID)
+	public string createCategory(string title, string ? parentID)
 	{
 		if(parentID != null)
 			return m_api.createCategory(title, int.parse(parentID));
@@ -243,7 +242,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		parser.parse();
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(m_api.getCategories(categories))
 		{
@@ -274,12 +273,12 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		return m_api.getUnreadCount();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, string ? feedID, bool isTagID, GLib.Cancellable ? cancellable = null)
 	{
 		var settings_general = new GLib.Settings("org.gnome.feedreader");
 
 		// first use newsPlus plugin to update states of 10x as much articles as we would normaly do
-		var unreadIDs = m_api.NewsPlus(ArticleStatus.UNREAD, 10*settings_general.get_int("max-articles"));
+		var unreadIDs = m_api.NewsPlus(ArticleStatus.UNREAD, 10 * settings_general.get_int("max-articles"));
 
 		if(cancellable != null && cancellable.is_cancelled())
 			return;
@@ -335,7 +334,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		}
 
 		if(articleIDs.length > 0)
-			articleIDs = articleIDs.substring(0, articleIDs.length -1);
+			articleIDs = articleIDs.substring(0, articleIDs.length - 1);
 
 		var articles = new Gee.LinkedList<article>();
 
@@ -343,7 +342,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 			m_api.getArticles(articleIDs, articles);
 
 		articles.sort((a, b) => {
-				return strcmp(a.getArticleID(), b.getArticleID());
+			return strcmp(a.getArticleID(), b.getArticleID());
 		});
 
 		if(cancellable != null && cancellable.is_cancelled())

--- a/plugins/backend/ttrss/ttrssLoginWidget.vala
+++ b/plugins/backend/ttrss/ttrssLoginWidget.vala
@@ -59,7 +59,7 @@ public class FeedReader.ttrssLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return false;
 	}
 
-	public Gtk.Box? getWidget()
+	public Gtk.Box ? getWidget()
 	{
 		var url_label = new Gtk.Label(_("Tiny Tiny RSS URL:"));
 		var user_label = new Gtk.Label(_("Username:"));
@@ -96,7 +96,6 @@ public class FeedReader.ttrssLoginWidget : Peas.ExtensionBase, LoginInterface {
 		grid.attach(m_userEntry, 1, 1, 1, 1);
 		grid.attach(password_label, 0, 2, 1, 1);
 		grid.attach(m_passwordEntry, 1, 2, 1, 1);
-
 
 		// http auth stuff ----------------------------------------------------
 		var auth_user_label = new Gtk.Label(_("Username:"));
@@ -196,7 +195,6 @@ public class FeedReader.ttrssLoginWidget : Peas.ExtensionBase, LoginInterface {
 		return "";
 	}
 }
-
 
 [ModuleInit]
 public void peas_register_types(GLib.TypeModule module)

--- a/plugins/backend/ttrss/ttrssMessage.vala
+++ b/plugins/backend/ttrss/ttrssMessage.vala
@@ -23,7 +23,6 @@ public class FeedReader.ttrssMessage : GLib.Object {
 	private Json.Object m_root_object;
 	private ttrssUtils m_utils;
 
-
 	public ttrssMessage(Soup.Session session, string destination)
 	{
 		m_utils = new ttrssUtils();
@@ -37,7 +36,6 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		if(m_message_soup == null)
 			Logger.error(@"ttrssMessage: can't send message to $destination");
 	}
-
 
 	public void add_int(string type, int val)
 	{
@@ -76,7 +74,7 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		m_message_soup.set_request(m_contenttype, Soup.MemoryUse.COPY, m_message_string.str.data);
 
 		if(settingsTweaks.get_boolean("do-not-track"))
-				m_message_soup.request_headers.append("DNT", "1");
+			m_message_soup.request_headers.append("DNT", "1");
 
 		var status = m_session.send_message(m_message_soup);
 
@@ -90,7 +88,6 @@ public class FeedReader.ttrssMessage : GLib.Object {
 			Logger.info("TLS errors: " + Utils.printTlsCertificateFlags(m_message_soup.tls_errors));
 			return ConnectionError.CA_ERROR;
 		}
-
 
 		if(m_message_soup.status_code != 200)
 		{
@@ -117,10 +114,8 @@ public class FeedReader.ttrssMessage : GLib.Object {
 
 		m_root_object = m_parser.get_root().get_object();
 
-
 		if(m_root_object.has_member("error"))
 			parseError(m_root_object);
-
 
 		if(m_root_object.has_member("status"))
 		{
@@ -145,7 +140,7 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		return ConnectionError.UNKNOWN;
 	}
 
-	public Json.Object? get_response_object()
+	public Json.Object ? get_response_object()
 	{
 		if(m_root_object.has_member("content"))
 		{
@@ -154,7 +149,7 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		return null;
 	}
 
-	public int64? get_response_int()
+	public int64 ? get_response_int()
 	{
 		if(m_root_object.has_member("content"))
 		{
@@ -163,7 +158,7 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		return null;
 	}
 
-	public string? get_response_string()
+	public string ? get_response_string()
 	{
 		if(m_root_object.has_member("content"))
 		{
@@ -172,8 +167,7 @@ public class FeedReader.ttrssMessage : GLib.Object {
 		return null;
 	}
 
-
-	public Json.Array? get_response_array()
+	public Json.Array ? get_response_array()
 	{
 		if(m_root_object.has_member("content"))
 		{

--- a/plugins/backend/ttrss/ttrssUtils.vala
+++ b/plugins/backend/ttrss/ttrssUtils.vala
@@ -36,7 +36,7 @@ public class FeedReader.ttrssUtils : GLib.Object {
 
 		string tmp_url = Utils.gsettingReadString(m_settings, "url");
 
-		if(tmp_url != ""){
+		if(tmp_url != "") {
 			if(!tmp_url.has_suffix("/"))
 				tmp_url = tmp_url + "/";
 
@@ -44,7 +44,7 @@ public class FeedReader.ttrssUtils : GLib.Object {
 				tmp_url = tmp_url + "api/";
 
 			if(!tmp_url.has_prefix("http://") && !tmp_url.has_prefix("https://"))
-					tmp_url = "https://" + tmp_url;
+				tmp_url = "https://" + tmp_url;
 		}
 
 		Logger.debug("ttrss URL: " + tmp_url);
@@ -88,11 +88,11 @@ public class FeedReader.ttrssUtils : GLib.Object {
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 
-		string? passwd = "";
+		string ? passwd = "";
 
 		try
 		{
@@ -115,9 +115,9 @@ public class FeedReader.ttrssUtils : GLib.Object {
 	public void setPassword(string passwd)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										  "URL", Secret.SchemaAttributeType.STRING,
-										  "Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 		try
@@ -140,20 +140,20 @@ public class FeedReader.ttrssUtils : GLib.Object {
 	{
 		bool removed = false;
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-										"URL", Secret.SchemaAttributeType.STRING,
-										"Username", Secret.SchemaAttributeType.STRING);
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                  "URL", Secret.SchemaAttributeType.STRING,
+		                                  "Username", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getUser();
 
 		Secret.password_clearv.begin (pwSchema, attributes, null, (obj, async_res) => {
 			try
 			{
-				removed = Secret.password_clearv.end(async_res);
+			    removed = Secret.password_clearv.end(async_res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("ttrssUtils.deletePassword: %s".printf(e.message));
+			    Logger.error("ttrssUtils.deletePassword: %s".printf(e.message));
 			}
 		});
 		return removed;
@@ -164,9 +164,9 @@ public class FeedReader.ttrssUtils : GLib.Object {
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
 		                                  "URL", Secret.SchemaAttributeType.STRING,
 		                                  "Username", Secret.SchemaAttributeType.STRING,
-										  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
+		                                  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
 
-		var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		attributes["URL"] = getURL();
 		attributes["Username"] = getHtaccessUser();
 		attributes["htaccess"] = "true";
@@ -194,21 +194,21 @@ public class FeedReader.ttrssUtils : GLib.Object {
 	public void setHtAccessPassword(string passwd)
 	{
 		var pwAuthSchema = new Secret.Schema ("org.gnome.feedreader.password", Secret.SchemaFlags.NONE,
-											  "URL", Secret.SchemaAttributeType.STRING,
-											  "Username", Secret.SchemaAttributeType.STRING,
-											  "htaccess", Secret.SchemaAttributeType.BOOLEAN);
-		var authAttributes = new GLib.HashTable<string,string>(str_hash, str_equal);
+		                                      "URL", Secret.SchemaAttributeType.STRING,
+		                                      "Username", Secret.SchemaAttributeType.STRING,
+		                                      "htaccess", Secret.SchemaAttributeType.BOOLEAN);
+		var authAttributes = new GLib.HashTable<string, string>(str_hash, str_equal);
 		authAttributes["URL"] = getURL();
 		authAttributes["Username"] = getHtaccessUser();
 		authAttributes["htaccess"] = "true";
 		try
 		{
 			Secret.password_storev_sync(pwAuthSchema,
-										authAttributes,
-										Secret.COLLECTION_DEFAULT,
-										"FeedReader: ttrss htaccess Authentication",
-										passwd,
-										null);
+			                            authAttributes,
+			                            Secret.COLLECTION_DEFAULT,
+			                            "FeedReader: ttrss htaccess Authentication",
+			                            passwd,
+			                            null);
 		}
 		catch(GLib.Error e)
 		{

--- a/plugins/share/Browser/Browser.vala
+++ b/plugins/share/Browser/Browser.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.Browser : ShareAccountInterface, Peas.ExtensionBase {
 
 	public bool addBookmark(string id, string url, bool system)
@@ -42,12 +41,12 @@ public class FeedReader.Browser : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public string getIconName()
-    {
+	{
 		if(Gtk.IconTheme.get_default().lookup_icon("applications-internet", 0, Gtk.IconLookupFlags.FORCE_SVG) != null)
 			return "applications-internet";
 
-        return "feed-share-browser";
-    }
+		return "feed-share-browser";
+	}
 
 	public string getUsername(string id)
 	{
@@ -65,36 +64,36 @@ public class FeedReader.Browser : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public bool useSystemAccounts()
-    {
-        return false;
-    }
+	{
+		return false;
+	}
 
 	public string pluginID()
-    {
-        return "browser";
-    }
+	{
+		return "browser";
+	}
 
 	public string pluginName()
 	{
 		return _("Open in Browser");
 	}
 
-	public ServiceSetup? newSetup_withID(string id, string username)
-    {
-        return null;
-    }
-
-    public ServiceSetup? newSetup()
-    {
-        return null;
-    }
-
-	public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSetup_withID(string id, string username)
 	{
 		return null;
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ServiceSetup ? newSetup()
+	{
+		return null;
+	}
+
+	public ServiceSetup ? newSystemAccount(string id, string username)
+	{
+		return null;
+	}
+
+	public ShareForm ? shareWidget(string url)
 	{
 		return null;
 	}

--- a/plugins/share/Email/Email.vala
+++ b/plugins/share/Email/Email.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.ShareMail : ShareAccountInterface, Peas.ExtensionBase {
 
 	private string m_body;
@@ -50,12 +49,12 @@ public class FeedReader.ShareMail : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public string getIconName()
-    {
+	{
 		if(Gtk.IconTheme.get_default().lookup_icon("mail-send", 0, Gtk.IconLookupFlags.FORCE_SVG) != null)
 			return "mail-send";
 
-        return "feed-share-mail";
-    }
+		return "feed-share-mail";
+	}
 
 	public string getUsername(string id)
 	{
@@ -73,36 +72,36 @@ public class FeedReader.ShareMail : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public bool useSystemAccounts()
-    {
-        return false;
-    }
+	{
+		return false;
+	}
 
 	public string pluginID()
-    {
-        return "mail";
-    }
+	{
+		return "mail";
+	}
 
 	public string pluginName()
 	{
 		return "Email";
 	}
 
-	public ServiceSetup? newSetup_withID(string id, string username)
-    {
-        return null;
-    }
-
-    public ServiceSetup? newSetup()
-    {
-        return null;
-    }
-
-	public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSetup_withID(string id, string username)
 	{
 		return null;
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ServiceSetup ? newSetup()
+	{
+		return null;
+	}
+
+	public ServiceSetup ? newSystemAccount(string id, string username)
+	{
+		return null;
+	}
+
+	public ShareForm ? shareWidget(string url)
 	{
 		var widget = new EmailForm(url);
 		widget.share.connect(() => {

--- a/plugins/share/Email/EmailForm.vala
+++ b/plugins/share/Email/EmailForm.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.EmailForm : ShareForm {
 
 	private Gtk.Entry m_entry;

--- a/plugins/share/Instapaper/InstapaperAPI.vala
+++ b/plugins/share/Instapaper/InstapaperAPI.vala
@@ -14,219 +14,217 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.InstapaperSecrets {
-	const string base_uri			= "https://www.instapaper.com/api/";
-	const string oauth_consumer_key		= "b7681e07bf554b15813511217054e1b2";
-	const string oauth_consumer_secret	= "c5307cb359d54685904f6d38aaeede6f";
-	const string oauth_callback			= "feedreader://instapaper";
+	const string base_uri           = "https://www.instapaper.com/api/";
+	const string oauth_consumer_key     = "b7681e07bf554b15813511217054e1b2";
+	const string oauth_consumer_secret  = "c5307cb359d54685904f6d38aaeede6f";
+	const string oauth_callback         = "feedreader://instapaper";
 }
 
 public class FeedReader.InstaAPI : ShareAccountInterface, Peas.ExtensionBase {
 
-    public InstaAPI()
-    {
+	public InstaAPI()
+	{
 
-    }
+	}
 
 	public void setupSystemAccounts(Gee.ArrayList<ShareAccount> accounts)
 	{
 
 	}
 
-    public string getRequestToken()
-    {
-        return "";
-    }
+	public string getRequestToken()
+	{
+		return "";
+	}
 
-    public bool getAccessToken(string id, string username, string password)
-    {
-        string userID = "";
+	public bool getAccessToken(string id, string username, string password)
+	{
+		string userID = "";
 
-        var oauthObject = new Rest.OAuthProxy (
-            InstapaperSecrets.oauth_consumer_key,
-            InstapaperSecrets.oauth_consumer_secret,
-            "https://www.instapaper.com/api/1/",
-            false);
+		var oauthObject = new Rest.OAuthProxy (
+			InstapaperSecrets.oauth_consumer_key,
+			InstapaperSecrets.oauth_consumer_secret,
+			"https://www.instapaper.com/api/1/",
+			false);
 
-        var call = oauthObject.new_call();
+		var call = oauthObject.new_call();
 		oauthObject.url_format = "https://www.instapaper.com/api/1/";
 		call.set_function ("oauth/access_token");
 		call.set_method("POST");
 		call.add_param("x_auth_mode", "client_auth");
 		call.add_param("x_auth_username", username);
-        call.add_param("x_auth_password", password);
-        try
-        {
-            call.run();
-        }
-        catch(Error e)
-        {
-            Logger.error("instapaper getAccessToken: " + e.message);
-        }
+		call.add_param("x_auth_password", password);
+		try
+		{
+			call.run();
+		}
+		catch(Error e)
+		{
+			Logger.error("instapaper getAccessToken: " + e.message);
+		}
 
-        string response = call.get_payload();
-        int64 status = call.get_status_code();
+		string response = call.get_payload();
+		int64 status = call.get_status_code();
 
-        if(status != 200)
-        {
-            return false;
-        }
+		if(status != 200)
+		{
+			return false;
+		}
 
+		int secretStart = response.index_of_char('=') + 1;
+		int secretEnd = response.index_of_char('&', secretStart);
+		int tokenStart = response.index_of_char('=', secretEnd) + 1;
 
-        int secretStart = response.index_of_char('=')+1;
-        int secretEnd = response.index_of_char('&', secretStart);
-        int tokenStart = response.index_of_char('=', secretEnd)+1;
+		string accessToken_secret = response.substring(secretStart, secretEnd - secretStart);
+		string accessToken = response.substring(tokenStart);
 
-        string accessToken_secret = response.substring(secretStart, secretEnd-secretStart);
-        string accessToken = response.substring(tokenStart);
+		oauthObject.set_token(accessToken);
+		oauthObject.set_token_secret(accessToken_secret);
 
-        oauthObject.set_token(accessToken);
-        oauthObject.set_token_secret(accessToken_secret);
-
-        // get userID -------------------------------------------------------------------------------------------------
-        var call2 = oauthObject.new_call();
+		// get userID -------------------------------------------------------------------------------------------------
+		var call2 = oauthObject.new_call();
 		oauthObject.url_format = "https://www.instapaper.com/api/1/";
 		call2.set_function("account/verify_credentials");
 		call2.set_method("POST");
-        try
-        {
-            call2.run();
-        }
-        catch(Error e)
-        {
-            Logger.debug("getUserID: " + e.message);
-        }
+		try
+		{
+			call2.run();
+		}
+		catch(Error e)
+		{
+			Logger.debug("getUserID: " + e.message);
+		}
 
-        var parser = new Json.Parser();
-        try
-        {
-            parser.load_from_data(call2.get_payload());
-        }
-        catch (Error e)
-        {
-            Logger.error("Could not load response to Message from instapaper");
-            Logger.error(e.message);
-        }
+		var parser = new Json.Parser();
+		try
+		{
+			parser.load_from_data(call2.get_payload());
+		}
+		catch (Error e)
+		{
+			Logger.error("Could not load response to Message from instapaper");
+			Logger.error(e.message);
+		}
 
-        var root_node = parser.get_root();
-        var userArray = root_node.get_array();
-        var root_object = userArray.get_object_element(0);
-        if(root_object.has_member("user_id"))
-        {
-            userID = root_object.get_int_member("user_id").to_string();
-        }
-        else if(root_object.has_member("error"))
-        {
-            Logger.error(root_object.get_int_member("error_code").to_string());
-            Logger.error(root_object.get_string_member("message"));
-        }
-        //-------------------------------------------------------------------------------------------------------------
+		var root_node = parser.get_root();
+		var userArray = root_node.get_array();
+		var root_object = userArray.get_object_element(0);
+		if(root_object.has_member("user_id"))
+		{
+			userID = root_object.get_int_member("user_id").to_string();
+		}
+		else if(root_object.has_member("error"))
+		{
+			Logger.error(root_object.get_int_member("error_code").to_string());
+			Logger.error(root_object.get_string_member("message"));
+		}
+		//-------------------------------------------------------------------------------------------------------------
 
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/instapaper/%s/".printf(id));
+		settings.set_string("oauth-access-token", accessToken);
+		settings.set_string("oauth-access-token-secret", accessToken_secret);
+		settings.set_string("username", username);
+		settings.set_string("user-id", userID);
 
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/instapaper/%s/".printf(id));
-        settings.set_string("oauth-access-token", accessToken);
-    	settings.set_string("oauth-access-token-secret", accessToken_secret);
-        settings.set_string("username", username);
-        settings.set_string("user-id", userID);
-
-        var array = Settings.share("instapaper").get_strv("account-ids");
-        array += id;
+		var array = Settings.share("instapaper").get_strv("account-ids");
+		array += id;
 		Settings.share("instapaper").set_strv("account-ids", array);
 
-        var pwSchema = new Secret.Schema ("org.gnome.feedreader.instapaper.password", Secret.SchemaFlags.NONE,
-                                        "userID", Secret.SchemaAttributeType.STRING);
+		var pwSchema = new Secret.Schema ("org.gnome.feedreader.instapaper.password", Secret.SchemaFlags.NONE,
+		                                  "userID", Secret.SchemaAttributeType.STRING);
 
-        var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
-        attributes["userID"] = userID;
-        try
-        {
-            Secret.password_storev_sync(pwSchema, attributes, Secret.COLLECTION_DEFAULT, "Feedreader: Instapaper login", password, null);
-        }
-        catch(GLib.Error e)
-        {
-            Logger.error("InstaAPI - getAccessToken: " + e.message);
-        }
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
+		attributes["userID"] = userID;
+		try
+		{
+			Secret.password_storev_sync(pwSchema, attributes, Secret.COLLECTION_DEFAULT, "Feedreader: Instapaper login", password, null);
+		}
+		catch(GLib.Error e)
+		{
+			Logger.error("InstaAPI - getAccessToken: " + e.message);
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    public bool addBookmark(string id, string url, bool system)
-    {
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/instapaper/%s/".printf(id));
+	public bool addBookmark(string id, string url, bool system)
+	{
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/instapaper/%s/".printf(id));
 
-        var pwSchema = new Secret.Schema ("org.gnome.feedreader.instapaper.password", Secret.SchemaFlags.NONE, "userID", Secret.SchemaAttributeType.STRING);
-        var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
-        attributes["userID"] = settings.get_string("user-id");
+		var pwSchema = new Secret.Schema ("org.gnome.feedreader.instapaper.password", Secret.SchemaFlags.NONE, "userID", Secret.SchemaAttributeType.STRING);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
+		attributes["userID"] = settings.get_string("user-id");
 
-        string password = "";
-        try
-        {
-            password = Secret.password_lookupv_sync(pwSchema, attributes, null);
-        }
-        catch(GLib.Error e)
-        {
-            Logger.error("InstaAPI addBookmark: " + e.message);
-        }
+		string password = "";
+		try
+		{
+			password = Secret.password_lookupv_sync(pwSchema, attributes, null);
+		}
+		catch(GLib.Error e)
+		{
+			Logger.error("InstaAPI addBookmark: " + e.message);
+		}
 
-        var session = new Soup.Session();
+		var session = new Soup.Session();
 		session.user_agent = Constants.USER_AGENT;
-        string message  = "user_id=" + settings.get_string("user-id")
-        				+ "&username=" + settings.get_string("username")
-                        + "&password=" + password
-                        + "&url=" + GLib.Uri.escape_string(url);
+		string message  = "user_id=" + settings.get_string("user-id")
+		                  + "&username=" + settings.get_string("username")
+		                  + "&password=" + password
+		                  + "&url=" + GLib.Uri.escape_string(url);
 
-        Logger.debug("InstaAPI: " + message);
+		Logger.debug("InstaAPI: " + message);
 
-        var message_soup = new Soup.Message("POST", "https://www.instapaper.com/api/add");
-        message_soup.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message.data);
+		var message_soup = new Soup.Message("POST", "https://www.instapaper.com/api/add");
+		message_soup.set_request("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, message.data);
 
-        if(Settings.tweaks().get_boolean("do-not-track"))
-				message_soup.request_headers.append("DNT", "1");
+		if(Settings.tweaks().get_boolean("do-not-track"))
+			message_soup.request_headers.append("DNT", "1");
 
 		session.send_message(message_soup);
 		string response = (string)message_soup.response_body.flatten().data;
 
-        if(response == null || response == "")
+		if(response == null || response == "")
 			return false;
 
 		Logger.debug("InstaAPI: " + response);
 
-        return true;
-    }
+		return true;
+	}
 
-    public bool logout(string id)
-    {
+	public bool logout(string id)
+	{
 		Logger.debug(@"InstaAPI.logout($id)");
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", @"/org/gnome/feedreader/share/instapaper/$id/");
-        var pwSchema = new Secret.Schema("org.gnome.feedreader.instapaper.password",
-                                        Secret.SchemaFlags.NONE, "userID", Secret.SchemaAttributeType.STRING);
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", @"/org/gnome/feedreader/share/instapaper/$id/");
+		var pwSchema = new Secret.Schema("org.gnome.feedreader.instapaper.password",
+		                                 Secret.SchemaFlags.NONE, "userID", Secret.SchemaAttributeType.STRING);
 
-        var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
-        attributes["userID"] = settings.get_string("user-id");
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
+		attributes["userID"] = settings.get_string("user-id");
 		bool removed = false;
 
-        Secret.password_clearv.begin(pwSchema, attributes, null, (obj, async_res) => {
+		Secret.password_clearv.begin(pwSchema, attributes, null, (obj, async_res) => {
 			try
 			{
-				removed = Secret.password_clearv.end(async_res);
-				if(!removed)
+			    removed = Secret.password_clearv.end(async_res);
+			    if(!removed)
 					Logger.error(@"Could not delete password of InstaAPI account $id");
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("InstaAPI.logout: %s".printf(e.message));
+			    Logger.error("InstaAPI.logout: %s".printf(e.message));
 			}
-        });
+		});
 
-        var keys = settings.list_keys();
+		var keys = settings.list_keys();
 		foreach(string key in keys)
 		{
 			settings.reset(key);
 		}
 
-        var array = Settings.share("instapaper").get_strv("account-ids");
+		var array = Settings.share("instapaper").get_strv("account-ids");
 
-    	string[] array2 = {};
-    	foreach(string i in array)
+		string[] array2 = {};
+		foreach(string i in array)
 		{
 			if(i != id)
 				array2 += i;
@@ -234,21 +232,21 @@ public class FeedReader.InstaAPI : ShareAccountInterface, Peas.ExtensionBase {
 		Settings.share("instapaper").set_strv("account-ids", array2);
 		deleteAccount(id);
 
-        return true;
-    }
+		return true;
+	}
 
-    public string getIconName()
-    {
-        return "feed-share-instapaper";
-    }
+	public string getIconName()
+	{
+		return "feed-share-instapaper";
+	}
 
-    public string getUsername(string id)
-    {
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/instapaper/%s/".printf(id));
-        return settings.get_string("username");
-    }
+	public string getUsername(string id)
+	{
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/instapaper/%s/".printf(id));
+		return settings.get_string("username");
+	}
 
-    public bool needSetup()
+	public bool needSetup()
 	{
 		return true;
 	}
@@ -259,41 +257,41 @@ public class FeedReader.InstaAPI : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public bool useSystemAccounts()
-    {
-        return false;
-    }
+	{
+		return false;
+	}
 
-    public string pluginID()
-    {
-        return "instapaper";
-    }
+	public string pluginID()
+	{
+		return "instapaper";
+	}
 
-    public string pluginName()
-    {
-        return "Instapaper";
-    }
+	public string pluginName()
+	{
+		return "Instapaper";
+	}
 
-    public string getURL(string token)
-    {
-        return "";
-    }
+	public string getURL(string token)
+	{
+		return "";
+	}
 
-    public ServiceSetup? newSetup_withID(string id, string username)
-    {
-        return new InstapaperSetup(id, this, username);
-    }
+	public ServiceSetup ? newSetup_withID(string id, string username)
+	{
+		return new InstapaperSetup(id, this, username);
+	}
 
-    public ServiceSetup? newSetup()
-    {
-        return new InstapaperSetup(null, this);
-    }
+	public ServiceSetup ? newSetup()
+	{
+		return new InstapaperSetup(null, this);
+	}
 
-	public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSystemAccount(string id, string username)
 	{
 		return null;
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ShareForm ? shareWidget(string url)
 	{
 		return null;
 	}

--- a/plugins/share/Instapaper/InstapaperSetup.vala
+++ b/plugins/share/Instapaper/InstapaperSetup.vala
@@ -20,7 +20,7 @@ public class FeedReader.InstapaperSetup : ServiceSetup {
 	private Gtk.Revealer m_login_revealer;
 	private InstaAPI m_api;
 
-	public InstapaperSetup(string? id, InstaAPI api, string username = "")
+	public InstapaperSetup(string ? id, InstaAPI api, string username = "")
 	{
 		bool loggedIN = false;
 		if(username != "")
@@ -39,8 +39,8 @@ public class FeedReader.InstapaperSetup : ServiceSetup {
 		grid.margin_bottom = 10;
 		grid.margin_top = 5;
 
-        m_userEntry = new Gtk.Entry();
-        m_passEntry = new Gtk.Entry();
+		m_userEntry = new Gtk.Entry();
+		m_passEntry = new Gtk.Entry();
 		m_passEntry.set_input_purpose(Gtk.InputPurpose.PASSWORD);
 		m_passEntry.set_visibility(false);
 
@@ -52,10 +52,10 @@ public class FeedReader.InstapaperSetup : ServiceSetup {
 			login();
 		});
 
-        grid.attach(new Gtk.Label(_("Username:")), 0, 0, 1, 1);
-        grid.attach(new Gtk.Label(_("Password:")), 0, 1, 1, 1);
-        grid.attach(m_userEntry, 1, 0, 1, 1);
-        grid.attach(m_passEntry, 1, 1, 1, 1);
+		grid.attach(new Gtk.Label(_("Username:")), 0, 0, 1, 1);
+		grid.attach(new Gtk.Label(_("Password:")), 0, 1, 1, 1);
+		grid.attach(m_userEntry, 1, 0, 1, 1);
+		grid.attach(m_passEntry, 1, 1, 1, 1);
 
 		m_login_revealer = new Gtk.Revealer();
 		m_login_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
@@ -69,7 +69,6 @@ public class FeedReader.InstapaperSetup : ServiceSetup {
 		if(id != null)
 			m_id = id;
 	}
-
 
 	public override void login()
 	{

--- a/plugins/share/Pocket/PocketAPI.vala
+++ b/plugins/share/Pocket/PocketAPI.vala
@@ -14,30 +14,30 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.PocketSecrets {
-	const string base_uri			= "https://getpocket.com/v3/";
-	const string oauth_consumer_key		= "43273-30a11c29b5eeabfa905df168";
-	const string oauth_callback			= "feedreader://pocket";
+	const string base_uri           = "https://getpocket.com/v3/";
+	const string oauth_consumer_key     = "43273-30a11c29b5eeabfa905df168";
+	const string oauth_callback         = "feedreader://pocket";
 }
 
 public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 
-    public PocketAPI()
-    {
+	public PocketAPI()
+	{
 
-    }
+	}
 
 	public void setupSystemAccounts(Gee.ArrayList<ShareAccount> accounts)
 	{
 		try
 		{
-			Goa.Client? client = new Goa.Client.sync();
+			Goa.Client ? client = new Goa.Client.sync();
 			if(client != null)
 			{
 				var goaAccounts = client.get_accounts();
 				foreach(var object in goaAccounts)
 				{
 					if(object.account.provider_type == "pocket"
-					&& !object.account.read_later_disabled)
+					   && !object.account.read_later_disabled)
 					{
 						accounts.add(
 							new ShareAccount(
@@ -47,8 +47,8 @@ public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 								getIconName(),
 								pluginName(),
 								true
-							)
-						);
+								)
+							);
 					}
 				}
 			}
@@ -63,65 +63,64 @@ public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 		}
 	}
 
-    public string getRequestToken()
-    {
-    	Logger.debug("PocketAPI: get request token");
-        var session = new Soup.Session();
+	public string getRequestToken()
+	{
+		Logger.debug("PocketAPI: get request token");
+		var session = new Soup.Session();
 		session.user_agent = Constants.USER_AGENT;
-        string message = "consumer_key=" + PocketSecrets.oauth_consumer_key + "&redirect_uri=" + PocketSecrets.oauth_callback;
+		string message = "consumer_key=" + PocketSecrets.oauth_consumer_key + "&redirect_uri=" + PocketSecrets.oauth_callback;
 
-        var message_soup = new Soup.Message("POST", "https://getpocket.com/v3/oauth/request");
-        message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
+		var message_soup = new Soup.Message("POST", "https://getpocket.com/v3/oauth/request");
+		message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
 
-        if(Settings.tweaks().get_boolean("do-not-track"))
-				message_soup.request_headers.append("DNT", "1");
+		if(Settings.tweaks().get_boolean("do-not-track"))
+			message_soup.request_headers.append("DNT", "1");
 
 		session.send_message(message_soup);
 
-        string response = (string)message_soup.response_body.flatten().data;
-        return response.substring(response.index_of_char('=')+1);
-    }
+		string response = (string)message_soup.response_body.flatten().data;
+		return response.substring(response.index_of_char('=') + 1);
+	}
 
-    public bool getAccessToken(string id, string requestToken)
-    {
-        var session = new Soup.Session();
+	public bool getAccessToken(string id, string requestToken)
+	{
+		var session = new Soup.Session();
 		session.user_agent = Constants.USER_AGENT;
-        string message = "consumer_key=" + PocketSecrets.oauth_consumer_key + "&code=" + requestToken;
+		string message = "consumer_key=" + PocketSecrets.oauth_consumer_key + "&code=" + requestToken;
 
-        var message_soup = new Soup.Message("POST", "https://getpocket.com/v3/oauth/authorize");
-        message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
+		var message_soup = new Soup.Message("POST", "https://getpocket.com/v3/oauth/authorize");
+		message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
 
-        if(Settings.tweaks().get_boolean("do-not-track"))
-				message_soup.request_headers.append("DNT", "1");
+		if(Settings.tweaks().get_boolean("do-not-track"))
+			message_soup.request_headers.append("DNT", "1");
 
 		session.send_message(message_soup);
 
-        if((string)message_soup.response_body.flatten().data == null
-		|| (string)message_soup.response_body.flatten().data == "")
+		if((string)message_soup.response_body.flatten().data == null
+		   || (string)message_soup.response_body.flatten().data == "")
 			return false;
 
-        string response = (string)message_soup.response_body.flatten().data;
-        Logger.debug(response);
-        int tokenStart = response.index_of_char('=')+1;
-        int tokenEnd = response.index_of_char('&', tokenStart);
-        int userStart = response.index_of_char('=', tokenEnd)+1;
+		string response = (string)message_soup.response_body.flatten().data;
+		Logger.debug(response);
+		int tokenStart = response.index_of_char('=') + 1;
+		int tokenEnd = response.index_of_char('&', tokenStart);
+		int userStart = response.index_of_char('=', tokenEnd) + 1;
 
-        string accessToken = response.substring(tokenStart, tokenEnd-tokenStart);
-        string user = GLib.Uri.unescape_string(response.substring(userStart));
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/pocket/%s/".printf(id));
-        settings.set_string("oauth-access-token", accessToken);
-        settings.set_string("username", user);
+		string accessToken = response.substring(tokenStart, tokenEnd - tokenStart);
+		string user = GLib.Uri.unescape_string(response.substring(userStart));
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/pocket/%s/".printf(id));
+		settings.set_string("oauth-access-token", accessToken);
+		settings.set_string("username", user);
 
-        var array = Settings.share("pocket").get_strv("account-ids");
-        array += id;
+		var array = Settings.share("pocket").get_strv("account-ids");
+		array += id;
 		Settings.share("pocket").set_strv("account-ids", array);
 
-        return true;
-    }
+		return true;
+	}
 
-
-    public bool addBookmark(string id, string url, bool system)
-    {
+	public bool addBookmark(string id, string url, bool system)
+	{
 		string oauthToken = "";
 
 		if(system)
@@ -129,14 +128,14 @@ public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 			Logger.debug(@"PocketAPI.addBookmark: $id is system account");
 			try
 			{
-				Goa.Client? client = new Goa.Client.sync();
+				Goa.Client ? client = new Goa.Client.sync();
 				if(client != null)
 				{
 					var accounts = client.get_accounts();
 					foreach(var object in accounts)
 					{
 						if(object.account.provider_type == "pocket"
-						&& object.account.id == id)
+						   && object.account.id == id)
 						{
 							int expires = -1;
 							object.oauth2_based.call_get_access_token_sync(out oauthToken, out expires);
@@ -160,44 +159,43 @@ public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 			oauthToken = settings.get_string("oauth-access-token");
 		}
 
-
-        var session = new Soup.Session();
+		var session = new Soup.Session();
 		session.user_agent = Constants.USER_AGENT;
-        string message = "url=" + GLib.Uri.escape_string(url)
-                        + "&consumer_key=" + PocketSecrets.oauth_consumer_key
-                        + "&access_token=" + oauthToken;
+		string message = "url=" + GLib.Uri.escape_string(url)
+		                 + "&consumer_key=" + PocketSecrets.oauth_consumer_key
+		                 + "&access_token=" + oauthToken;
 
-        Logger.debug("PocketAPI: " + message);
+		Logger.debug("PocketAPI: " + message);
 
-        var message_soup = new Soup.Message("POST", "https://getpocket.com/v3/add");
-        message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
+		var message_soup = new Soup.Message("POST", "https://getpocket.com/v3/add");
+		message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
 
-        if(Settings.tweaks().get_boolean("do-not-track"))
-				message_soup.request_headers.append("DNT", "1");
+		if(Settings.tweaks().get_boolean("do-not-track"))
+			message_soup.request_headers.append("DNT", "1");
 
 		session.send_message(message_soup);
 
-        if((string)message_soup.response_body.flatten().data == null
-		|| (string)message_soup.response_body.flatten().data == "")
+		if((string)message_soup.response_body.flatten().data == null
+		   || (string)message_soup.response_body.flatten().data == "")
 			return false;
 
-        return true;
-    }
+		return true;
+	}
 
-    public bool logout(string id)
-    {
+	public bool logout(string id)
+	{
 		Logger.debug(@"PocketAPI: logout($id)");
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/pocket/%s/".printf(id));
-    	var keys = settings.list_keys();
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/pocket/%s/".printf(id));
+		var keys = settings.list_keys();
 		foreach(string key in keys)
 		{
 			settings.reset(key);
 		}
 
-        var array = Settings.share("pocket").get_strv("account-ids");
-    	string[] array2 = {};
+		var array = Settings.share("pocket").get_strv("account-ids");
+		string[] array2 = {};
 
-    	foreach(string i in array)
+		foreach(string i in array)
 		{
 			if(i != id)
 				array2 += i;
@@ -205,28 +203,28 @@ public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 		Settings.share("pocket").set_strv("account-ids", array2);
 		deleteAccount(id);
 
-        return true;
-    }
+		return true;
+	}
 
-    public string getURL(string token)
-    {
-		return	"https://getpocket.com/auth/authorize?request_token="
-				+ token + "&redirect_uri="
-				+ GLib.Uri.escape_string(PocketSecrets.oauth_callback);
-    }
+	public string getURL(string token)
+	{
+		return "https://getpocket.com/auth/authorize?request_token="
+		       + token + "&redirect_uri="
+		       + GLib.Uri.escape_string(PocketSecrets.oauth_callback);
+	}
 
-    public string getIconName()
-    {
-        return "feed-share-pocket";
-    }
+	public string getIconName()
+	{
+		return "feed-share-pocket";
+	}
 
-    public string getUsername(string id)
-    {
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/pocket/%s/".printf(id));
-        return settings.get_string("username");
-    }
+	public string getUsername(string id)
+	{
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/pocket/%s/".printf(id));
+		return settings.get_string("username");
+	}
 
-    public bool needSetup()
+	public bool needSetup()
 	{
 		return true;
 	}
@@ -237,48 +235,48 @@ public class FeedReader.PocketAPI : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public bool useSystemAccounts()
-    {
+	{
 		try
 		{
-			Goa.Client? client = new Goa.Client.sync();
+			Goa.Client ? client = new Goa.Client.sync();
 			if(client != null)
 				return true;
 
-	        return false;
+			return false;
 		}
 		catch(GLib.Error e)
 		{
 			Logger.debug("PocketAPI.useSystemAccounts(): %s".printf(e.message));
 			return false;
 		}
-    }
+	}
 
-    public string pluginID()
-    {
-        return "pocket";
-    }
+	public string pluginID()
+	{
+		return "pocket";
+	}
 
-    public string pluginName()
-    {
-        return "Pocket";
-    }
+	public string pluginName()
+	{
+		return "Pocket";
+	}
 
-    public ServiceSetup? newSetup_withID(string id, string username)
-    {
-        return new PocketSetup(id, this, username);
-    }
+	public ServiceSetup ? newSetup_withID(string id, string username)
+	{
+		return new PocketSetup(id, this, username);
+	}
 
-    public ServiceSetup? newSetup()
-    {
-        return new PocketSetup(null, this);
-    }
+	public ServiceSetup ? newSetup()
+	{
+		return new PocketSetup(null, this);
+	}
 
-	public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSystemAccount(string id, string username)
 	{
 		return new PocketSetup(id, this, username, true);
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ShareForm ? shareWidget(string url)
 	{
 		return null;
 	}

--- a/plugins/share/Pocket/PocketSetup.vala
+++ b/plugins/share/Pocket/PocketSetup.vala
@@ -17,7 +17,7 @@ public class FeedReader.PocketSetup : ServiceSetup {
 
 	private PocketAPI m_api;
 
-	public PocketSetup(string? id, PocketAPI api, string username = "", bool system = false)
+	public PocketSetup(string ? id, PocketAPI api, string username = "", bool system = false)
 	{
 		bool loggedIN = false;
 		if(username != "")
@@ -30,7 +30,6 @@ public class FeedReader.PocketSetup : ServiceSetup {
 		if(id != null)
 			m_id = id;
 	}
-
 
 	public override void login()
 	{
@@ -48,27 +47,26 @@ public class FeedReader.PocketSetup : ServiceSetup {
 
 		}
 
-
 		m_login_button.set_label(_("waiting"));
 		m_login_button.set_sensitive(false);
 		FeedReaderApp.get_default().callback.connect((content) => {
 			if(content == PocketSecrets.oauth_callback)
 			{
-				if(m_api.getAccessToken(id, requestToken))
-				{
-					m_id = id;
-					m_api.addAccount(id, m_api.pluginID(), m_api.getUsername(id), m_api.getIconName(), m_api.pluginName());
-					m_iconStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.SLIDE_LEFT);
-					m_spinner.stop();
-					m_isLoggedIN = true;
-					m_label.set_label(m_api.getUsername(id));
-					m_labelStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.CROSSFADE);
-					m_login_button.clicked.disconnect(login);
-					m_login_button.clicked.connect(logout);
+			    if(m_api.getAccessToken(id, requestToken))
+			    {
+			        m_id = id;
+			        m_api.addAccount(id, m_api.pluginID(), m_api.getUsername(id), m_api.getIconName(), m_api.pluginName());
+			        m_iconStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.SLIDE_LEFT);
+			        m_spinner.stop();
+			        m_isLoggedIN = true;
+			        m_label.set_label(m_api.getUsername(id));
+			        m_labelStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.CROSSFADE);
+			        m_login_button.clicked.disconnect(login);
+			        m_login_button.clicked.connect(logout);
 				}
-				else
-				{
-					m_iconStack.set_visible_child_full("button", Gtk.StackTransitionType.SLIDE_RIGHT);
+			    else
+			    {
+			        m_iconStack.set_visible_child_full("button", Gtk.StackTransitionType.SLIDE_RIGHT);
 				}
 			}
 		});

--- a/plugins/share/Telegram/Telegram.vala
+++ b/plugins/share/Telegram/Telegram.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.Telegram : ShareAccountInterface, Peas.ExtensionBase {
 
 	string tg_text;
@@ -47,9 +46,9 @@ public class FeedReader.Telegram : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public string getIconName()
-    {
-        return "feed-share-telegram";
-    }
+	{
+		return "feed-share-telegram";
+	}
 
 	public string getUsername(string id)
 	{
@@ -67,36 +66,36 @@ public class FeedReader.Telegram : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public bool useSystemAccounts()
-    {
-        return false;
-    }
+	{
+		return false;
+	}
 
 	public string pluginID()
-    {
-        return "telegram";
-    }
+	{
+		return "telegram";
+	}
 
 	public string pluginName()
 	{
 		return _("Telegram");
 	}
 
-	public ServiceSetup? newSetup_withID(string id, string username)
-    {
-    	return new TelegramSetup(id, this, username);
-    }
-
-    public ServiceSetup? newSetup()
+	public ServiceSetup ? newSetup_withID(string id, string username)
 	{
-    	return new TelegramSetup(null, this);
+		return new TelegramSetup(id, this, username);
 	}
 
-	public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSetup()
+	{
+		return new TelegramSetup(null, this);
+	}
+
+	public ServiceSetup ? newSystemAccount(string id, string username)
 	{
 		return null;
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ShareForm ? shareWidget(string url)
 	{
 		var widget = new TelegramForm();
 		widget.share.connect(() => {

--- a/plugins/share/Telegram/TelegramForm.vala
+++ b/plugins/share/Telegram/TelegramForm.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.TelegramForm : ShareForm {
 
 	private Gtk.TextView m_textView;

--- a/plugins/share/Telegram/TelegramSetup.vala
+++ b/plugins/share/Telegram/TelegramSetup.vala
@@ -17,7 +17,7 @@ public class FeedReader.TelegramSetup : ServiceSetup {
 
 	private Telegram m_tg;
 
-	public TelegramSetup(string? id, Telegram tg, string username = "")
+	public TelegramSetup(string ? id, Telegram tg, string username = "")
 	{
 		bool loggedIN = false;
 		if(username != "")
@@ -31,7 +31,6 @@ public class FeedReader.TelegramSetup : ServiceSetup {
 		m_logout_button.set_label(_("Remove"));
 		m_id = m_tg.pluginID();
 	}
-
 
 	public override void login()
 	{

--- a/plugins/share/Twitter/TwitterAPI.vala
+++ b/plugins/share/Twitter/TwitterAPI.vala
@@ -14,10 +14,10 @@
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FeedReader.TwitterSecrets {
-	const string base_uri			= "https://api.twitter.com/";
-	const string key				= "hqScCfRLj5ImAtwypRKhbVpXo";
-	const string secret				= "wydD2zd6mgBUnlrdbqNqS0U0dJCWBJ9X0cqtdErk8Hn7aeperP";
-	const string callback			= "feedreader://twitter";
+	const string base_uri           = "https://api.twitter.com/";
+	const string key                = "hqScCfRLj5ImAtwypRKhbVpXo";
+	const string secret             = "wydD2zd6mgBUnlrdbqNqS0U0dJCWBJ9X0cqtdErk8Hn7aeperP";
+	const string callback           = "feedreader://twitter";
 }
 
 public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
@@ -26,25 +26,25 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 	private string m_tweet;
 	private int m_urlLength = 0;
 
-    public TwitterAPI()
-    {
+	public TwitterAPI()
+	{
 
-    }
+	}
 
 	public void setupSystemAccounts(Gee.ArrayList<ShareAccount> accounts)
 	{
 
 	}
 
-    public string getRequestToken()
-    {
+	public string getRequestToken()
+	{
 		Logger.debug("TwitterAPI: get request token");
 
 		m_oauthObject = new Rest.OAuthProxy (
-            TwitterSecrets.key,
-            TwitterSecrets.secret,
-            "https://api.twitter.com/",
-            false);
+			TwitterSecrets.key,
+			TwitterSecrets.secret,
+			"https://api.twitter.com/",
+			false);
 
 		try
 		{
@@ -56,10 +56,10 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 		}
 
 		return m_oauthObject.get_token();
-    }
+	}
 
-    public bool getAccessToken(string id, string verifier)
-    {
+	public bool getAccessToken(string id, string verifier)
+	{
 		try
 		{
 			m_oauthObject.access_token("oauth/access_token", verifier);
@@ -69,7 +69,7 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 			Logger.error("TwitterAPI.getAccessToken: %s".printf(e.message));
 		}
 
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
 		string token = m_oauthObject.get_token();
 		string secret = m_oauthObject.get_token_secret();
 		settings.set_string("oauth-access-token", token);
@@ -84,22 +84,22 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 
 		try
 		{
-            call.run();
-        }
-        catch(Error e)
-        {
-            Logger.error(e.message);
+			call.run();
+		}
+		catch(Error e)
+		{
+			Logger.error(e.message);
 		}
 
 		var parser = new Json.Parser();
-        try
+		try
 		{
-            parser.load_from_data(call.get_payload());
-        }
-        catch(Error e)
+			parser.load_from_data(call.get_payload());
+		}
+		catch(Error e)
 		{
-            Logger.error("Could not load response to Message from twitter");
-            Logger.error(e.message);
+			Logger.error("Could not load response to Message from twitter");
+			Logger.error(e.message);
 		}
 
 		var root_object = parser.get_root().get_object();
@@ -114,29 +114,26 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 			settings.set_string("username", root_object.get_string_member("name"));
 		}
 
-
-
-        var array = Settings.share("twitter").get_strv("account-ids");
-        array += id;
+		var array = Settings.share("twitter").get_strv("account-ids");
+		array += id;
 		Settings.share("twitter").set_strv("account-ids", array);
 
-        return true;
-    }
+		return true;
+	}
 
-
-    public bool addBookmark(string id, string url, bool system)
-    {
+	public bool addBookmark(string id, string url, bool system)
+	{
 		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
 		string token = settings.get_string("oauth-access-token");
 		string secret = settings.get_string("oauth-access-token-secret");
 
 		var oauthObject = new Rest.OAuthProxy.with_token (
-            TwitterSecrets.key,
-            TwitterSecrets.secret,
+			TwitterSecrets.key,
+			TwitterSecrets.secret,
 			token,
 			secret,
-            "https://api.twitter.com/",
-            false);
+			"https://api.twitter.com/",
+			false);
 
 		var call = oauthObject.new_call();
 		call.set_function("1.1/statuses/update.json");
@@ -145,30 +142,30 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 
 		try
 		{
-            call.run();
-        }
-        catch(Error e)
-        {
-            Logger.error(e.message);
+			call.run();
+		}
+		catch(Error e)
+		{
+			Logger.error(e.message);
 			return false;
 		}
 
-        return true;
-    }
+		return true;
+	}
 
-    public bool logout(string id)
-    {
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
-    	var keys = settings.list_keys();
+	public bool logout(string id)
+	{
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
+		var keys = settings.list_keys();
 		foreach(string key in keys)
 		{
 			settings.reset(key);
 		}
 
-        var array = Settings.share("twitter").get_strv("account-ids");
-    	string[] array2 = {};
+		var array = Settings.share("twitter").get_strv("account-ids");
+		string[] array2 = {};
 
-    	foreach(string i in array)
+		foreach(string i in array)
 		{
 			if(i != id)
 				array2 += i;
@@ -176,28 +173,28 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 		Settings.share("twitter").set_strv("account-ids", array2);
 		deleteAccount(id);
 
-        return true;
-    }
+		return true;
+	}
 
-    public string getURL(string token)
-    {
-		return	TwitterSecrets.base_uri
-				+ "oauth/authenticate"
-				+ "?oauth_token=" + token;
-    }
+	public string getURL(string token)
+	{
+		return TwitterSecrets.base_uri
+		       + "oauth/authenticate"
+		       + "?oauth_token=" + token;
+	}
 
-    public string getIconName()
-    {
-        return "feed-share-twitter";
-    }
+	public string getIconName()
+	{
+		return "feed-share-twitter";
+	}
 
-    public string getUsername(string id)
-    {
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
-        return settings.get_string("username");
-    }
+	public string getUsername(string id)
+	{
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
+		return settings.get_string("username");
+	}
 
-    public bool needSetup()
+	public bool needSetup()
 	{
 		return true;
 	}
@@ -208,36 +205,36 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 	}
 
 	public bool useSystemAccounts()
-    {
-        return false;
-    }
+	{
+		return false;
+	}
 
-    public string pluginID()
-    {
-        return "twitter";
-    }
+	public string pluginID()
+	{
+		return "twitter";
+	}
 
-    public string pluginName()
-    {
-        return "Twitter";
-    }
+	public string pluginName()
+	{
+		return "Twitter";
+	}
 
-    public ServiceSetup? newSetup_withID(string id, string username)
-    {
-        return new TwitterSetup(id, this, username);
-    }
+	public ServiceSetup ? newSetup_withID(string id, string username)
+	{
+		return new TwitterSetup(id, this, username);
+	}
 
-    public ServiceSetup? newSetup()
-    {
-        return new TwitterSetup(null, this);
-    }
+	public ServiceSetup ? newSetup()
+	{
+		return new TwitterSetup(null, this);
+	}
 
-	public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSystemAccount(string id, string username)
 	{
 		return null;
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ShareForm ? shareWidget(string url)
 	{
 		var widget = new TwitterForm(url);
 
@@ -255,7 +252,7 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 		if(m_urlLength > 0)
 			return m_urlLength;
 
-        var array = Settings.share("twitter").get_strv("account-ids");
+		var array = Settings.share("twitter").get_strv("account-ids");
 		string id = array[0];
 
 		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/twitter/%s/".printf(id));
@@ -263,12 +260,12 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 		string secret = settings.get_string("oauth-access-token-secret");
 
 		var oauthObject = new Rest.OAuthProxy.with_token (
-            TwitterSecrets.key,
-            TwitterSecrets.secret,
+			TwitterSecrets.key,
+			TwitterSecrets.secret,
 			token,
 			secret,
-            "https://api.twitter.com/",
-            false);
+			"https://api.twitter.com/",
+			false);
 
 		var call = oauthObject.new_call();
 		call.set_function("1.1/help/configuration.json");
@@ -276,16 +273,16 @@ public class FeedReader.TwitterAPI : ShareAccountInterface, Peas.ExtensionBase {
 
 		try
 		{
-            call.run();
-        }
-        catch(Error e){}
+			call.run();
+		}
+		catch(Error e) {}
 
 		var parser = new Json.Parser();
-        try
+		try
 		{
-            parser.load_from_data(call.get_payload());
-        }
-        catch(Error e){}
+			parser.load_from_data(call.get_payload());
+		}
+		catch(Error e) {}
 
 		var root_object = parser.get_root().get_object();
 		m_urlLength = (int)root_object.get_int_member("short_url_length");

--- a/plugins/share/Twitter/TwitterForm.vala
+++ b/plugins/share/Twitter/TwitterForm.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.TwitterForm : ShareForm {
 
 	private Gtk.TextView m_textView;
@@ -121,9 +120,9 @@ public class FeedReader.TwitterForm : ShareForm {
 		if(text.contains("$URL"))
 		{
 			if(m_url.length >= m_urlLength)
-				return (text.length-3) + m_urlLength;
+				return (text.length - 3) + m_urlLength;
 			else
-				return (text.length-3) + m_url.length;
+				return (text.length - 3) + m_url.length;
 		}
 
 		return text.length;

--- a/plugins/share/Twitter/TwitterSetup.vala
+++ b/plugins/share/Twitter/TwitterSetup.vala
@@ -17,7 +17,7 @@ public class FeedReader.TwitterSetup : ServiceSetup {
 
 	private TwitterAPI m_api;
 
-	public TwitterSetup(string? id, TwitterAPI api, string username = "")
+	public TwitterSetup(string ? id, TwitterAPI api, string username = "")
 	{
 		bool loggedIN = false;
 		if(username != "")
@@ -30,7 +30,6 @@ public class FeedReader.TwitterSetup : ServiceSetup {
 		if(id != null)
 			m_id = id;
 	}
-
 
 	public override void login()
 	{
@@ -54,30 +53,30 @@ public class FeedReader.TwitterSetup : ServiceSetup {
 
 			if(content.has_prefix(TwitterSecrets.callback))
 			{
-				int token_start = content.index_of("token=")+6;
-				int token_end = content.index_of("&", token_start);
-				string token = content.substring(token_start, token_end-token_start);
+			    int token_start = content.index_of("token=") + 6;
+			    int token_end = content.index_of("&", token_start);
+			    string token = content.substring(token_start, token_end - token_start);
 
-				int verifier_start = content.index_of("verifier=")+9;
-				string verifier = content.substring(verifier_start);
+			    int verifier_start = content.index_of("verifier=") + 9;
+			    string verifier = content.substring(verifier_start);
 
-				if(token == requestToken)
-				{
-					if(m_api.getAccessToken(id, verifier))
-					{
-						m_id = id;
-						m_api.addAccount(id, m_api.pluginID(), m_api.getUsername(id), m_api.getIconName(), m_api.pluginName());
-						m_iconStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.SLIDE_LEFT);
-						m_isLoggedIN = true;
-						m_spinner.stop();
-						m_label.set_label(m_api.getUsername(id));
-						m_labelStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.CROSSFADE);
-						m_login_button.clicked.disconnect(login);
-						m_login_button.clicked.connect(logout);
+			    if(token == requestToken)
+			    {
+			        if(m_api.getAccessToken(id, verifier))
+			        {
+			            m_id = id;
+			            m_api.addAccount(id, m_api.pluginID(), m_api.getUsername(id), m_api.getIconName(), m_api.pluginName());
+			            m_iconStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.SLIDE_LEFT);
+			            m_isLoggedIN = true;
+			            m_spinner.stop();
+			            m_label.set_label(m_api.getUsername(id));
+			            m_labelStack.set_visible_child_full("loggedIN", Gtk.StackTransitionType.CROSSFADE);
+			            m_login_button.clicked.disconnect(login);
+			            m_login_button.clicked.connect(logout);
 					}
-					else
-					{
-						m_iconStack.set_visible_child_full("button", Gtk.StackTransitionType.SLIDE_RIGHT);
+			        else
+			        {
+			            m_iconStack.set_visible_child_full("button", Gtk.StackTransitionType.SLIDE_RIGHT);
 					}
 				}
 

--- a/plugins/share/Wallabag/WallabagAPI.vala
+++ b/plugins/share/Wallabag/WallabagAPI.vala
@@ -15,35 +15,34 @@
 
 public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase {
 
-    public WallabagAPI()
-    {
+	public WallabagAPI()
+	{
 
-    }
+	}
 
-    public void setupSystemAccounts(Gee.ArrayList<ShareAccount> accounts)
-    {
+	public void setupSystemAccounts(Gee.ArrayList<ShareAccount> accounts)
+	{
 
-    }
+	}
 
-    public bool getAccessToken(string id, string username, string password, string clientID, string clientSecret, string baseURL)
-    {
+	public bool getAccessToken(string id, string username, string password, string clientID, string clientSecret, string baseURL)
+	{
 		Logger.debug("WallabagAPI getAccessToken");
-        var session = new Soup.Session();
-        session.user_agent = Constants.USER_AGENT;
-        string message = "grant_type=password"
-		 				+ "&client_id=" + clientID
-						+ "&client_secret=" + clientSecret
-						+ "&username=" + GLib.Uri.escape_string(username)
-						+ "&password=" + GLib.Uri.escape_string(password);
-
+		var session = new Soup.Session();
+		session.user_agent = Constants.USER_AGENT;
+		string message = "grant_type=password"
+		                 + "&client_id=" + clientID
+		                 + "&client_secret=" + clientSecret
+		                 + "&username=" + GLib.Uri.escape_string(username)
+		                 + "&password=" + GLib.Uri.escape_string(password);
 
 		string url = baseURL + "oauth/v2/token";
-        var message_soup = new Soup.Message("POST", url);
-        message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
+		var message_soup = new Soup.Message("POST", url);
+		message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
 		session.send_message(message_soup);
 
-        if((string)message_soup.response_body.flatten().data == null
-		|| (string)message_soup.response_body.flatten().data == "")
+		if((string)message_soup.response_body.flatten().data == null
+		   || (string)message_soup.response_body.flatten().data == "")
 		{
 			Logger.error("WallabagAPI - getAccessToken: no response");
 			Logger.error(url);
@@ -51,51 +50,49 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 			return false;
 		}
 
-        string response = (string)message_soup.response_body.flatten().data;
-        Logger.debug(response);
+		string response = (string)message_soup.response_body.flatten().data;
+		Logger.debug(response);
 
 		var parser = new Json.Parser();
-        try
-        {
-            parser.load_from_data(response);
-        }
-        catch (Error e)
-        {
-            Logger.error("Could not load response to Message from instapaper");
-            Logger.error(e.message);
-            return false;
-        }
+		try
+		{
+			parser.load_from_data(response);
+		}
+		catch (Error e)
+		{
+			Logger.error("Could not load response to Message from instapaper");
+			Logger.error(e.message);
+			return false;
+		}
 
-        var root_node = parser.get_root();
-        var root_object = root_node.get_object();
+		var root_node = parser.get_root();
+		var root_object = root_node.get_object();
 
-        if(!root_object.has_member("access_token"))
-        {
-            Logger.error("WallabagAPI.getAccessToken: no member access_token in response");
-            return false;
-        }
+		if(!root_object.has_member("access_token"))
+		{
+			Logger.error("WallabagAPI.getAccessToken: no member access_token in response");
+			return false;
+		}
 		string accessToken = root_object.get_string_member("access_token");
 
-
 		int64 now = (new DateTime.now_local()).to_unix();
-        if(!root_object.has_member("expires_in"))
-        {
-            Logger.error("WallabagAPI.getAccessToken: no member expires_in in response");
-            return false;
-        }
+		if(!root_object.has_member("expires_in"))
+		{
+			Logger.error("WallabagAPI.getAccessToken: no member expires_in in response");
+			return false;
+		}
 		int64 expires = root_object.get_int_member("expires_in");
 		//string refreshToken = root_object.get_string_member("refresh_token");
 
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
-        settings.set_string("oauth-access-token", accessToken);
-        settings.set_string("username", username);
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
+		settings.set_string("oauth-access-token", accessToken);
+		settings.set_string("username", username);
 		settings.set_int("access-token-expires", (int)(now + expires));
 		settings.set_string("url", baseURL);
-        settings.set_string("client-id", clientID);
+		settings.set_string("client-id", clientID);
 		settings.set_string("client-secret", clientSecret);
 
-
-        var array = Settings.share("wallabag").get_strv("account-ids");
+		var array = Settings.share("wallabag").get_strv("account-ids");
 		foreach(string i in array)
 		{
 			if(i == id)
@@ -104,32 +101,30 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 				return true;
 			}
 		}
-        array += id;
+		array += id;
 		Settings.share("wallabag").set_strv("account-ids", array);
 
-
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.wallabag.password", Secret.SchemaFlags.NONE,
-                                        "username", Secret.SchemaAttributeType.STRING,
-										"id", Secret.SchemaAttributeType.STRING);
+		                                  "username", Secret.SchemaAttributeType.STRING,
+		                                  "id", Secret.SchemaAttributeType.STRING);
 
-        var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
-        attributes["username"] = username;
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
+		attributes["username"] = username;
 		attributes["id"] = id;
-        try
-        {
-            Secret.password_storev_sync(pwSchema, attributes, Secret.COLLECTION_DEFAULT, "Feedreader: Wallabag login", password, null);
-        }
-        catch(GLib.Error e)
-        {
-            Logger.error("WallabagAPI - getAccessToken: " + e.message);
-        }
+		try
+		{
+			Secret.password_storev_sync(pwSchema, attributes, Secret.COLLECTION_DEFAULT, "Feedreader: Wallabag login", password, null);
+		}
+		catch(GLib.Error e)
+		{
+			Logger.error("WallabagAPI - getAccessToken: " + e.message);
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-
-    public bool addBookmark(string id, string url, bool system)
-    {
+	public bool addBookmark(string id, string url, bool system)
+	{
 		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
 
 		Logger.debug("WallabagAPI - addBookmark: " + url);
@@ -146,18 +141,18 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 
 		Logger.debug("WallabagAPI - addBookmark: token still valid");
 
-        var session = new Soup.Session();
-        session.user_agent = Constants.USER_AGENT;
-        string message = "url=" + GLib.Uri.escape_string(url);
+		var session = new Soup.Session();
+		session.user_agent = Constants.USER_AGENT;
+		string message = "url=" + GLib.Uri.escape_string(url);
 		string baseURL = settings.get_string("url");
 
-        var message_soup = new Soup.Message("POST", baseURL + "api/entries.json");
-        message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
+		var message_soup = new Soup.Message("POST", baseURL + "api/entries.json");
+		message_soup.set_request("application/x-www-form-urlencoded; charset=UTF8", Soup.MemoryUse.COPY, message.data);
 		message_soup.request_headers.append("Authorization", "Bearer " + settings.get_string("oauth-access-token"));
 		session.send_message(message_soup);
 
-        if((string)message_soup.response_body.flatten().data == null
-		|| (string)message_soup.response_body.flatten().data == "")
+		if((string)message_soup.response_body.flatten().data == null
+		   || (string)message_soup.response_body.flatten().data == "")
 		{
 			Logger.error("WallabagAPI - addBookmark: no response");
 			Logger.error(url);
@@ -165,25 +160,25 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 			return false;
 		}
 
-        return true;
-    }
+		return true;
+	}
 
-    public bool logout(string id)
-    {
+	public bool logout(string id)
+	{
 		Logger.debug("WallabagAPI - logout");
-        deletePassword(id);
+		deletePassword(id);
 
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
-    	var keys = settings.list_keys();
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
+		var keys = settings.list_keys();
 		foreach(string key in keys)
 		{
 			settings.reset(key);
 		}
 
-        var array = Settings.share("wallabag").get_strv("account-ids");
-    	string[] array2 = {};
+		var array = Settings.share("wallabag").get_strv("account-ids");
+		string[] array2 = {};
 
-    	foreach(string i in array)
+		foreach(string i in array)
 		{
 			if(i != id)
 				array2 += i;
@@ -191,8 +186,8 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 		Settings.share("wallabag").set_strv("account-ids", array2);
 		deleteAccount(id);
 
-        return true;
-    }
+		return true;
+	}
 
 	private bool accessTokenValid(string id)
 	{
@@ -209,25 +204,25 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 		return true;
 	}
 
-    public string getIconName()
-    {
-        return "feed-share-wallabag";
-    }
+	public string getIconName()
+	{
+		return "feed-share-wallabag";
+	}
 
-    public string getUsername(string id)
-    {
-        var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
-        return settings.get_string("username");
-    }
+	public string getUsername(string id)
+	{
+		var settings = new GLib.Settings.with_path("org.gnome.feedreader.share.account", "/org/gnome/feedreader/share/wallabag/%s/".printf(id));
+		return settings.get_string("username");
+	}
 
 	public string getPasswd(string id)
 	{
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.wallabag.password", Secret.SchemaFlags.NONE,
-                                        "username", Secret.SchemaAttributeType.STRING,
-										"id", Secret.SchemaAttributeType.STRING);
+		                                  "username", Secret.SchemaAttributeType.STRING,
+		                                  "id", Secret.SchemaAttributeType.STRING);
 
-        var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
-        attributes["username"] = getUsername(id);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
+		attributes["username"] = getUsername(id);
 		attributes["id"] = id;
 
 		string passwd = "";
@@ -253,72 +248,72 @@ public class FeedReader.WallabagAPI : ShareAccountInterface, Peas.ExtensionBase 
 	{
 		bool removed = false;
 		var pwSchema = new Secret.Schema ("org.gnome.feedreader.wallabag.password", Secret.SchemaFlags.NONE,
-                                        "username", Secret.SchemaAttributeType.STRING,
-										"id", Secret.SchemaAttributeType.STRING);
+		                                  "username", Secret.SchemaAttributeType.STRING,
+		                                  "id", Secret.SchemaAttributeType.STRING);
 
-        var attributes = new GLib.HashTable<string,string>(str_hash, str_equal);
-        attributes["username"] = getUsername(id);
+		var attributes = new GLib.HashTable<string, string>(str_hash, str_equal);
+		attributes["username"] = getUsername(id);
 		attributes["id"] = id;
 
-        Logger.debug(getUsername(id));
-        Logger.debug(id);
+		Logger.debug(getUsername(id));
+		Logger.debug(id);
 
 		Secret.password_clearv.begin(pwSchema, attributes, null, (obj, async_res) => {
 			try
 			{
-				removed = Secret.password_clearv.end(async_res);
+			    removed = Secret.password_clearv.end(async_res);
 
-                if(!removed)
-                    Logger.error(@"WallabagAPI: could not delete password of account $id");
+			    if(!removed)
+					Logger.error(@"WallabagAPI: could not delete password of account $id");
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("WallabagAPI.deletePassword: %s".printf(e.message));
+			    Logger.error("WallabagAPI.deletePassword: %s".printf(e.message));
 			}
 		});
 	}
 
-    public bool needSetup()
+	public bool needSetup()
 	{
 		return true;
 	}
 
-    public bool singleInstance()
+	public bool singleInstance()
 	{
 		return false;
 	}
 
-    public bool useSystemAccounts()
-    {
-        return false;
-    }
+	public bool useSystemAccounts()
+	{
+		return false;
+	}
 
-    public string pluginID()
-    {
-        return "wallabag";
-    }
+	public string pluginID()
+	{
+		return "wallabag";
+	}
 
-    public string pluginName()
-    {
-        return "wallabag";
-    }
+	public string pluginName()
+	{
+		return "wallabag";
+	}
 
-    public ServiceSetup? newSetup_withID(string id, string username)
-    {
-        return new WallabagSetup(id, this, username);
-    }
+	public ServiceSetup ? newSetup_withID(string id, string username)
+	{
+		return new WallabagSetup(id, this, username);
+	}
 
-    public ServiceSetup? newSetup()
-    {
-        return new WallabagSetup(null, this);
-    }
+	public ServiceSetup ? newSetup()
+	{
+		return new WallabagSetup(null, this);
+	}
 
-    public ServiceSetup? newSystemAccount(string id, string username)
+	public ServiceSetup ? newSystemAccount(string id, string username)
 	{
 		return null;
 	}
 
-	public ShareForm? shareWidget(string url)
+	public ShareForm ? shareWidget(string url)
 	{
 		return null;
 	}

--- a/plugins/share/Wallabag/WallabagSetup.vala
+++ b/plugins/share/Wallabag/WallabagSetup.vala
@@ -23,7 +23,7 @@ public class FeedReader.WallabagSetup : ServiceSetup {
 	private Gtk.Revealer m_login_revealer;
 	private WallabagAPI m_api;
 
-	public WallabagSetup(string? id, WallabagAPI api, string username = "")
+	public WallabagSetup(string ? id, WallabagAPI api, string username = "")
 	{
 		bool loggedIN = false;
 		if(username != "")
@@ -42,11 +42,11 @@ public class FeedReader.WallabagSetup : ServiceSetup {
 		grid.margin_bottom = 10;
 		grid.margin_top = 5;
 
-        m_urlEntry = new Gtk.Entry();
+		m_urlEntry = new Gtk.Entry();
 		m_idEntry = new Gtk.Entry();
 		m_secretEntry = new Gtk.Entry();
 		m_userEntry = new Gtk.Entry();
-        m_passEntry = new Gtk.Entry();
+		m_passEntry = new Gtk.Entry();
 		m_passEntry.set_input_purpose(Gtk.InputPurpose.PASSWORD);
 		m_passEntry.set_visibility(false);
 
@@ -85,13 +85,13 @@ public class FeedReader.WallabagSetup : ServiceSetup {
 		grid.attach(urlLabel, 0, 0, 1, 1);
 		grid.attach(idLabel, 0, 1, 1, 1);
 		grid.attach(secretLabel, 0, 2, 1, 1);
-        grid.attach(userLabel, 0, 3, 1, 1);
-        grid.attach(pwLabel, 0, 4, 1, 1);
-        grid.attach(m_urlEntry, 1, 0, 1, 1);
+		grid.attach(userLabel, 0, 3, 1, 1);
+		grid.attach(pwLabel, 0, 4, 1, 1);
+		grid.attach(m_urlEntry, 1, 0, 1, 1);
 		grid.attach(m_idEntry, 1, 1, 1, 1);
 		grid.attach(m_secretEntry, 1, 2, 1, 1);
 		grid.attach(m_userEntry, 1, 3, 1, 1);
-        grid.attach(m_passEntry, 1, 4, 1, 1);
+		grid.attach(m_passEntry, 1, 4, 1, 1);
 
 		m_login_revealer = new Gtk.Revealer();
 		m_login_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
@@ -105,7 +105,6 @@ public class FeedReader.WallabagSetup : ServiceSetup {
 		if(id != null)
 			m_id = id;
 	}
-
 
 	public override void login()
 	{

--- a/src/ActionCache.vala
+++ b/src/ActionCache.vala
@@ -24,7 +24,7 @@ public class FeedReader.ActionCache : GLib.Object {
 
 	private Gee.ArrayList<CachedAction> m_list;
 
-	private static ActionCache? m_cache = null;
+	private static ActionCache ? m_cache = null;
 
 	public static ActionCache get_default()
 	{
@@ -81,24 +81,24 @@ public class FeedReader.ActionCache : GLib.Object {
 	{
 		switch(action.getType())
 		{
-			case CachedActions.MARK_READ:
-			case CachedActions.MARK_UNREAD:
-			case CachedActions.MARK_STARRED:
-			case CachedActions.MARK_UNSTARRED:
-				removeOpposite(action);
-				break;
+		case CachedActions.MARK_READ:
+		case CachedActions.MARK_UNREAD:
+		case CachedActions.MARK_STARRED:
+		case CachedActions.MARK_UNSTARRED:
+			removeOpposite(action);
+			break;
 
-			case CachedActions.MARK_READ_FEED:
-				removeForFeed(action.getID());
-				break;
+		case CachedActions.MARK_READ_FEED:
+			removeForFeed(action.getID());
+			break;
 
-			case CachedActions.MARK_READ_CATEGORY:
-				removeForCategory(action.getID());
-				break;
+		case CachedActions.MARK_READ_CATEGORY:
+			removeForCategory(action.getID());
+			break;
 
-			case CachedActions.MARK_READ_ALL:
-				removeForALL();
-				break;
+		case CachedActions.MARK_READ_ALL:
+			removeForALL();
+			break;
 		}
 
 		m_list.add(action);
@@ -109,7 +109,7 @@ public class FeedReader.ActionCache : GLib.Object {
 		foreach(CachedAction a in m_list)
 		{
 			if(a.getID() == action.getID()
-			&& a.getType() == action.opposite())
+			   && a.getType() == action.opposite())
 			{
 				m_list.remove(a);
 				break;
@@ -122,7 +122,7 @@ public class FeedReader.ActionCache : GLib.Object {
 		foreach(CachedAction a in m_list)
 		{
 			if(a.getType() == CachedActions.MARK_READ
-			|| a.getType() == CachedActions.MARK_UNREAD)
+			   || a.getType() == CachedActions.MARK_UNREAD)
 			{
 				if(feedID == dbDaemon.get_default().getFeedIDofArticle(a.getID()))
 				{
@@ -140,7 +140,7 @@ public class FeedReader.ActionCache : GLib.Object {
 			foreach(CachedAction a in m_list)
 			{
 				if(a.getType() == CachedActions.MARK_READ_FEED
-				&& a.getID() == feedID)
+				   && a.getID() == feedID)
 				{
 					m_list.remove(a);
 				}
@@ -156,13 +156,13 @@ public class FeedReader.ActionCache : GLib.Object {
 		{
 			switch(a.getType())
 			{
-				case CachedActions.MARK_READ:
-				case CachedActions.MARK_UNREAD:
-				case CachedActions.MARK_READ_FEED:
-				case CachedActions.MARK_READ_CATEGORY:
-				case CachedActions.MARK_READ_ALL:
-					m_list.remove(a);
-					break;
+			case CachedActions.MARK_READ:
+			case CachedActions.MARK_UNREAD:
+			case CachedActions.MARK_READ_FEED:
+			case CachedActions.MARK_READ_CATEGORY:
+			case CachedActions.MARK_READ_ALL:
+				m_list.remove(a);
+				break;
 			}
 		}
 	}
@@ -178,7 +178,7 @@ public class FeedReader.ActionCache : GLib.Object {
 		foreach(CachedAction a in m_list)
 		{
 			if(a.getType() == type
-			&& a.getID() == articleID)
+			   && a.getID() == articleID)
 			{
 				if(type == CachedActions.MARK_STARRED)
 					return ArticleStatus.MARKED;
@@ -198,7 +198,7 @@ public class FeedReader.ActionCache : GLib.Object {
 			foreach(CachedAction action in m_list)
 			{
 				if(action.getType() == CachedActions.MARK_UNREAD
-				&& action.getID() == a.getArticleID())
+				   && action.getID() == a.getArticleID())
 					return ArticleStatus.UNREAD;
 			}
 		}
@@ -208,22 +208,22 @@ public class FeedReader.ActionCache : GLib.Object {
 			{
 				switch(action.getType())
 				{
-					case CachedActions.MARK_READ_ALL:
+				case CachedActions.MARK_READ_ALL:
+					return ArticleStatus.READ;
+
+				case CachedActions.MARK_READ_FEED:
+					if(action.getID() == a.getFeedID())
 						return ArticleStatus.READ;
+					break;
 
-					case CachedActions.MARK_READ_FEED:
-						if(action.getID() == a.getFeedID())
+				case CachedActions.MARK_READ_CATEGORY:
+					var feedIDs = dbDaemon.get_default().getFeedIDofCategorie(a.getArticleID());
+					foreach(string feedID in feedIDs)
+					{
+						if(feedID == a.getFeedID())
 							return ArticleStatus.READ;
-						break;
-
-					case CachedActions.MARK_READ_CATEGORY:
-						var feedIDs = dbDaemon.get_default().getFeedIDofCategorie(a.getArticleID());
-						foreach(string feedID in feedIDs)
-						{
-							if(feedID == a.getFeedID())
-								return ArticleStatus.READ;
-						}
-						break;
+					}
+					break;
 				}
 			}
 		}

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -16,12 +16,12 @@
 public class FeedReader.FeedServer : GLib.Object {
 
 	private bool m_pluginLoaded = false;
-	private string? m_plugName = null;
+	private string ? m_plugName = null;
 	private Peas.ExtensionSet m_extensions;
-	private FeedServerInterface? m_plugin;
+	private FeedServerInterface ? m_plugin;
 	private Peas.Engine m_engine;
 
-	private static FeedServer? m_server;
+	private static FeedServer ? m_server;
 
 	public static FeedServer get_default()
 	{
@@ -71,7 +71,6 @@ public class FeedReader.FeedServer : GLib.Object {
 			return false;
 		}
 
-
 		Logger.debug("feedserver: unload plugin %s".printf(m_plugName));
 		if(m_pluginLoaded)
 		{
@@ -112,7 +111,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		return m_pluginLoaded;
 	}
 
-	public void syncContent(GLib.Cancellable? cancellable = null)
+	public void syncContent(GLib.Cancellable ? cancellable = null)
 	{
 		if(!serverAvailable())
 		{
@@ -193,7 +192,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		dbDaemon.get_default().updateFTS();
 
 		int after = dbDaemon.get_default().getHighestRowID();
-		int newArticles = after-before;
+		int newArticles = after - before;
 		if(newArticles > 0)
 		{
 			Notification.send(newArticles);
@@ -202,20 +201,20 @@ public class FeedReader.FeedServer : GLib.Object {
 
 		switch(Settings.general().get_enum("drop-articles-after"))
 		{
-			case DropArticles.NEVER:
-	            break;
+		case DropArticles.NEVER:
+			break;
 
-			case DropArticles.ONE_WEEK:
-				dbDaemon.get_default().dropOldArtilces(1);
-				break;
+		case DropArticles.ONE_WEEK:
+			dbDaemon.get_default().dropOldArtilces(1);
+			break;
 
-			case DropArticles.ONE_MONTH:
-				dbDaemon.get_default().dropOldArtilces(4);
-				break;
+		case DropArticles.ONE_MONTH:
+			dbDaemon.get_default().dropOldArtilces(4);
+			break;
 
-			case DropArticles.SIX_MONTHS:
-				dbDaemon.get_default().dropOldArtilces(24);
-				break;
+		case DropArticles.SIX_MONTHS:
+			dbDaemon.get_default().dropOldArtilces(24);
+			break;
 		}
 
 		var now = new DateTime.now_local();
@@ -226,7 +225,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		return;
 	}
 
-	public void InitSyncContent(GLib.Cancellable? cancellable = null)
+	public void InitSyncContent(GLib.Cancellable ? cancellable = null)
 	{
 		Logger.debug("FeedServer: initial sync");
 
@@ -272,7 +271,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		syncProgress(_("Getting tagged articles"));
 		foreach(var tag_item in tags)
 		{
-			getArticles((Settings.general().get_int("max-articles")/8), ArticleStatus.ALL, tag_item.getTagID(), true, cancellable);
+			getArticles((Settings.general().get_int("max-articles") / 8), ArticleStatus.ALL, tag_item.getTagID(), true, cancellable);
 			if(cancellable != null && cancellable.is_cancelled())
 				return;
 		}
@@ -333,7 +332,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		}
 	}
 
-	public void grabContent(GLib.Cancellable? cancellable = null)
+	public void grabContent(GLib.Cancellable ? cancellable = null)
 	{
 		Logger.debug("FeedServer: grabContent");
 		var articles = dbDaemon.get_default().readUnfetchedArticles();
@@ -374,7 +373,7 @@ public class FeedReader.FeedServer : GLib.Object {
 						while(html.has_prefix(xml))
 						{
 							int end = html.index_of_char('>');
-							html = html.slice(end+1, html.length).chug();
+							html = html.slice(end + 1, html.length).chug();
 						}
 
 						Article.setHTML(html);
@@ -398,7 +397,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		}
 	}
 
-	private void downloadImages(Soup.Session session, article Article, GLib.Cancellable? cancellable = null)
+	private void downloadImages(Soup.Session session, article Article, GLib.Cancellable ? cancellable = null)
 	{
 		if(!Settings.general().get_boolean("download-images"))
 			return;
@@ -464,7 +463,7 @@ public class FeedReader.FeedServer : GLib.Object {
 			while(html.has_prefix(xml))
 			{
 				int end = html.index_of_char('>');
-				html = html.slice(end+1, html.length).chug();
+				html = html.slice(end + 1, html.length).chug();
 			}
 
 			string path = GLib.Environment.get_user_data_dir() + "/debug-article/%s.html".printf(title);
@@ -488,8 +487,8 @@ public class FeedReader.FeedServer : GLib.Object {
 					return;
 				}
 
-				output = output.replace("\n"," ");
-				output = output.replace("_"," ");
+				output = output.replace("\n", " ");
+				output = output.replace("_", " ");
 
 				path = GLib.Environment.get_user_data_dir() + "/debug-article/%s.txt".printf(title);
 
@@ -541,10 +540,10 @@ public class FeedReader.FeedServer : GLib.Object {
 		while(pos1 != -1)
 		{
 			pos2 = html.index_of("/>", pos1);
-			string broken_iframe = html.substring(pos1, pos2+2-pos1);
+			string broken_iframe = html.substring(pos1, pos2 + 2 - pos1);
 			string fixed_iframe = broken_iframe.substring(0, broken_iframe.length) + "></iframe>";
 			html = html.replace(broken_iframe, fixed_iframe);
-			int pos3 = html.index_of("<iframe", pos1+7);
+			int pos3 = html.index_of("<iframe", pos1 + 7);
 			if(pos3 == pos1)
 				break;
 			else
@@ -783,7 +782,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		return m_plugin.serverAvailable();
 	}
 
-	public bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg)
+	public bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg)
 	{
 		if(!m_pluginLoaded)
 			return false;
@@ -815,7 +814,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		m_plugin.renameFeed(feedID, title);
 	}
 
-	public void moveFeed(string feedID, string newCatID, string? currentCatID = null)
+	public void moveFeed(string feedID, string newCatID, string ? currentCatID = null)
 	{
 		if(!m_pluginLoaded)
 			return;
@@ -823,7 +822,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		m_plugin.moveFeed(feedID, newCatID, currentCatID);
 	}
 
-	public string createCategory(string title, string? parentID = null)
+	public string createCategory(string title, string ? parentID = null)
 	{
 		if(!m_pluginLoaded)
 			return "";
@@ -871,7 +870,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		m_plugin.importOPML(opml);
 	}
 
-	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null)
+	public bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null)
 	{
 		if(!m_pluginLoaded)
 			return false;
@@ -887,7 +886,7 @@ public class FeedReader.FeedServer : GLib.Object {
 		return m_plugin.getUnreadCount();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? feedID = null, bool isTagID = false, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet = ArticleStatus.ALL, string ? feedID = null, bool isTagID = false, GLib.Cancellable ? cancellable = null)
 	{
 		if(!m_pluginLoaded)
 			return;

--- a/src/Backend/FeedServerInterface.vala
+++ b/src/Backend/FeedServerInterface.vala
@@ -80,7 +80,7 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract bool serverAvailable();
 
-	public abstract bool addFeed(string feedURL, string? catID, string? newCatName, out string feedID, out string errmsg);
+	public abstract bool addFeed(string feedURL, string ? catID, string ? newCatName, out string feedID, out string errmsg);
 
 	public abstract void addFeeds(Gee.List<feed> feeds);
 
@@ -88,9 +88,9 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract void renameFeed(string feedID, string title);
 
-	public abstract void moveFeed(string feedID, string newCatID, string? currentCatID = null);
+	public abstract void moveFeed(string feedID, string newCatID, string ? currentCatID = null);
 
-	public abstract string createCategory(string title, string? parentID = null);
+	public abstract string createCategory(string title, string ? parentID = null);
 
 	public abstract void renameCategory(string catID, string title);
 
@@ -102,10 +102,10 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract void importOPML(string opml);
 
-	public abstract bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable? cancellable = null);
+	public abstract bool getFeedsAndCats(Gee.List<feed> feeds, Gee.List<category> categories, Gee.List<tag> tags, GLib.Cancellable ? cancellable = null);
 
 	public abstract int getUnreadCount();
 
-	public abstract void getArticles(int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? feedID = null, bool isTagID = false, GLib.Cancellable? cancellable = null);
+	public abstract void getArticles(int count, ArticleStatus whatToGet = ArticleStatus.ALL, string ? feedID = null, bool isTagID = false, GLib.Cancellable ? cancellable = null);
 
 }

--- a/src/Backend/OPMLparser.vala
+++ b/src/Backend/OPMLparser.vala
@@ -43,13 +43,13 @@ public class FeedReader.OPMLparser : GLib.Object {
 			{
 				switch(node->name)
 				{
-					case "head":
-						parseHead(node);
-						break;
+				case "head":
+					parseHead(node);
+					break;
 
-					case "body":
-						parseTree(node);
-						break;
+				case "body":
+					parseTree(node);
+					break;
 				}
 			}
 		}
@@ -69,23 +69,23 @@ public class FeedReader.OPMLparser : GLib.Object {
 			{
 				switch(node->name)
 				{
-					case "title":
-						Logger.debug("Title: " + node->get_content());
-						break;
+				case "title":
+					Logger.debug("Title: " + node->get_content());
+					break;
 
-					case "dateCreated":
-						Logger.debug("dateCreated: " + node->get_content());
-						break;
+				case "dateCreated":
+					Logger.debug("dateCreated: " + node->get_content());
+					break;
 
-					case "dateModified":
-						Logger.debug("dateModified: " + node->get_content());
-						break;
+				case "dateModified":
+					Logger.debug("dateModified: " + node->get_content());
+					break;
 				}
 			}
 		}
 	}
 
-	private void parseTree(Xml.Node* root, string? catID = null)
+	private void parseTree(Xml.Node* root, string ? catID = null)
 	{
 		m_level++;
 		Logger.debug(@"Parse OPML tree level $m_level");
@@ -107,7 +107,7 @@ public class FeedReader.OPMLparser : GLib.Object {
 		m_level--;
 	}
 
-	private void parseCat(Xml.Node* node, string? parentCatID = null)
+	private void parseCat(Xml.Node* node, string ? parentCatID = null)
 	{
 		string title = "No Title";
 		if(hasProp(node, "text"))
@@ -120,7 +120,7 @@ public class FeedReader.OPMLparser : GLib.Object {
 		parseTree(node, catID);
 	}
 
-	private void parseFeed(Xml.Node* node, string? catID = null)
+	private void parseFeed(Xml.Node* node, string ? catID = null)
 	{
 		if(node->get_prop("type") == "rss" || node->get_prop("type") == "atom")
 		{

--- a/src/CachedActionManager.vala
+++ b/src/CachedActionManager.vala
@@ -18,7 +18,7 @@ public class FeedReader.CachedActionManager : GLib.Object {
 	private CachedActions m_lastAction = CachedActions.NONE;
 	private string m_ids = "";
 
-	private static CachedActionManager? m_manager = null;
+	private static CachedActionManager ? m_manager = null;
 
 	public static CachedActionManager get_default()
 	{
@@ -32,7 +32,6 @@ public class FeedReader.CachedActionManager : GLib.Object {
 	{
 
 	}
-
 
 	public void markArticleRead(string id, ArticleStatus read)
 	{
@@ -92,7 +91,6 @@ public class FeedReader.CachedActionManager : GLib.Object {
 			return;
 		}
 
-
 		Logger.debug("CachedActionManager: executeActions");
 
 		var actions = dbDaemon.get_default().readCachedActions();
@@ -102,35 +100,35 @@ public class FeedReader.CachedActionManager : GLib.Object {
 			Logger.debug("CachedActionManager: executeActions %s %s".printf(action.getID(), action.getType().to_string()));
 			switch(action.getType())
 			{
-				case CachedActions.MARK_READ:
-				case CachedActions.MARK_UNREAD:
-					if(action.getType() != m_lastAction && m_ids != "")
-					{
-						m_ids += action.getID();
-						execute(m_ids.substring(1), m_lastAction);
-						m_lastAction = CachedActions.NONE;
-						m_ids = "";
-					}
-					else
-					{
-						m_ids += "," + action.getID();
-					}
-					break;
-				case CachedActions.MARK_STARRED:
-					FeedServer.get_default().setArticleIsMarked(action.getID(), ArticleStatus.MARKED);
-					break;
-				case CachedActions.MARK_UNSTARRED:
-					FeedServer.get_default().setArticleIsMarked(action.getID(), ArticleStatus.UNMARKED);
-					break;
-				case CachedActions.MARK_READ_FEED:
-					FeedServer.get_default().setFeedRead(action.getID());
-					break;
-				case CachedActions.MARK_READ_CATEGORY:
-					FeedServer.get_default().setCategoryRead(action.getID());
-					break;
-				case CachedActions.MARK_READ_ALL:
-					FeedServer.get_default().markAllItemsRead();
-					break;
+			case CachedActions.MARK_READ:
+			case CachedActions.MARK_UNREAD:
+				if(action.getType() != m_lastAction && m_ids != "")
+				{
+					m_ids += action.getID();
+					execute(m_ids.substring(1), m_lastAction);
+					m_lastAction = CachedActions.NONE;
+					m_ids = "";
+				}
+				else
+				{
+					m_ids += "," + action.getID();
+				}
+				break;
+			case CachedActions.MARK_STARRED:
+				FeedServer.get_default().setArticleIsMarked(action.getID(), ArticleStatus.MARKED);
+				break;
+			case CachedActions.MARK_UNSTARRED:
+				FeedServer.get_default().setArticleIsMarked(action.getID(), ArticleStatus.UNMARKED);
+				break;
+			case CachedActions.MARK_READ_FEED:
+				FeedServer.get_default().setFeedRead(action.getID());
+				break;
+			case CachedActions.MARK_READ_CATEGORY:
+				FeedServer.get_default().setCategoryRead(action.getID());
+				break;
+			case CachedActions.MARK_READ_ALL:
+				FeedServer.get_default().markAllItemsRead();
+				break;
 			}
 
 			m_lastAction = action.getType();
@@ -149,12 +147,12 @@ public class FeedReader.CachedActionManager : GLib.Object {
 		Logger.debug("CachedActionManager: execute %s %s".printf(ids, action.to_string()));
 		switch(action)
 		{
-			case CachedActions.MARK_READ:
-				FeedServer.get_default().setArticleIsRead(ids, ArticleStatus.READ);
-				break;
-			case CachedActions.MARK_UNREAD:
-				FeedServer.get_default().setArticleIsRead(ids, ArticleStatus.UNREAD);
-				break;
+		case CachedActions.MARK_READ:
+			FeedServer.get_default().setArticleIsRead(ids, ArticleStatus.READ);
+			break;
+		case CachedActions.MARK_UNREAD:
+			FeedServer.get_default().setArticleIsRead(ids, ArticleStatus.UNREAD);
+			break;
 		}
 	}
 

--- a/src/ContentGrabber/grabber.vala
+++ b/src/ContentGrabber/grabber.vala
@@ -15,8 +15,8 @@
 
 public class FeedReader.Grabber : GLib.Object {
 	private string m_articleURL;
-	private string? m_articleID;
-	private string? m_feedID;
+	private string ? m_articleID;
+	private string ? m_feedID;
 	private string m_rawHtml;
 	private string m_nexPageURL;
 	private GrabberConfig m_config;
@@ -28,13 +28,12 @@ public class FeedReader.Grabber : GLib.Object {
 	private bool m_foundSomething;
 	private bool m_singlePage;
 
-
 	public string m_author;
 	public string m_title;
 	public string m_date;
 	public string m_html;
 
-	public Grabber(Soup.Session session, string articleURL, string? articleID, string? feedID)
+	public Grabber(Soup.Session session, string articleURL, string ? articleID, string ? feedID)
 	{
 		m_articleURL = articleURL;
 		m_articleID = articleID;
@@ -82,12 +81,11 @@ public class FeedReader.Grabber : GLib.Object {
 			}
 		}
 
-
 		Logger.debug("Grabber: no config (%s.txt) - cutSubdomain - found for article: %s".printf(newHostName, m_articleURL));
 		return false;
 	}
 
-	public bool process(GLib.Cancellable? cancellable = null)
+	public bool process(GLib.Cancellable ? cancellable = null)
 	{
 		Logger.debug("Grabber: process article: " + m_articleURL);
 
@@ -116,7 +114,7 @@ public class FeedReader.Grabber : GLib.Object {
 				string ytHTML = "<div class=\"videoWrapper\"><iframe width=\"100%\" src=\"https://www.youtube.com/embed/%s\" frameborder=\"0\" allowfullscreen></iframe></div>";
 				int start = m_articleURL.index_of(youtube) + youtube.length;
 				int end = m_articleURL.index_of("?", start);
-				string id = m_articleURL.substring(start, (end == -1) ? -1 : end-start);
+				string id = m_articleURL.substring(start, (end == -1) ? -1 : end - start);
 
 				m_html = ytHTML.printf(id);
 				return true;
@@ -149,7 +147,6 @@ public class FeedReader.Grabber : GLib.Object {
 		if(!downloaded && !download())
 			return false;
 
-
 		Logger.debug("Grabber: download success");
 
 		prepArticle();
@@ -178,7 +175,7 @@ public class FeedReader.Grabber : GLib.Object {
 
 		m_session.send_message(message);
 		var params = new GLib.HashTable<string, string>(null, null);
-		string? contentType = message.response_headers.get_content_type(out params);
+		string ? contentType = message.response_headers.get_content_type(out params);
 		if(contentType != null)
 		{
 			if(contentType == "text/html")
@@ -197,10 +194,10 @@ public class FeedReader.Grabber : GLib.Object {
 		msg.restarted.connect(() => {
 			Logger.debug("Grabber: download redirected - " + msg.status_code.to_string());
 			if(msg.status_code == Soup.Status.MOVED_TEMPORARILY
-			|| msg.status_code == Soup.Status.MOVED_PERMANENTLY)
+			   || msg.status_code == Soup.Status.MOVED_PERMANENTLY)
 			{
-				m_articleURL = msg.uri.to_string(false);
-				Logger.debug(@"Grabber: new url is: $m_articleURL");
+			    m_articleURL = msg.uri.to_string(false);
+			    Logger.debug(@"Grabber: new url is: $m_articleURL");
 			}
 		});
 
@@ -234,7 +231,7 @@ public class FeedReader.Grabber : GLib.Object {
 			if(start != -1)
 			{
 				int end = m_rawHtml.index_of("\"", start);
-				locale = m_rawHtml.substring(start, end-start);
+				locale = m_rawHtml.substring(start, end - start);
 			}
 			else
 			{
@@ -243,7 +240,7 @@ public class FeedReader.Grabber : GLib.Object {
 				if(start != -1)
 				{
 					int end = m_rawHtml.index_of("\"", start);
-					locale = m_rawHtml.substring(start, end-start);
+					locale = m_rawHtml.substring(start, end - start);
 				}
 				else
 				{
@@ -265,7 +262,7 @@ public class FeedReader.Grabber : GLib.Object {
 		return true;
 	}
 
-	private bool parse(GLib.Cancellable? cancellable = null)
+	private bool parse(GLib.Cancellable ? cancellable = null)
 	{
 		m_nexPageURL = null;
 		Logger.debug("Grabber: start parsing");
@@ -293,7 +290,6 @@ public class FeedReader.Grabber : GLib.Object {
 		}
 
 		Logger.debug("Grabber: html parsed");
-
 
 		// get link to next page of article if there are more than one pages
 		if(m_config.getXPathNextPageURL() != null)
@@ -458,7 +454,7 @@ public class FeedReader.Grabber : GLib.Object {
 		// and http://blog.instapaper.com/post/730281947
 		Logger.debug("Grabber: strip instapaper and readability");
 		grabberUtils.stripNode(doc,
-				"//*[contains(concat(' ',normalize-space(@class),' '),' entry-unrelated ') or contains(concat(' ',normalize-space(@class),' '),' instapaper_ignore ')]");
+		                       "//*[contains(concat(' ',normalize-space(@class),' '),' entry-unrelated ') or contains(concat(' ',normalize-space(@class),' '),' instapaper_ignore ')]");
 
 		if(cancellable != null && cancellable.is_cancelled())
 		{
@@ -590,12 +586,12 @@ public class FeedReader.Grabber : GLib.Object {
 			Logger.debug("Grabber: date: %s".printf(m_date));
 	}
 
-	public string? getAuthor()
+	public string ? getAuthor()
 	{
 		return m_author;
 	}
 
-	public string? getTitle()
+	public string ? getTitle()
 	{
 		return m_title;
 	}

--- a/src/ContentGrabber/grabberConfig.vala
+++ b/src/ContentGrabber/grabberConfig.vala
@@ -264,7 +264,6 @@ public class FeedReader.GrabberConfig : GLib.Object {
 			Logger.debug("testURL: " + m_testURL);
 	}
 
-
 	public string getXPathNextPageURL()
 	{
 		return m_nextPageLink;

--- a/src/ContentGrabber/grabberUtils.vala
+++ b/src/ContentGrabber/grabberUtils.vala
@@ -54,7 +54,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return foundSomething;
 	}
 
-	public static string? getURL(Html.Doc* doc, string xpath)
+	public static string ? getURL(Html.Doc * doc, string xpath)
 	{
 		var cntx = new Xml.XPath.Context(doc);
 		var res = cntx.eval_expression(xpath);
@@ -78,7 +78,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return URL;
 	}
 
-	public static string? getValue(Html.Doc* doc, string xpath, bool remove = false)
+	public static string ? getValue(Html.Doc * doc, string xpath, bool remove = false)
 	{
 		Xml.XPath.Context cntx = new Xml.XPath.Context(doc);
 		Xml.XPath.Object* res = cntx.eval_expression(xpath);
@@ -207,8 +207,8 @@ public class FeedReader.grabberUtils : GLib.Object {
 		Xml.XPath.Object* res = cntx.eval_expression(query);
 
 		if(res != null
-		&& res->type == Xml.XPath.ObjectType.NODESET
-		&& res->nodesetval != null)
+		   && res->type == Xml.XPath.ObjectType.NODESET
+		   && res->nodesetval != null)
 		{
 			for(int i = 0; i < res->nodesetval->length(); ++i)
 			{
@@ -230,8 +230,8 @@ public class FeedReader.grabberUtils : GLib.Object {
 		Xml.XPath.Object* res = cntx.eval_expression(xpath);
 
 		if(res != null
-		&& res->type == Xml.XPath.ObjectType.NODESET
-		&& res->nodesetval != null)
+		   && res->type == Xml.XPath.ObjectType.NODESET
+		   && res->nodesetval != null)
 		{
 			for(int i = 0; i < res->nodesetval->length(); i++)
 			{
@@ -278,7 +278,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return true;
 	}
 
-	public static bool removeAttributes(Html.Doc* doc, string? tag, string attribute)
+	public static bool removeAttributes(Html.Doc* doc, string ? tag, string attribute)
 	{
 		Xml.XPath.Context cntx = new Xml.XPath.Context(doc);
 		Xml.XPath.Object* res;
@@ -307,7 +307,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return true;
 	}
 
-	public static bool addAttributes(Html.Doc* doc, string? tag, string attribute, string val)
+	public static bool addAttributes(Html.Doc* doc, string ? tag, string attribute, string val)
 	{
 		Xml.XPath.Context cntx = new Xml.XPath.Context(doc);
 		Xml.XPath.Object* res;
@@ -349,15 +349,15 @@ public class FeedReader.grabberUtils : GLib.Object {
 		Xml.XPath.Object* res = cntx.eval_expression(xpath);
 
 		if(res != null
-		&& res->type == Xml.XPath.ObjectType.NODESET
-		&& res->nodesetval != null)
+		   && res->type == Xml.XPath.ObjectType.NODESET
+		   && res->nodesetval != null)
 		{
 			for(int i = 0; i < res->nodesetval->length(); i++)
 			{
 				Xml.Node* node = res->nodesetval->item(i);
 				if(node->get_prop("class") != null
-				|| node->get_prop("id") != null
-				|| node->get_prop("src") != null)
+				   || node->get_prop("id") != null
+				   || node->get_prop("src") != null)
 				{
 					node->unlink();
 					node->free_list();
@@ -368,7 +368,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		delete res;
 	}
 
-	public static string cleanString(string? text)
+	public static string cleanString(string ? text)
 	{
 		if(text == null)
 			return "";
@@ -406,7 +406,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 			baseURL = articleURL.substring(0, index);
 			if(baseURL.has_suffix("/"))
 			{
-				baseURL = baseURL.substring(0, baseURL.char_count()-1);
+				baseURL = baseURL.substring(0, baseURL.char_count() - 1);
 			}
 			return baseURL + incompleteURL;
 		}
@@ -417,8 +417,8 @@ public class FeedReader.grabberUtils : GLib.Object {
 			return baseURL + incompleteURL;
 		}
 		else if(!incompleteURL.has_prefix("http")
-		&& !incompleteURL.has_prefix("www")
-		&& !incompleteURL.has_prefix("//"))
+		        && !incompleteURL.has_prefix("www")
+		        && !incompleteURL.has_prefix("//"))
 		{
 			index = articleURL.index_of_char('/', index);
 			baseURL = articleURL.substring(0, index);
@@ -459,7 +459,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		if(cutSubdomain)
 		{
 			index = hostname.index_of_char('.');
-			if(index != -1 && hostname.index_of_char('.', index+1) != -1)
+			if(index != -1 && hostname.index_of_char('.', index + 1) != -1)
 			{
 				hostname = hostname.substring(index);
 			}
@@ -468,8 +468,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return hostname;
 	}
 
-
-	public static bool saveImages(Soup.Session session, Html.Doc* doc, string articleID, string feedID, GLib.Cancellable? cancellable = null)
+	public static bool saveImages(Soup.Session session, Html.Doc* doc, string articleID, string feedID, GLib.Cancellable ? cancellable = null)
 	{
 		Logger.debug("GrabberUtils: save Images: %s, %s".printf(articleID, feedID));
 		Xml.XPath.Context cntx = new Xml.XPath.Context(doc);
@@ -495,21 +494,21 @@ public class FeedReader.grabberUtils : GLib.Object {
 			{
 				if(
 					((node->get_prop("width") != null && int.parse(node->get_prop("width")) > 1)
-					|| (node->get_prop("width") == null))
-				&&
+					 || (node->get_prop("width") == null))
+					&&
 					((node->get_prop("height") != null && int.parse(node->get_prop("height")) > 1)
-					|| (node->get_prop("height") == null))
-				)
+					 || (node->get_prop("height") == null))
+					)
 				{
-					string? original = downloadImage(session, node->get_prop("src"), articleID, feedID, i+1);
+					string ? original = downloadImage(session, node->get_prop("src"), articleID, feedID, i + 1);
 
 					if(original == null)
 						continue;
 
-					string? parentURL = checkParent(session, node);
+					string ? parentURL = checkParent(session, node);
 					if(parentURL != null)
 					{
-						string parent = downloadImage(session, parentURL, articleID, feedID, i+1, true);
+						string parent = downloadImage(session, parentURL, articleID, feedID, i + 1, true);
 
 						if(compareImageSize(parent, original) > 0)
 						{
@@ -527,7 +526,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 					}
 					else
 					{
-						string? resized = resizeImg(original);
+						string ? resized = resizeImg(original);
 						if(resized != null)
 						{
 							node->set_prop("src", resized);
@@ -544,8 +543,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return true;
 	}
 
-
-	public static string? downloadImage(Soup.Session session, string? url, string articleID, string feedID, int nr, bool parent = false)
+	public static string ? downloadImage(Soup.Session session, string ? url, string articleID, string feedID, int nr, bool parent = false)
 	{
 		if(url == null)
 			return null;
@@ -595,7 +593,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 			if(status == 200)
 			{
 				var params = new GLib.HashTable<string, string>(null, null);
-				string? contentType = message_dlImg.response_headers.get_content_type(out params);
+				string ? contentType = message_dlImg.response_headers.get_content_type(out params);
 				if(contentType != null)
 				{
 					Logger.debug(@"Grabber: type $contentType");
@@ -606,9 +604,9 @@ public class FeedReader.grabberUtils : GLib.Object {
 				}
 
 				try{
-					FileUtils.set_contents(	localFilename,
-											(string)message_dlImg.response_body.flatten().data,
-											(long)message_dlImg.response_body.length);
+					FileUtils.set_contents( localFilename,
+					                        (string)message_dlImg.response_body.flatten().data,
+					                        (long)message_dlImg.response_body.length);
 				}
 				catch(GLib.FileError e)
 				{
@@ -626,16 +624,15 @@ public class FeedReader.grabberUtils : GLib.Object {
 		return localFilename.replace("?", "%3F");
 	}
 
-
 	// if image is >2000px then resize it to 1000px and add FR_huge attribute
 	// with url to original image
-	private static string? resizeImg(string path)
+	private static string ? resizeImg(string path)
 	{
 		try
 		{
-			int? height = 0;
-			int? width = 0;
-			Gdk.PixbufFormat? format = Gdk.Pixbuf.get_file_info(path, out width, out height);
+			int ? height = 0;
+			int ? width = 0;
+			Gdk.PixbufFormat ? format = Gdk.Pixbuf.get_file_info(path, out width, out height);
 
 			if(format == null || height == null || width == null)
 				return null;
@@ -668,27 +665,27 @@ public class FeedReader.grabberUtils : GLib.Object {
 	// -1: file1 < file2
 	private static int compareImageSize(string file1, string file2)
 	{
-		int? height1 = 0;
-		int? width1 = 0;
+		int ? height1 = 0;
+		int ? width1 = 0;
 		Gdk.Pixbuf.get_file_info(file1, out width1, out height1);
 
-		int? height2 = 0;
-		int? width2 = 0;
+		int ? height2 = 0;
+		int ? width2 = 0;
 		Gdk.Pixbuf.get_file_info(file2, out width2, out height2);
 
 		if(height1 == null
-		|| width1 == null
-		|| height2 == null
-		|| width2 == null)
+		   || width1 == null
+		   || height2 == null
+		   || width2 == null)
 		{
 			Logger.warning("Utils.compareImageSize: couldn't read image sizes");
 			return 0;
 		}
 
 		if(height1 == height2
-		&& width1 == width2)
+		   && width1 == width2)
 			return 0;
-		else if(height1*width1 > height2*width2)
+		else if(height1 * width1 > height2 * width2)
 			return 1;
 		else
 			return -1;
@@ -696,7 +693,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 
 	// check if the parent node is a link that points to a picture
 	// (most likely a bigger version of said picture)
-	private static string? checkParent(Soup.Session session, Xml.Node* node)
+	private static string ? checkParent(Soup.Session session, Xml.Node * node)
 	{
 		Logger.debug("Grabber: checkParent");
 		string smallImgURL = node->get_prop("src");
@@ -719,7 +716,7 @@ public class FeedReader.grabberUtils : GLib.Object {
 					return null;
 				session.send_message(message);
 				var params = new GLib.HashTable<string, string>(null, null);
-				string? contentType = message.response_headers.get_content_type(out params);
+				string ? contentType = message.response_headers.get_content_type(out params);
 				size = message.response_headers.get_content_length();
 				var message2 = new Soup.Message("HEAD", smallImgURL);
 				if(message2 == null)
@@ -758,12 +755,12 @@ public class FeedReader.grabberUtils : GLib.Object {
 		while(pos1 != -1)
 		{
 			pos2 = html.index_of("/>", pos1);
-			string broken_iframe = html.substring(pos1, pos2+2-pos1);
+			string broken_iframe = html.substring(pos1, pos2 + 2 - pos1);
 			Logger.debug("GrabberUtils: broken = %s".printf(broken_iframe));
-			string fixed_iframe = broken_iframe.substring(0, broken_iframe.length-2) + "></iframe>";
+			string fixed_iframe = broken_iframe.substring(0, broken_iframe.length - 2) + "></iframe>";
 			Logger.debug("GrabberUtils: fixed = %s".printf(fixed_iframe));
 			html = html.replace(broken_iframe, fixed_iframe);
-			int pos3 = html.index_of("<iframe", pos1+7);
+			int pos3 = html.index_of("<iframe", pos1 + 7);
 			if(pos3 == pos1 || pos3 > html.length)
 				break;
 			else

--- a/src/DBusConnection.vala
+++ b/src/DBusConnection.vala
@@ -26,7 +26,6 @@ namespace FeedReader {
 		public abstract void markAllItemsRead() throws IOError;
 		public abstract void updateBadge() throws IOError;
 
-
 		// OFFLINE / ONLINE
 		public abstract LoginResponse login(string plugin) throws IOError;
 		public abstract LoginResponse isLoggedIn() throws IOError;
@@ -69,7 +68,7 @@ namespace FeedReader {
 		public abstract void addFeed(string feedURL, string cat, bool isID, bool asynchron) throws IOError;
 		public abstract void removeFeed(string feedID) throws IOError;
 		public abstract void removeFeedOnlyFromCat(string m_feedID, string m_catID) throws IOError;
-		public abstract void moveFeed(string feedID, string currentCatID, string? newCatID = null) throws IOError;
+		public abstract void moveFeed(string feedID, string currentCatID, string ? newCatID = null) throws IOError;
 		public abstract void renameFeed(string feedID, string newName) throws IOError;
 		public abstract void importOPML(string opml) throws IOError;
 
@@ -90,10 +89,9 @@ namespace FeedReader {
 		public signal void updateSyncProgress(string progress);
 	}
 
-
 	public class DBusConnection : GLib.Object {
 
-		private static FeedDaemon? m_connection = null;
+		private static FeedDaemon ? m_connection = null;
 
 		public static FeedDaemon get_default()
 		{
@@ -179,8 +177,8 @@ namespace FeedReader {
 				Logger.debug("DBusConnection: setOffline");
 				if(FeedReaderApp.get_default().isOnline())
 				{
-					FeedReaderApp.get_default().setOnline(false);
-					ColumnView.get_default().setOffline();
+				    FeedReaderApp.get_default().setOnline(false);
+				    ColumnView.get_default().setOffline();
 				}
 			});
 
@@ -188,8 +186,8 @@ namespace FeedReader {
 				Logger.debug("DBusConnection: setOnline");
 				if(!FeedReaderApp.get_default().isOnline())
 				{
-					FeedReaderApp.get_default().setOnline(true);
-					ColumnView.get_default().setOnline();
+				    FeedReaderApp.get_default().setOnline(true);
+				    ColumnView.get_default().setOnline();
 				}
 			});
 

--- a/src/Daemon.vala
+++ b/src/Daemon.vala
@@ -45,7 +45,7 @@ namespace FeedReader {
 		public signal void opmlImported();
 		public signal void updateSyncProgress(string progress);
 
-		private static FeedDaemonServer? m_daemon;
+		private static FeedDaemonServer ? m_daemon;
 
 		public static FeedDaemonServer get_default()
 		{
@@ -75,11 +75,11 @@ namespace FeedReader {
 			GLib.NetworkMonitor.get_default().network_changed.connect((available) => {
 				if(available)
 				{
-					checkOnline();
+				    checkOnline();
 				}
 				else
 				{
-					setOffline();
+				    setOffline();
 				}
 			});
 		}
@@ -103,7 +103,6 @@ namespace FeedReader {
 		{
 			return AboutInfo.version;
 		}
-
 
 		public bool supportTags()
 		{
@@ -167,21 +166,21 @@ namespace FeedReader {
 			if(time == 0)
 				return;
 
-			m_timeout_source_id = GLib.Timeout.add_seconds_full(GLib.Priority.DEFAULT, time*60, () => {
+			m_timeout_source_id = GLib.Timeout.add_seconds_full(GLib.Priority.DEFAULT, time * 60, () => {
 				if(!Settings.state().get_boolean("currently-updating")
-				&& FeedServer.get_default().pluginLoaded())
+				   && FeedServer.get_default().pluginLoaded())
 				{
-			   		Logger.debug("daemon: Timeout!");
-					startSync(false);
+				    Logger.debug("daemon: Timeout!");
+				    startSync(false);
 				}
 				return true;
 			});
 		}
 
-		private void sync(bool initSync = false, GLib.Cancellable? cancellable = null)
+		private void sync(bool initSync = false, GLib.Cancellable ? cancellable = null)
 		{
 			if(Settings.state().get_boolean("currently-updating")
-			|| Settings.state().get_boolean("spring-cleaning"))
+			   || Settings.state().get_boolean("spring-cleaning"))
 			{
 				Logger.debug("Cant sync because login failed or sync/clean already ongoing");
 				return;
@@ -205,7 +204,7 @@ namespace FeedReader {
 			Settings.state().set_boolean("currently-updating", true);
 
 			if(!checkOnline()
-			|| (cancellable != null && cancellable.is_cancelled()))
+			   || (cancellable != null && cancellable.is_cancelled()))
 			{
 				finishSync();
 				return;
@@ -269,7 +268,6 @@ namespace FeedReader {
 			return true;
 		}
 
-
 		public async bool checkOnlineAsync()
 		{
 			if(!FeedServer.get_default().pluginLoaded())
@@ -327,7 +325,6 @@ namespace FeedReader {
 			{
 				setOffline();
 			}
-
 
 			Logger.debug("daemon: login status = " + m_loggedin.to_string());
 			return m_loggedin;
@@ -399,7 +396,6 @@ namespace FeedReader {
 					callAsync.begin((owned)pl, (obj, res) => { callAsync.end(res); });
 				}
 
-
 				asyncPayload pl = () => { dbDaemon.get_default().update_article(articleID, "marked", status); };
 				callAsync.begin((owned)pl, (obj, res) => {
 					callAsync.end(res);
@@ -407,7 +403,6 @@ namespace FeedReader {
 				});
 			}
 		}
-
 
 		public string createTag(string caption)
 		{
@@ -630,14 +625,14 @@ namespace FeedReader {
 			});
 		}
 
-		public string addCategory(string title, string? parentID = null, bool createLocally = false)
+		public string addCategory(string title, string ? parentID = null, bool createLocally = false)
 		{
 			Logger.debug("daemon: addCategory " + title);
 			string catID = FeedServer.get_default().createCategory(title, parentID);
 
 			if(createLocally)
 			{
-				string? parent = parentID;
+				string ? parent = parentID;
 				int level = 1;
 				if(parentID == null || parentID == "")
 				{
@@ -646,7 +641,7 @@ namespace FeedReader {
 				else
 				{
 					var parentCat = dbDaemon.get_default().read_category(parentID);
-					level = parentCat.getLevel()+1;
+					level = parentCat.getLevel() + 1;
 				}
 
 				var cat = new category(catID, title, 0, 99, parent, level);
@@ -710,7 +705,7 @@ namespace FeedReader {
 			});
 		}
 
-		public void moveFeed(string feedID, string currentCatID, string? newCatID = null)
+		public void moveFeed(string feedID, string currentCatID, string ? newCatID = null)
 		{
 			asyncPayload pl = () => { FeedServer.get_default().moveFeed(feedID, newCatID, currentCatID); };
 			callAsync.begin((owned)pl, (obj, res) => { callAsync.end(res); });
@@ -724,9 +719,9 @@ namespace FeedReader {
 
 		public void addFeed(string feedURL, string cat, bool isID, bool asynchron)
 		{
-			string? catID = null;
-			string? newCatName = null;
-			string? feedID = null;
+			string ? catID = null;
+			string ? newCatName = null;
+			string ? feedID = null;
 			bool success = false;
 			string errmsg = "";
 
@@ -796,7 +791,7 @@ namespace FeedReader {
 		{
 #if WITH_LIBUNITY
 			if(!Settings.state().get_boolean("spring-cleaning")
-			&& Settings.tweaks().get_boolean("show-badge"))
+			   && Settings.tweaks().get_boolean("show-badge"))
 			{
 				var count = dbDaemon.get_default().get_unread_total();
 				Logger.debug("daemon: update badge count %u".printf(count));
@@ -841,13 +836,13 @@ namespace FeedReader {
 	{
 		try
 		{
-		    conn.register_object("/org/gnome/FeedReader/Daemon", FeedDaemonServer.get_default());
+			conn.register_object("/org/gnome/FeedReader/Daemon", FeedDaemonServer.get_default());
 		}
 		catch (IOError e)
 		{
-		    Logger.warning("daemon: Could not register service. Will shut down!");
-		    Logger.warning(e.message);
-		    exit(-1);
+			Logger.warning("daemon: Could not register service. Will shut down!");
+			Logger.warning(e.message);
+			exit(-1);
 		}
 		Logger.debug("daemon: bus aquired");
 	}
@@ -863,10 +858,9 @@ namespace FeedReader {
 
 	private static bool version = false;
 	private static bool unreadCount = false;
-	private static string? grabArticle = null;
-	private static string? grabImages = null;
-	private static string? articleUrl = null;
-
+	private static string ? grabArticle = null;
+	private static string ? grabImages = null;
+	private static string ? articleUrl = null;
 
 	int main(string[] args)
 	{
@@ -893,10 +887,10 @@ namespace FeedReader {
 
 		if(unreadCount)
 		{
-			var old_stdout =(owned)stdout;
+			var old_stdout = (owned)stdout;
 			stdout = FileStream.open("/dev/null", "w");
 			Logger.init();
-			stdout =(owned)old_stdout;
+			stdout = (owned)old_stdout;
 			stdout.printf("%u\n", dbDaemon.get_default().get_unread_total());
 			return 0;
 		}
@@ -925,16 +919,16 @@ namespace FeedReader {
 		dbDaemon.get_default();
 
 		Bus.own_name (BusType.SESSION, "org.gnome.FeedReader.Daemon", BusNameOwnerFlags.NONE,
-				      on_bus_aquired,
-				      () => {
-				      			Settings.state().set_boolean("currently-updating", false);
-								Settings.state().set_boolean("spring-cleaning", false);
-				      },
-				      () => {
-				      			Logger.warning("daemon: Could not aquire name (already running). Will shut down!");
-				          		exit(-1);
-				          	}
-				      );
+		              on_bus_aquired,
+		              () => {
+			Settings.state().set_boolean("currently-updating", false);
+			Settings.state().set_boolean("spring-cleaning", false);
+		},
+		              () => {
+			Logger.warning("daemon: Could not aquire name (already running). Will shut down!");
+			exit(-1);
+		}
+		              );
 		var mainloop = new GLib.MainLoop();
 		mainloop.run();
 		return 0;

--- a/src/Enums.vala
+++ b/src/Enums.vala
@@ -22,8 +22,8 @@ namespace FeedReader {
 
 		public string to_string()
 		{
- 			return ((int)this).to_string();
- 		}
+			return ((int)this).to_string();
+		}
 	}
 
 	public enum ArticleListState {
@@ -33,8 +33,8 @@ namespace FeedReader {
 	}
 
 	public enum DragTarget {
-	    TAG,
-	    FEED,
+		TAG,
+		FEED,
 		CAT
 	}
 
@@ -194,8 +194,8 @@ namespace FeedReader {
 
 		public string to_string()
 		{
- 			return ((int)this).to_string();
- 		}
+			return ((int)this).to_string();
+		}
 	}
 
 	public enum ArticleListBalance {

--- a/src/FavIconCache.vala
+++ b/src/FavIconCache.vala
@@ -16,7 +16,7 @@
 public class FeedReader.FavIconCache : GLib.Object {
 
 	private Gee.HashMap<string, Gdk.Pixbuf> m_map;
-	private static FavIconCache? m_cache = null;
+	private static FavIconCache ? m_cache = null;
 
 	public static FavIconCache get_default()
 	{
@@ -51,8 +51,8 @@ public class FeedReader.FavIconCache : GLib.Object {
 				}
 			}
 			var enumerator = iconDirectory.enumerate_children(GLib.FileAttribute.STANDARD_NAME, 0);
-			GLib.FileInfo? fileInfo = null;
-			GLib.File? file = null;
+			GLib.FileInfo ? fileInfo = null;
+			GLib.File ? file = null;
 
 			while(true)
 			{
@@ -115,7 +115,7 @@ public class FeedReader.FavIconCache : GLib.Object {
 		return m_map.has_key(iconName);
 	}
 
-	public Gdk.Pixbuf? getIcon(string name, bool firstTry = true)
+	public Gdk.Pixbuf ? getIcon(string name, bool firstTry = true)
 	{
 		string fixedName = name.replace("/", "_").replace(".", "_");
 

--- a/src/FeedReader.vala
+++ b/src/FeedReader.vala
@@ -24,9 +24,8 @@ namespace FeedReader {
 
 		private MainWindow m_window;
 		private bool m_online = true;
-		private static FeedReaderApp? m_app = null;
-		public signal void callback(string content);
-
+		private static FeedReaderApp ? m_app = null;
+		public signal void callback (string content);
 
 		public new static FeedReaderApp get_default()
 		{
@@ -90,7 +89,7 @@ namespace FeedReader {
 			if(args.length > 1)
 			{
 				Logger.debug("FeedReader: callback %s".printf(args[1]));
-				callback(args[1]);
+				callback (args[1]);
 			}
 
 			activate();
@@ -140,10 +139,9 @@ namespace FeedReader {
 
 		private FeedReaderApp()
 		{
-			GLib.Object(application_id: "org.gnome.FeedReader", flags: ApplicationFlags.HANDLES_COMMAND_LINE);
+			GLib.Object(application_id: "org.gnome.FeedReader", flags : ApplicationFlags.HANDLES_COMMAND_LINE);
 		}
 	}
-
 
 	public static int main (string[] args)
 	{
@@ -233,9 +231,9 @@ namespace FeedReader {
 
 	private static bool version = false;
 	private static bool about = false;
-	private static string? media = null;
-	private static string? pingURL = null;
-	private static string? feedURL = null;
+	private static string ? media = null;
+	private static string ? pingURL = null;
+	private static string ? feedURL = null;
 
 	static void show_about(string[] args)
 	{

--- a/src/LoginInterface.vala
+++ b/src/LoginInterface.vala
@@ -25,7 +25,7 @@ public interface FeedReader.LoginInterface : GLib.Object {
 
 	public abstract string getID();
 
-	public abstract Gtk.Box? getWidget();
+	public abstract Gtk.Box ? getWidget();
 
 	public abstract string iconName();
 

--- a/src/Model/Article.vala
+++ b/src/Model/Article.vala
@@ -23,7 +23,7 @@ public class FeedReader.article : GLib.Object {
 	private string m_feedID;
 	private Gee.ArrayList<string> m_tags;
 	private Gee.ArrayList<string> m_media;
-	private string? m_author;
+	private string ? m_author;
 	private ArticleStatus m_unread;
 	private ArticleStatus m_marked;
 	private int m_sortID;
@@ -32,23 +32,21 @@ public class FeedReader.article : GLib.Object {
 	private int m_lastModified;
 	private int m_pos;
 
-
-
-	public article (	string articleID,
-						string title,
-						string url,
-						string feedID,
-						ArticleStatus unread,
-						ArticleStatus marked,
-						string html,
-						string preview,
-						string? author,
-						GLib.DateTime date,
-						int sortID,
-						string tags,
-						string media,
-						string guidHash = "",
-						int lastModified = 0)
+	public article (    string articleID,
+	                    string title,
+	                    string url,
+	                    string feedID,
+	                    ArticleStatus unread,
+	                    ArticleStatus marked,
+	                    string html,
+	                    string preview,
+	                    string ? author,
+	                    GLib.DateTime date,
+	                    int sortID,
+	                    string tags,
+	                    string media,
+	                    string guidHash = "",
+	                    int lastModified = 0)
 	{
 		m_articleID = articleID;
 		m_title = title;
@@ -116,12 +114,12 @@ public class FeedReader.article : GLib.Object {
 		m_preview = preview;
 	}
 
-	public string? getAuthor()
+	public string ? getAuthor()
 	{
 		return m_author;
 	}
 
-	public void setAuthor(string? author)
+	public void setAuthor(string ? author)
 	{
 		m_author = author;
 	}
@@ -164,7 +162,7 @@ public class FeedReader.article : GLib.Object {
 			{
 				return m_date.format("%H:%M");
 			}
-			else if(date_day == now_day-1)
+			else if(date_day == now_day - 1)
 			{
 				return _("Yesterday") + m_date.format(", %H:%M");
 			}

--- a/src/Model/CachedAction.vala
+++ b/src/Model/CachedAction.vala
@@ -59,14 +59,14 @@ public class FeedReader.CachedAction : GLib.Object {
 	{
 		switch(m_action)
 		{
-			case CachedActions.MARK_READ:
-				return CachedActions.MARK_UNREAD;
-			case CachedActions.MARK_UNREAD:
-				return CachedActions.MARK_READ;
-			case CachedActions.MARK_STARRED:
-				return CachedActions.MARK_UNSTARRED;
-			case CachedActions.MARK_UNSTARRED:
-				return CachedActions.MARK_STARRED;
+		case CachedActions.MARK_READ:
+			return CachedActions.MARK_UNREAD;
+		case CachedActions.MARK_UNREAD:
+			return CachedActions.MARK_READ;
+		case CachedActions.MARK_STARRED:
+			return CachedActions.MARK_UNSTARRED;
+		case CachedActions.MARK_UNSTARRED:
+			return CachedActions.MARK_STARRED;
 		}
 
 		return CachedActions.NONE;

--- a/src/Model/Feed.vala
+++ b/src/Model/Feed.vala
@@ -18,12 +18,12 @@ public class FeedReader.feed : GLib.Object {
 	private string m_feedID;
 	private string m_title;
 	private string m_url;
-	private string? m_xmlURL;
+	private string ? m_xmlURL;
 	private uint m_unread;
 	private string[] m_catIDs;
-	private string? m_iconURL;
+	private string ? m_iconURL;
 
-	public feed(string feedID, string title, string url, uint unread, string[] catIDs, string? iconURL = null, string? xmlURL = null)
+	public feed(string feedID, string title, string url, uint unread, string[] catIDs, string ? iconURL = null, string ? xmlURL = null)
 	{
 		m_feedID = feedID;
 		m_title = title;
@@ -112,17 +112,17 @@ public class FeedReader.feed : GLib.Object {
 		return false;
 	}
 
-	public string? getIconURL()
+	public string ? getIconURL()
 	{
 		return m_iconURL;
 	}
 
-	public void setIconURL(string? url)
+	public void setIconURL(string ? url)
 	{
 		m_iconURL = url;
 	}
 
-	public string? getXmlUrl()
+	public string ? getXmlUrl()
 	{
 		return m_xmlURL;
 	}

--- a/src/Model/InterfaceState.vala
+++ b/src/Model/InterfaceState.vala
@@ -28,7 +28,7 @@ public class FeedReader.InterfaceState : GLib.Object {
 	private string m_SearchTerm = "";
 	private string m_FeedListSelectedRow = "feed -4";
 	private string m_ArticleListSelectedRow = "0";
-	private string? m_ArticleListTopRow = null;
+	private string ? m_ArticleListTopRow = null;
 	private string[] m_ExpandedCategories = {};
 	private ArticleListState m_ArticleListState = ArticleListState.ALL;
 
@@ -146,7 +146,7 @@ public class FeedReader.InterfaceState : GLib.Object {
 		return m_ArticleListSelectedRow;
 	}
 
-	public void setArticleListTopRow(string? articleID)
+	public void setArticleListTopRow(string ? articleID)
 	{
 		m_ArticleListTopRow = articleID;
 	}

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -59,7 +59,6 @@ public class FeedReader.Notification : GLib.Object {
 				else
 					message = _("There are %u new articles (%u unread)").printf(newArticles, unread);
 
-
 				if(m_notification == null)
 				{
 					m_notification = new Notify.Notification(summary, message, AboutInfo.iconName);
@@ -74,13 +73,13 @@ public class FeedReader.Notification : GLib.Object {
 
 							try
 							{
-								m_notification.close();
-								string[] spawn_args = {"feedreader"};
-								GLib.Process.spawn_async("/", spawn_args, null , GLib.SpawnFlags.SEARCH_PATH, null, null);
+							    m_notification.close();
+							    string[] spawn_args = {"feedreader"};
+							    GLib.Process.spawn_async("/", spawn_args, null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 							}
 							catch(Error e)
 							{
-								Logger.error("Notification: close - " + e.message);
+							    Logger.error("Notification: close - " + e.message);
 							}
 						});
 					}

--- a/src/QueryBuilder.vala
+++ b/src/QueryBuilder.vala
@@ -48,12 +48,12 @@ public class FeedReader.QueryBuilder : GLib.Object {
 	{
 		switch(m_type)
 		{
-			case QueryType.INSERT:
-			case QueryType.INSERT_OR_IGNORE:
-			case QueryType.INSERT_OR_REPLACE:
-				m_fields.add(field);
-				m_values.add(value);
-				return true;
+		case QueryType.INSERT:
+		case QueryType.INSERT_OR_IGNORE:
+		case QueryType.INSERT_OR_REPLACE:
+			m_fields.add(field);
+			m_values.add(value);
+			return true;
 		}
 		Logger.error("insertValuePair");
 		return false;
@@ -89,8 +89,8 @@ public class FeedReader.QueryBuilder : GLib.Object {
 	public bool addEqualsCondition(string field, string value, bool positive = true, bool isString = false)
 	{
 		if(m_type == QueryType.UPDATE
-		|| m_type == QueryType.SELECT
-		|| m_type == QueryType.DELETE)
+		   || m_type == QueryType.SELECT
+		   || m_type == QueryType.DELETE)
 		{
 			string condition = "%s = %s";
 
@@ -110,8 +110,8 @@ public class FeedReader.QueryBuilder : GLib.Object {
 	public bool addCustomCondition(string condition)
 	{
 		if(m_type == QueryType.UPDATE
-		|| m_type == QueryType.SELECT
-		|| m_type == QueryType.DELETE)
+		   || m_type == QueryType.SELECT
+		   || m_type == QueryType.DELETE)
 		{
 			m_conditions.add(condition);
 			return true;
@@ -125,8 +125,8 @@ public class FeedReader.QueryBuilder : GLib.Object {
 		if(!instr)
 		{
 			if(m_type == QueryType.UPDATE
-			|| m_type == QueryType.SELECT
-			|| m_type == QueryType.DELETE)
+			   || m_type == QueryType.SELECT
+			   || m_type == QueryType.DELETE)
 			{
 				var compound_values = new GLib.StringBuilder();
 				foreach(string value in values)
@@ -135,7 +135,7 @@ public class FeedReader.QueryBuilder : GLib.Object {
 					compound_values.append(value);
 					compound_values.append("\",");
 				}
-				compound_values.erase(compound_values.len-1);
+				compound_values.erase(compound_values.len - 1);
 				m_conditions.add("%s IN (%s)".printf(field, compound_values.str));
 				return true;
 			}
@@ -143,8 +143,8 @@ public class FeedReader.QueryBuilder : GLib.Object {
 		else
 		{
 			if(m_type == QueryType.UPDATE
-			|| m_type == QueryType.SELECT
-			|| m_type == QueryType.DELETE)
+			   || m_type == QueryType.SELECT
+			   || m_type == QueryType.DELETE)
 			{
 				foreach(string value in values)
 				{
@@ -161,8 +161,8 @@ public class FeedReader.QueryBuilder : GLib.Object {
 	public bool addRangeConditionInt(string field, Gee.ArrayList<int> values)
 	{
 		if(m_type == QueryType.UPDATE
-		|| m_type == QueryType.SELECT
-		|| m_type == QueryType.DELETE)
+		   || m_type == QueryType.SELECT
+		   || m_type == QueryType.DELETE)
 		{
 			var compound_values = new GLib.StringBuilder();
 			foreach(int value in values)
@@ -170,7 +170,7 @@ public class FeedReader.QueryBuilder : GLib.Object {
 				compound_values.append(value.to_string());
 				compound_values.append(",");
 			}
-			compound_values.erase(compound_values.len-1);
+			compound_values.erase(compound_values.len - 1);
 			m_conditions.add("%s IN (%s)".printf(field, compound_values.str));
 			return true;
 		}
@@ -229,80 +229,77 @@ public class FeedReader.QueryBuilder : GLib.Object {
 
 		switch(m_type)
 		{
-			case QueryType.INSERT:
-			case QueryType.INSERT_OR_IGNORE:
-			case QueryType.INSERT_OR_REPLACE:
-				m_query.append("INSERT ");
+		case QueryType.INSERT:
+		case QueryType.INSERT_OR_IGNORE:
+		case QueryType.INSERT_OR_REPLACE:
+			m_query.append("INSERT ");
 
-				if(m_type == QueryType.INSERT_OR_IGNORE)
-					m_query.append("OR IGNORE ");
-				else if(m_type == QueryType.INSERT_OR_REPLACE)
-					m_query.append("OR REPLACE ");
+			if(m_type == QueryType.INSERT_OR_IGNORE)
+				m_query.append("OR IGNORE ");
+			else if(m_type == QueryType.INSERT_OR_REPLACE)
+				m_query.append("OR REPLACE ");
 
-				m_query.append("INTO ");
-				m_query.append(m_table);
-				m_query.append(" ");
+			m_query.append("INTO ");
+			m_query.append(m_table);
+			m_query.append(" ");
 
-				foreach(string field in m_fields)
-				{
-					m_insert_fields.append(",");
-					m_insert_fields.append(field);
-				}
-				m_insert_fields.overwrite(0, "(").append(")");
-				m_query.append(m_insert_fields.str);
+			foreach(string field in m_fields)
+			{
+				m_insert_fields.append(",");
+				m_insert_fields.append(field);
+			}
+			m_insert_fields.overwrite(0, "(").append(")");
+			m_query.append(m_insert_fields.str);
 
-				m_query.append(" VALUES ");
+			m_query.append(" VALUES ");
 
-				foreach(string value in m_values)
-				{
-					m_insert_values.append(",");
-					m_insert_values.append(value);
-				}
-				m_insert_values.overwrite(0, "(").append(")");
-				m_query.append(m_insert_values.str);
-				break;
+			foreach(string value in m_values)
+			{
+				m_insert_values.append(",");
+				m_insert_values.append(value);
+			}
+			m_insert_values.overwrite(0, "(").append(")");
+			m_query.append(m_insert_values.str);
+			break;
 
+		case QueryType.UPDATE:
+			m_query.append("UPDATE ");
+			m_query.append(m_table);
+			m_query.append(" SET ");
 
-			case QueryType.UPDATE:
-				m_query.append("UPDATE ");
-				m_query.append(m_table);
-				m_query.append(" SET ");
+			for(int i = 0; i < m_fields.size; i++)
+			{
+				m_query.append(m_fields.get(i));
+				m_query.append(" = ");
+				m_query.append(m_values.get(i));
+				m_query.append(", ");
+			}
 
-				for(int i = 0; i < m_fields.size; i++)
-				{
-					m_query.append(m_fields.get(i));
-					m_query.append(" = ");
-					m_query.append(m_values.get(i));
-					m_query.append(", ");
-				}
+			m_query.erase(m_query.len - 2);
+			m_query.append(buildConditions());
+			break;
 
-				m_query.erase(m_query.len-2);
-				m_query.append(buildConditions());
-				break;
+		case QueryType.DELETE:
+			m_query.append("DELETE FROM ");
+			m_query.append(m_table);
+			m_query.append(buildConditions());
+			break;
 
-
-			case QueryType.DELETE:
-				m_query.append("DELETE FROM ");
-				m_query.append(m_table);
-				m_query.append(buildConditions());
-				break;
-
-
-			case QueryType.SELECT:
-				m_query.append("SELECT ");
-				foreach(string field in m_fields)
-				{
-					m_query.append(field);
-					m_query.append(", ");
-				}
-				m_query.erase(m_query.len-2);
-				m_query.append(" FROM ");
-				m_query.append(m_table);
-				m_query.append(buildConditions());
-				m_query.append(m_orderBy);
-				m_query.append(m_limit);
-				m_query.append(m_offset);
-				break;
+		case QueryType.SELECT:
+			m_query.append("SELECT ");
+			foreach(string field in m_fields)
+			{
+				m_query.append(field);
+				m_query.append(", ");
+			}
+			m_query.erase(m_query.len - 2);
+			m_query.append(" FROM ");
+			m_query.append(m_table);
+			m_query.append(buildConditions());
+			m_query.append(m_orderBy);
+			m_query.append(m_limit);
+			m_query.append(m_offset);
+			break;
 		}
 
 		//print();
@@ -322,7 +319,7 @@ public class FeedReader.QueryBuilder : GLib.Object {
 			conditions.append(condition);
 			conditions.append(" AND ");
 		}
-		conditions.erase(conditions.len-4);
+		conditions.erase(conditions.len - 4);
 		return conditions.str;
 	}
 

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -15,10 +15,10 @@
 
 public class FeedReader.Settings : GLib.Object {
 
-	private static GLib.Settings? m_general = null;
-	private static GLib.Settings? m_tweaks = null;
-	private static GLib.Settings? m_state = null;
-	private static GLib.Settings? m_keys = null;
+	private static GLib.Settings ? m_general = null;
+	private static GLib.Settings ? m_tweaks = null;
+	private static GLib.Settings ? m_state = null;
+	private static GLib.Settings ? m_keys = null;
 	private static Gee.HashMap<string, GLib.Settings>? m_share = null;
 
 	public static GLib.Settings general()
@@ -53,7 +53,7 @@ public class FeedReader.Settings : GLib.Object {
 		return m_keys;
 	}
 
-	public static GLib.Settings? share(string pluginName)
+	public static GLib.Settings ? share(string pluginName)
 	{
 		if(m_share == null)
 			m_share = new Gee.HashMap<string, GLib.Settings>();

--- a/src/Share/ServiceSetup.vala
+++ b/src/Share/ServiceSetup.vala
@@ -104,7 +104,6 @@ public class FeedReader.ServiceSetup : Gtk.ListBoxRow {
 		m_seperator_box.pack_start(m_box, true, true, 0);
 		m_seperator_box.pack_end(separator, false, false, 0);
 
-
 		m_revealer = new Gtk.Revealer();
 		m_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
 		m_revealer.add(m_seperator_box);

--- a/src/Share/ShareAccountInterface.vala
+++ b/src/Share/ShareAccountInterface.vala
@@ -39,11 +39,11 @@ public interface FeedReader.ShareAccountInterface : GLib.Object {
 
 	public abstract bool singleInstance();
 
-	public abstract ServiceSetup? newSetup_withID(string id, string username);
+	public abstract ServiceSetup ? newSetup_withID(string id, string username);
 
-	public abstract ServiceSetup? newSetup();
+	public abstract ServiceSetup ? newSetup();
 
-	public abstract ServiceSetup? newSystemAccount(string id, string username);
+	public abstract ServiceSetup ? newSystemAccount(string id, string username);
 
-	public abstract ShareForm? shareWidget(string url);
+	public abstract ShareForm ? shareWidget(string url);
 }

--- a/src/Share/share.vala
+++ b/src/Share/share.vala
@@ -17,8 +17,8 @@ public class FeedReader.Share : GLib.Object {
 
 	private Gee.ArrayList<ShareAccount> m_accounts;
 	private Peas.ExtensionSet m_plugins;
-	private static Share? m_share = null;
-	private Goa.Client? m_client = null;
+	private static Share ? m_share = null;
+	private Goa.Client ? m_client = null;
 
 	public static Share get_default()
 	{
@@ -66,51 +66,51 @@ public class FeedReader.Share : GLib.Object {
 			plugin.setupSystemAccounts(m_accounts);
 			if(!plugin.singleInstance())
 			{
-				var accounts = Settings.share(plugID).get_strv("account-ids");
-				foreach(string accountID in accounts)
-				{
-					m_accounts.add(
+			    var accounts = Settings.share(plugID).get_strv("account-ids");
+			    foreach(string accountID in accounts)
+			    {
+			        m_accounts.add(
 						new ShareAccount(
 							accountID,
 							plugID,
 							plugin.getUsername(accountID),
 							plugin.getIconName(),
 							plugin.pluginName()
-						)
-					);
+							)
+						);
 				}
 			}
 			else if(!plugin.needSetup()
-			|| (plugin.needSetup() && Settings.share(plugID).get_boolean("enabled")))
+			        || (plugin.needSetup() && Settings.share(plugID).get_boolean("enabled")))
 			{
-				m_accounts.add(
+			    m_accounts.add(
 					new ShareAccount(
 						plugID,
 						plugID,
 						plugin.pluginName(),
 						plugin.getIconName(),
 						plugin.pluginName()
-					)
-				);
+						)
+					);
 			}
-		});
+		}) ;
 
 		// load gresource-icons from the plugins
 		Gtk.IconTheme.get_default().add_resource_path("/org/gnome/FeedReader/icons");
 	}
 
-	private ShareAccountInterface? getInterface(string type)
+	private ShareAccountInterface ? getInterface(string type)
 	{
-		ShareAccountInterface? plug = null;
+		ShareAccountInterface ? plug = null;
 
 		m_plugins.foreach((@set, info, exten) => {
 			var plugin = (exten as ShareAccountInterface);
 
 			if(plugin.pluginID() == type)
 			{
-				plug = plugin;
+			    plug = plugin;
 			}
-		});
+		}) ;
 
 		return plug;
 	}
@@ -126,7 +126,7 @@ public class FeedReader.Share : GLib.Object {
 			bool singleInstance = false;
 			if(plugin.singleInstance())
 			{
-				if(plugin.needSetup() && !Settings.share(pluginID).get_boolean("enabled"))
+			    if(plugin.needSetup() && !Settings.share(pluginID).get_boolean("enabled"))
 					singleInstance = true;
 			}
 			else
@@ -134,13 +134,12 @@ public class FeedReader.Share : GLib.Object {
 
 			if(plugin.needSetup() && !plugin.useSystemAccounts() && singleInstance)
 			{
-				accounts.add(new ShareAccount("", pluginID, "", plugin.getIconName(), plugin.pluginName()));
+			    accounts.add(new ShareAccount("", pluginID, "", plugin.getIconName(), plugin.pluginName()));
 			}
-		});
+		}) ;
 
 		return accounts;
 	}
-
 
 	public Gee.ArrayList<ShareAccount> getAccounts()
 	{
@@ -157,17 +156,17 @@ public class FeedReader.Share : GLib.Object {
 			var plugID = plugin.pluginID();
 			if(plugin.needSetup() && !plugin.singleInstance())
 			{
-				string[] ids = Settings.share(plugID).get_strv("account-ids");
-				foreach(string i in ids)
-				{
-					if(i == id)
-					{
-						unique = false;
-						return;
+			    string[] ids = Settings.share(plugID).get_strv("account-ids");
+			    foreach(string i in ids)
+			    {
+			        if(i == id)
+			        {
+			            unique = false;
+			            return;
 					}
 				}
 			}
-		});
+		}) ;
 
 		if(!unique)
 			return generateNewID();
@@ -181,7 +180,6 @@ public class FeedReader.Share : GLib.Object {
 		m_accounts.add(new ShareAccount(id, type, username, iconName, accountName));
 	}
 
-
 	public string getUsername(string accountID)
 	{
 		foreach(var account in m_accounts)
@@ -194,7 +192,6 @@ public class FeedReader.Share : GLib.Object {
 
 		return "";
 	}
-
 
 	public bool addBookmark(string accountID, string url)
 	{
@@ -222,7 +219,7 @@ public class FeedReader.Share : GLib.Object {
 		return false;
 	}
 
-	public ServiceSetup? newSetup_withID(string accountID)
+	public ServiceSetup ? newSetup_withID(string accountID)
 	{
 		foreach(var account in m_accounts)
 		{
@@ -235,12 +232,12 @@ public class FeedReader.Share : GLib.Object {
 		return null;
 	}
 
-	public ServiceSetup? newSetup(string type)
+	public ServiceSetup ? newSetup(string type)
 	{
 		return getInterface(type).newSetup();
 	}
 
-	public ServiceSetup? newSystemAccount(string accountID)
+	public ServiceSetup ? newSystemAccount(string accountID)
 	{
 		foreach(var account in m_accounts)
 		{
@@ -253,18 +250,18 @@ public class FeedReader.Share : GLib.Object {
 		return null;
 	}
 
-	public ShareForm? shareWidget(string type, string url)
+	public ShareForm ? shareWidget(string type, string url)
 	{
-		ShareForm? form = null;
+		ShareForm ? form = null;
 
 		m_plugins.foreach((@set, info, exten) => {
 			var plugin = (exten as ShareAccountInterface);
 
 			if(plugin.pluginID() == type)
 			{
-				form = plugin.shareWidget(url);
+			    form = plugin.shareWidget(url);
 			}
-		});
+		}) ;
 
 		return form;
 	}

--- a/src/Structs.vala
+++ b/src/Structs.vala
@@ -26,8 +26,8 @@ namespace FeedReader {
 		private const string ETAG_KEY = "etag";
 		private const string LAST_MODIFIED_KEY = "last_modified";
 
-		string? etag;
-		string? last_modified;
+		string ? etag;
+		string ? last_modified;
 
 		public ResourceMetadata()
 		{

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -15,7 +15,7 @@
 
 public class FeedReader.Utils : GLib.Object {
 
-	private static Soup.Session? m_session;
+	private static Soup.Session ? m_session;
 
 	private static Soup.Session getSession()
 	{
@@ -30,7 +30,7 @@ public class FeedReader.Utils : GLib.Object {
 		return m_session;
 	}
 
-	public static string UTF8fix(string? old_string, bool removeHTML = false)
+	public static string UTF8fix(string ? old_string, bool removeHTML = false)
 	{
 		if(old_string == null)
 		{
@@ -42,12 +42,12 @@ public class FeedReader.Utils : GLib.Object {
 		if(removeHTML)
 			rm_html = 1;
 
-		string? output = old_string.replace("\n"," ").strip();
+		string ? output = old_string.replace("\n", " ").strip();
 		output = libVilistextum.parse(old_string, rm_html);
 
 		if(output != null)
 		{
-			output = output.replace("\n"," ").strip();
+			output = output.replace("\n", " ").strip();
 			if(output != "")
 			{
 				return output;
@@ -62,17 +62,17 @@ public class FeedReader.Utils : GLib.Object {
 	}
 
 	/*public static GLib.DateTime convertStringToDate(string date)
-	{
-		return new GLib.DateTime(
-			new TimeZone.local(),
-			int.parse(date.substring(0, date.index_of_nth_char(4))),															// year
-			int.parse(date.substring(date.index_of_nth_char(5), date.index_of_nth_char(7) - date.index_of_nth_char(5))),		// month
-			int.parse(date.substring(date.index_of_nth_char(8), date.index_of_nth_char(10) - date.index_of_nth_char(8))),		// day
-			int.parse(date.substring(date.index_of_nth_char(11), date.index_of_nth_char(13) - date.index_of_nth_char(11))),		// hour
-			int.parse(date.substring(date.index_of_nth_char(14), date.index_of_nth_char(16) - date.index_of_nth_char(14))),		// min
-			int.parse(date.substring(date.index_of_nth_char(17), date.index_of_nth_char(19) - date.index_of_nth_char(17)))		// sec
-		);
-	}*/
+	   {
+	    return new GLib.DateTime(
+	        new TimeZone.local(),
+	        int.parse(date.substring(0, date.index_of_nth_char(4))),															// year
+	        int.parse(date.substring(date.index_of_nth_char(5), date.index_of_nth_char(7) - date.index_of_nth_char(5))),		// month
+	        int.parse(date.substring(date.index_of_nth_char(8), date.index_of_nth_char(10) - date.index_of_nth_char(8))),		// day
+	        int.parse(date.substring(date.index_of_nth_char(11), date.index_of_nth_char(13) - date.index_of_nth_char(11))),		// hour
+	        int.parse(date.substring(date.index_of_nth_char(14), date.index_of_nth_char(16) - date.index_of_nth_char(14))),		// min
+	        int.parse(date.substring(date.index_of_nth_char(17), date.index_of_nth_char(19) - date.index_of_nth_char(17)))		// sec
+	    );
+	   }*/
 
 	public static bool springCleaningNecessary()
 	{
@@ -84,9 +84,9 @@ public class FeedReader.Utils : GLib.Object {
 
 		Logger.debug("last clean: %s".printf(lastClean.format("%Y-%m-%d %H:%M:%S")));
 		Logger.debug("now: %s".printf(now.format("%Y-%m-%d %H:%M:%S")));
-		Logger.debug("difference: %f".printf(difference/GLib.TimeSpan.DAY));
+		Logger.debug("difference: %f".printf(difference / GLib.TimeSpan.DAY));
 
-		if((difference/GLib.TimeSpan.DAY) >= Settings.general().get_int("spring-clean-after"))
+		if((difference / GLib.TimeSpan.DAY) >= Settings.general().get_int("spring-clean-after"))
 			doCleaning = true;
 
 		return doCleaning;
@@ -98,8 +98,8 @@ public class FeedReader.Utils : GLib.Object {
 	{
 		string random = "";
 
-		for(int i=0;i<length;i++){
-			int random_index = Random.int_range(0,charset.length);
+		for(int i = 0; i<length; i++) {
+			int random_index = Random.int_range(0, charset.length);
 			string ch = charset.get_char(charset.index_of_nth_char(random_index)).to_string();
 			random += ch;
 		}
@@ -123,14 +123,13 @@ public class FeedReader.Utils : GLib.Object {
 		string desktop = "org.gnome.FeedReader-autostart.desktop";
 		string filename = GLib.Environment.get_user_data_dir() + "/" + desktop;
 
-
 		if(Settings.tweaks().get_boolean("feedreader-autostart") && !FileUtils.test(filename, GLib.FileTest.EXISTS))
 		{
 			try
 			{
 				var origin = File.new_for_path(Constants.INSTALL_PREFIX + "/share/FeedReader/" + desktop);
 				var destination = File.new_for_path(filename);
-	        	origin.copy(destination, FileCopyFlags.NONE);
+				origin.copy(destination, FileCopyFlags.NONE);
 			}
 			catch(GLib.Error e)
 			{
@@ -223,7 +222,6 @@ public class FeedReader.Utils : GLib.Object {
 		return false;
 	}
 
-
 	public static bool remove_directory(string path, uint level = 0)
 	{
 		++level;
@@ -243,7 +241,7 @@ public class FeedReader.Utils : GLib.Object {
 				if((file_info.get_file_type()) == GLib.FileType.DIRECTORY)
 				{
 					remove_directory(path + file_name + "/", level);
-		    	}
+				}
 
 				var file = directory.get_child(file_name);
 				file.delete();
@@ -259,10 +257,8 @@ public class FeedReader.Utils : GLib.Object {
 			Logger.error("Utils - remove_directory: " + e.message);
 		}
 
-
 		return flag;
 	}
-
 
 	public static string shortenURL(string url)
 	{
@@ -354,10 +350,10 @@ public class FeedReader.Utils : GLib.Object {
 
 	public static int countChar(string s, unichar c)
 	{
-	    int count = 0;
-	    for (int index = 0; (index = s.index_of_char(c, index)) >= 0; ++index, ++count)
-	        ;
-	    return count;
+		int count = 0;
+		for (int index = 0; (index = s.index_of_char(c, index)) >= 0; ++index, ++count)
+			;
+		return count;
 	}
 
 	public static string parseSearchTerm(string searchTerm)
@@ -432,7 +428,7 @@ public class FeedReader.Utils : GLib.Object {
 		var feedname = new GLib.StringBuilder(url);
 
 		if(feedname.str.has_suffix("/"))
-			feedname.erase(feedname.str.char_count()-1);
+			feedname.erase(feedname.str.char_count() - 1);
 
 		if(feedname.str.has_prefix("https://"))
 			feedname.erase(0, 8);
@@ -446,7 +442,7 @@ public class FeedReader.Utils : GLib.Object {
 		return feedname.str;
 	}
 
-	public static async void getFavIcons(Gee.List<feed> feeds, GLib.Cancellable? cancellable = null)
+	public static async void getFavIcons(Gee.List<feed> feeds, GLib.Cancellable ? cancellable = null)
 	{
 		// TODO: It would be nice if we could queue these in parallel
 		foreach(feed f in feeds)
@@ -477,18 +473,18 @@ public class FeedReader.Utils : GLib.Object {
 		var now = new DateTime.now_local();
 		var difference = now.difference(lastDownload);
 
-		if((difference/GLib.TimeSpan.DAY) >= Constants.REDOWNLOAD_FAVICONS_AFTER_DAYS)
+		if((difference / GLib.TimeSpan.DAY) >= Constants.REDOWNLOAD_FAVICONS_AFTER_DAYS)
 			Settings.state().set_int("last-favicon-update", (int)now.to_unix());
 	}
 
-	public static async bool downloadFavIcon(string feed_id, string feed_url, GLib.Cancellable? cancellable = null, string icon_path = GLib.Environment.get_user_data_dir() + "/feedreader/data/feed_icons/")
+	public static async bool downloadFavIcon(string feed_id, string feed_url, GLib.Cancellable ? cancellable = null, string icon_path = GLib.Environment.get_user_data_dir() + "/feedreader/data/feed_icons/")
 	{
 		var uri = new Soup.URI(feed_url);
 		string hostname = uri.get_host();
 		int first = hostname.index_of_char('.', 0);
-		int second = hostname.index_of_char('.', first+1);
+		int second = hostname.index_of_char('.', first + 1);
 		if(second != -1 && first != second)
-			hostname = hostname.substring(first+1);
+			hostname = hostname.substring(first + 1);
 		string siteURL = uri.get_scheme() + "://" + hostname;
 
 		// download html and parse to find location of favicon
@@ -531,19 +527,19 @@ public class FeedReader.Utils : GLib.Object {
 			var xpath = grabberUtils.getURL(doc, "//link[@rel='icon']");
 
 			if(xpath == null)
-			// check for <link rel="shortcut icon">
-			xpath = grabberUtils.getURL(doc, "//link[@rel='shortcut icon']");
+				// check for <link rel="shortcut icon">
+				xpath = grabberUtils.getURL(doc, "//link[@rel='shortcut icon']");
 
 			if(xpath == null)
-			// check for <link rel="apple-touch-icon">
-			xpath = grabberUtils.getURL(doc, "//link[@rel='apple-touch-icon']");
+				// check for <link rel="apple-touch-icon">
+				xpath = grabberUtils.getURL(doc, "//link[@rel='apple-touch-icon']");
 
 			if(xpath != null)
 			{
 				Logger.debug(@"Utils.downloadFavIcon: xpath success $xpath");
 				xpath = grabberUtils.completeURL(xpath, siteURL);
 				if(yield downloadIcon(feed_id, xpath, cancellable, icon_path))
-				return true;
+					return true;
 			}
 			else
 			{
@@ -561,7 +557,7 @@ public class FeedReader.Utils : GLib.Object {
 		return yield downloadIcon(feed_id, icon_url, cancellable, icon_path);
 	}
 
-	public static async bool downloadIcon(string feed_id, string? icon_url, Cancellable? cancellable, string icon_path = GLib.Environment.get_user_data_dir() + "/feedreader/data/feed_icons/")
+	public static async bool downloadIcon(string feed_id, string ? icon_url, Cancellable ? cancellable, string icon_path = GLib.Environment.get_user_data_dir() + "/feedreader/data/feed_icons/")
 	{
 		if(icon_url == "" || icon_url == null || GLib.Uri.parse_scheme(icon_url) == null)
 		{
@@ -570,17 +566,17 @@ public class FeedReader.Utils : GLib.Object {
 		}
 
 		var path = GLib.File.new_for_path(icon_path);
-		try{path.make_directory_with_parents();}catch(GLib.Error e){}
+		try{path.make_directory_with_parents();}catch(GLib.Error e) {}
 		string filename_prefix = icon_path + feed_id.replace("/", "_").replace(".", "_");
 		string local_filename = filename_prefix + ".ico";
 		string metadata_filename = filename_prefix + ".txt";
 		bool icon_exists = FileUtils.test(local_filename, GLib.FileTest.EXISTS);
 
-		string? etag = null;
+		string ? etag = null;
 		// Normally, we would store a last modified time as a datetime type, but
 		// servers aren't consistent about the format so we need to treat it as a
 		// black box.
-		string? last_modified = null;
+		string ? last_modified = null;
 		if(icon_exists)
 		{
 			var lastDownload = new DateTime.from_unix_local(Settings.state().get_int("last-favicon-update"));
@@ -588,7 +584,7 @@ public class FeedReader.Utils : GLib.Object {
 			var difference = now.difference(lastDownload);
 
 			// icon was already downloaded a few days ago, don't even check if it was updated
-			if((difference/GLib.TimeSpan.DAY) < Constants.REDOWNLOAD_FAVICONS_AFTER_DAYS)
+			if((difference / GLib.TimeSpan.DAY) < Constants.REDOWNLOAD_FAVICONS_AFTER_DAYS)
 				return true;
 
 			var metadata = ResourceMetadata.from_file(metadata_filename);
@@ -645,7 +641,7 @@ public class FeedReader.Utils : GLib.Object {
 				return false;
 			}
 			if(icon_exists
-			&& (string)data == getFileContent(local_filename))
+			   && (string)data == getFileContent(local_filename))
 			{
 				// file exists and is identical to remote file
 				// we already downloaded it, but there is no need to write to the disc
@@ -674,11 +670,11 @@ public class FeedReader.Utils : GLib.Object {
 		return false;
 	}
 
-	private static string? getFileContent(string filename)
+	private static string ? getFileContent(string filename)
 	{
 		try
 		{
-			string? contents = null;
+			string ? contents = null;
 			FileUtils.get_contents(filename, out contents);
 			return contents;
 		}
@@ -708,7 +704,7 @@ public class FeedReader.Utils : GLib.Object {
 			Logger.error("Utils.gsettingWriteString: writing %s %s failed".printf(setting.schema_id, key));
 	}
 
-	public static async uint8[] inputStreamToArray(InputStream stream, Cancellable? cancellable=null) throws Error
+	public static async uint8[] inputStreamToArray(InputStream stream, Cancellable ? cancellable = null) throws Error
 	{
 		Array<uint8> result = new Array<uint8>();
 		uint8[] buffer = new uint8[1024];

--- a/src/UtilsDaemon.vala
+++ b/src/UtilsDaemon.vala
@@ -50,12 +50,12 @@ public class FeedReader.UtilsDaemon : GLib.Object {
 					while(output.has_prefix(xml))
 					{
 						int end = output.index_of_char('>');
-						output = output.slice(end+1, output.length).chug();
+						output = output.slice(end + 1, output.length).chug();
 						output = output.strip();
 					}
 
-					output = output.replace("\n"," ");
-					output = output.replace("_"," ");
+					output = output.replace("\n", " ");
+					output = output.replace("_", " ");
 
 					Article.setPreview(output.chug());
 				}
@@ -78,7 +78,7 @@ public class FeedReader.UtilsDaemon : GLib.Object {
 				string modified_html = _("No Text available for this article :(");
 				if(Article.getHTML() != "")
 				{
-					modified_html = Article.getHTML().replace("src=\"//","src=\"http://");
+					modified_html = Article.getHTML().replace("src=\"//", "src=\"http://");
 				}
 				Article.setHTML(modified_html);
 			}
@@ -103,17 +103,17 @@ public class FeedReader.UtilsDaemon : GLib.Object {
 
 		switch(selectedRow[0])
 		{
-			case "feed":
-				IDtype = FeedListType.FEED;
-				break;
+		case "feed":
+			IDtype = FeedListType.FEED;
+			break;
 
-			case "cat":
-				IDtype = FeedListType.CATEGORY;
-				break;
+		case "cat":
+			IDtype = FeedListType.CATEGORY;
+			break;
 
-			case "tag":
-				IDtype = FeedListType.TAG;
-				break;
+		case "tag":
+			IDtype = FeedListType.TAG;
+			break;
 		}
 
 		int count = dbDaemon.get_default().getArticleCountNewerThanID(topRow, selectedRow[1], IDtype, state, searchTerm);

--- a/src/UtilsUI.vala
+++ b/src/UtilsUI.vala
@@ -15,14 +15,13 @@
 
 public class FeedReader.UtilsUI : GLib.Object {
 
-
 	public static uint getRelevantArticles(int newArticlesCount)
 	{
 		var interfacestate = MainWindow.get_default().getInterfaceState();
 		string[] selectedRow = interfacestate.getFeedListSelectedRow().split(" ", 2);
 		ArticleListState state = interfacestate.getArticleListState();
 		string searchTerm = interfacestate.getSearchTerm();
-		string? topRow = interfacestate.getArticleListTopRow();
+		string ? topRow = interfacestate.getArticleListTopRow();
 
 		FeedListType IDtype = FeedListType.FEED;
 
@@ -31,17 +30,17 @@ public class FeedReader.UtilsUI : GLib.Object {
 
 		switch(selectedRow[0])
 		{
-			case "feed":
-				IDtype = FeedListType.FEED;
-				break;
+		case "feed":
+			IDtype = FeedListType.FEED;
+			break;
 
-			case "cat":
-				IDtype = FeedListType.CATEGORY;
-				break;
+		case "cat":
+			IDtype = FeedListType.CATEGORY;
+			break;
 
-			case "tag":
-				IDtype = FeedListType.TAG;
-				break;
+		case "tag":
+			IDtype = FeedListType.TAG;
+			break;
 		}
 
 		int count = 0;
@@ -53,7 +52,7 @@ public class FeedReader.UtilsUI : GLib.Object {
 		return count;
 	}
 
-	public static string buildArticle(string html, string title, string url, string? author, string date, string feedID)
+	public static string buildArticle(string html, string title, string url, string ? author, string date, string feedID)
 	{
 		var article = new GLib.StringBuilder();
 		string author_date = "";
@@ -99,25 +98,24 @@ public class FeedReader.UtilsUI : GLib.Object {
 		article.erase(feed_pos, feed_id.length);
 		article.insert(feed_pos, dbUI.get_default().getFeedName(feedID));
 
-
 		string theme = "theme ";
 		switch(Settings.general().get_enum("article-theme"))
 		{
-			case ArticleTheme.DEFAULT:
-				theme += "default";
-				break;
+		case ArticleTheme.DEFAULT:
+			theme += "default";
+			break;
 
-			case ArticleTheme.SPRING:
-				theme += "spring";
-				break;
+		case ArticleTheme.SPRING:
+			theme += "spring";
+			break;
 
-			case ArticleTheme.MIDNIGHT:
-				theme += "midnight";
-				break;
+		case ArticleTheme.MIDNIGHT:
+			theme += "midnight";
+			break;
 
-			case ArticleTheme.PARCHMENT:
-				theme += "parchment";
-				break;
+		case ArticleTheme.PARCHMENT:
+			theme += "parchment";
+			break;
 		}
 
 		string theme_id = "$THEME";
@@ -130,7 +128,7 @@ public class FeedReader.UtilsUI : GLib.Object {
 
 		if(Settings.tweaks().get_boolean("article-select-text"))
 		{
-			article.erase(select_pos-1, select_id.length+1);
+			article.erase(select_pos - 1, select_id.length + 1);
 		}
 		else
 		{
@@ -142,7 +140,7 @@ public class FeedReader.UtilsUI : GLib.Object {
 		string font = Settings.general().get_string("font");
 		var desc = Pango.FontDescription.from_string(font);
 		string fontfamilly = desc.get_family();
-		uint fontsize = (uint)GLib.Math.roundf(desc.get_size()/Pango.SCALE);
+		uint fontsize = (uint)GLib.Math.roundf(desc.get_size() / Pango.SCALE);
 		string small_size = (fontsize - 2).to_string();
 		string large_size = (fontsize * 2).to_string();
 		string normal_size = fontsize.to_string();
@@ -167,7 +165,6 @@ public class FeedReader.UtilsUI : GLib.Object {
 			article.insert(i, small_size);
 		}
 
-
 		try
 		{
 			uint8[] contents;
@@ -186,7 +183,7 @@ public class FeedReader.UtilsUI : GLib.Object {
 		return article.str;
 	}
 
-	public static bool canManipulateContent(bool? online = null)
+	public static bool canManipulateContent(bool ? online = null)
 	{
 		try
 		{
@@ -249,8 +246,8 @@ public class FeedReader.UtilsUI : GLib.Object {
 		try
 		{
 			if(!dbUI.get_default().haveCategories()
-			&& !DBusConnection.get_default().supportTags()
-			&& !dbUI.get_default().haveFeedsWithoutCat())
+			   && !DBusConnection.get_default().supportTags()
+			   && !dbUI.get_default().haveFeedsWithoutCat())
 				return true;
 		}
 		catch(GLib.Error e)
@@ -267,7 +264,7 @@ public class FeedReader.UtilsUI : GLib.Object {
 		try
 		{
 			string articleName = "Article.pdf";
-			string? articleID = ColumnView.get_default().displayedArticle();
+			string ? articleID = ColumnView.get_default().displayedArticle();
 			if(articleID != null)
 				articleName = dbUI.get_default().read_article(articleID).getTitle();
 
@@ -283,12 +280,12 @@ public class FeedReader.UtilsUI : GLib.Object {
 			map.set("image/x-icon", ".ico");
 
 			var save_dialog = new Gtk.FileChooserDialog("Save Image",
-														MainWindow.get_default(),
-														Gtk.FileChooserAction.SAVE,
-														_("Cancel"),
-														Gtk.ResponseType.CANCEL,
-														_("Save"),
-														Gtk.ResponseType.ACCEPT);
+			                                            MainWindow.get_default(),
+			                                            Gtk.FileChooserAction.SAVE,
+			                                            _("Cancel"),
+			                                            Gtk.ResponseType.CANCEL,
+			                                            _("Save"),
+			                                            Gtk.ResponseType.ACCEPT);
 			save_dialog.set_do_overwrite_confirmation(true);
 			save_dialog.set_modal(true);
 			save_dialog.set_current_folder(GLib.Environment.get_user_data_dir());
@@ -297,24 +294,24 @@ public class FeedReader.UtilsUI : GLib.Object {
 			save_dialog.response.connect((dialog, response_id) => {
 				switch(response_id)
 				{
-					case Gtk.ResponseType.ACCEPT:
-						try
-						{
-							var savefile = save_dialog.get_file();
-							uint8[] data;
-							string etag;
-							file.load_contents(null, out data, out etag);
-							savefile.replace_contents(data, null, false, GLib.FileCreateFlags.REPLACE_DESTINATION, null, null);
-						}
-						catch(Error e)
-						{
-							Logger.debug("imagePopup: save file: " + e.message);
-						}
-						break;
+				case Gtk.ResponseType.ACCEPT:
+					try
+					{
+					    var savefile = save_dialog.get_file();
+					    uint8[] data;
+					    string etag;
+					    file.load_contents(null, out data, out etag);
+					    savefile.replace_contents(data, null, false, GLib.FileCreateFlags.REPLACE_DESTINATION, null, null);
+					}
+					catch(Error e)
+					{
+					    Logger.debug("imagePopup: save file: " + e.message);
+					}
+					break;
 
-					case Gtk.ResponseType.CANCEL:
-					default:
-						break;
+				case Gtk.ResponseType.CANCEL:
+				default:
+					break;
 				}
 				save_dialog.destroy();
 			});
@@ -379,59 +376,59 @@ public class FeedReader.UtilsUI : GLib.Object {
 	}
 
 	/*public static void testGOA()
-	{
-		try
-		{
-			Goa.Client? client = new Goa.Client.sync();
+	   {
+	    try
+	    {
+	        Goa.Client? client = new Goa.Client.sync();
 
-			if(client != null)
-			{
-				var accounts = client.get_accounts();
-				foreach(var object in accounts)
-				{
-					stdout.printf("account type: %s\n", object.account.provider_type);
-					stdout.printf("account name: %s\n", object.account.provider_name);
-					stdout.printf("account identity: %s\n", object.account.identity);
-					stdout.printf("account id: %s\n", object.account.id);
+	        if(client != null)
+	        {
+	            var accounts = client.get_accounts();
+	            foreach(var object in accounts)
+	            {
+	                stdout.printf("account type: %s\n", object.account.provider_type);
+	                stdout.printf("account name: %s\n", object.account.provider_name);
+	                stdout.printf("account identity: %s\n", object.account.identity);
+	                stdout.printf("account id: %s\n", object.account.id);
 
-					if(object.oauth2_based != null)
-					{
-						string access_token = "";
-						int expires = -1;
-						object.oauth2_based.call_get_access_token_sync(out access_token, out expires);
-						stdout.printf("access token 2: %s\n", access_token);
-						stdout.printf("expires in: %i\n", expires);
-						stdout.printf("client id: %s\n", object.oauth2_based.client_id);
-						stdout.printf("client secret: %s\n", object.oauth2_based.client_secret);
-					}
-					else if(object.oauth_based != null)
-					{
-						string access_token = "";
-						string access_token_secret = "";
-						int expires = -1;
-						object.oauth_based.call_get_access_token_sync(out access_token, out access_token_secret, out expires);
-						stdout.printf("access token: %s\n", access_token);
-						stdout.printf("access token secret: %s\n", access_token_secret);
-						stdout.printf("expires in: %i\n", expires);
-					}
-					else if(object.password_based != null)
-					{
-						string password = "";
-						object.password_based.call_get_password_sync ("abc", out password);
-						stdout.printf("password: %s\n", password);
-						stdout.printf("presentation identity: %s\n", object.account.presentation_identity);
-					}
-					stdout.printf("\n");
-				}
-			}
-			else
-			{
-				stdout.printf("goa not available");
-			}
-		}
-		catch(GLib.Error e)
-		{
-			Logger.error("UtilsUI.testGOA: %s".printf(e.message));
-		}
-	}*/
+	                if(object.oauth2_based != null)
+	                {
+	                    string access_token = "";
+	                    int expires = -1;
+	                    object.oauth2_based.call_get_access_token_sync(out access_token, out expires);
+	                    stdout.printf("access token 2: %s\n", access_token);
+	                    stdout.printf("expires in: %i\n", expires);
+	                    stdout.printf("client id: %s\n", object.oauth2_based.client_id);
+	                    stdout.printf("client secret: %s\n", object.oauth2_based.client_secret);
+	                }
+	                else if(object.oauth_based != null)
+	                {
+	                    string access_token = "";
+	                    string access_token_secret = "";
+	                    int expires = -1;
+	                    object.oauth_based.call_get_access_token_sync(out access_token, out access_token_secret, out expires);
+	                    stdout.printf("access token: %s\n", access_token);
+	                    stdout.printf("access token secret: %s\n", access_token_secret);
+	                    stdout.printf("expires in: %i\n", expires);
+	                }
+	                else if(object.password_based != null)
+	                {
+	                    string password = "";
+	                    object.password_based.call_get_password_sync ("abc", out password);
+	                    stdout.printf("password: %s\n", password);
+	                    stdout.printf("presentation identity: %s\n", object.account.presentation_identity);
+	                }
+	                stdout.printf("\n");
+	            }
+	        }
+	        else
+	        {
+	            stdout.printf("goa not available");
+	        }
+	    }
+	    catch(GLib.Error e)
+	    {
+	        Logger.error("UtilsUI.testGOA: %s".printf(e.message));
+	    }
+	   }*/
 }

--- a/src/Widgets/AddPopover.vala
+++ b/src/Widgets/AddPopover.vala
@@ -41,7 +41,7 @@ public class FeedReader.AddPopover : Gtk.Popover {
 		m_catEntry.icon_press.connect((pos, event) => {
 			if(pos == Gtk.EntryIconPosition.SECONDARY)
 			{
-				m_catEntry.set_text("");
+			    m_catEntry.set_text("");
 			}
 		});
 		var urlLabel = new Gtk.Label(_("URL:"));
@@ -87,7 +87,6 @@ public class FeedReader.AddPopover : Gtk.Popover {
 		m_opmlGrid.attach(m_chooser, 1, 0, 1, 1);
 		m_opmlGrid.attach(importButton, 0, 1, 2, 1);
 
-
 		m_stack = new Gtk.Stack();
 		m_stack.add_titled(m_feedGrid, "feeds", _("Add feed"));
 		m_stack.add_titled(m_opmlGrid, "opml", _("Import OPML"));
@@ -112,8 +111,8 @@ public class FeedReader.AddPopover : Gtk.Popover {
 
 			foreach(var cat in m_cats)
 			{
-				list_store.append(out iter);
-				list_store.set(iter, 0, cat.getTitle());
+			    list_store.append(out iter);
+			    list_store.set(iter, 0, cat.getTitle());
 			}
 			m_complete = new Gtk.EntryCompletion();
 			m_complete.set_text_column(0);
@@ -126,13 +125,13 @@ public class FeedReader.AddPopover : Gtk.Popover {
 	private void addFeed()
 	{
 		if(m_urlEntry.text == ""
-		|| GLib.Uri.parse_scheme(m_urlEntry.text) == null)
+		   || GLib.Uri.parse_scheme(m_urlEntry.text) == null)
 		{
 			m_urlEntry.grab_focus();
 			return;
 		}
 
-		string? catID = dbUI.get_default().getCategoryID(m_catEntry.text);
+		string ? catID = dbUI.get_default().getCategoryID(m_catEntry.text);
 		bool isID = true;
 
 		if(catID == null)

--- a/src/Widgets/ArticleList/ArticleList.vala
+++ b/src/Widgets/ArticleList/ArticleList.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.ArticleList : Gtk.Overlay {
 
 	private Gtk.Stack m_stack;
@@ -39,7 +38,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 	private ulong m_handlerID2 = 0;
 	private ulong m_handlerID3 = 0;
 
-	public signal void row_activated(articleRow? row);
+	public signal void row_activated(articleRow ? row);
 
 	public ArticleList()
 	{
@@ -101,17 +100,17 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		this.size_allocate.connect((allocation) => {
 			if(allocation.height != m_height)
 			{
-				if(allocation.height > m_height
-				&& m_stack.get_visible_child_name() != "empty"
-				&& m_stack.get_visible_child_name() != "syncing")
-				{
-					Logger.debug("ArticleList: size changed");
-					if(m_currentList.needLoadMore(allocation.height))
-						loadMore.begin((obj, res) =>{
+			    if(allocation.height > m_height
+			       && m_stack.get_visible_child_name() != "empty"
+			       && m_stack.get_visible_child_name() != "syncing")
+			    {
+			        Logger.debug("ArticleList: size changed");
+			        if(m_currentList.needLoadMore(allocation.height))
+						loadMore.begin((obj, res) => {
 							loadMore.end(res);
 						});
 				}
-				m_height = allocation.height;
+			    m_height = allocation.height;
 			}
 		});
 	}
@@ -137,16 +136,16 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		//-----------------------------------------------------------------------------------------------------------------------------------------------------
 		ThreadFunc<void*> run = () => {
 			int height = this.get_allocated_height();
-			uint limit = height/100 + 5;
+			uint limit = height / 100 + 5;
 			offset = getListOffset();
 
 			Logger.debug("load articles from db");
 			articles = dbUI.get_default().read_articles(m_selectedFeedListID,
-														m_selectedFeedListType,
-														m_state,
-														m_searchTerm,
-														limit,
-														offset);
+			                                            m_selectedFeedListType,
+			                                            m_state,
+			                                            m_searchTerm,
+			                                            limit,
+			                                            offset);
 			Logger.debug("actual articles loaded: " + articles.size.to_string());
 
 			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
@@ -169,7 +168,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 			}
 			else
 			{
-				loadNewer.begin((int)offset, 0, (obj, res) =>{
+				loadNewer.begin((int)offset, 0, (obj, res) => {
 					loadNewer.end(res);
 				});
 			}
@@ -211,8 +210,8 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 				if(m_handlerID1 != 0)
 				{
-					m_currentList.disconnect(m_handlerID1);
-					m_handlerID1 = 0;
+				    m_currentList.disconnect(m_handlerID1);
+				    m_handlerID1 = 0;
 				}
 			});
 
@@ -228,7 +227,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		Logger.debug(@"new rowCount: $count");
 		if(count > 0)
 		{
-			loadNewer.begin(count, offset, (obj, res) =>{
+			loadNewer.begin(count, offset, (obj, res) => {
 				loadNewer.end(res);
 			});
 		}
@@ -252,11 +251,11 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 			uint offset = m_currentList.getSizeForState() + determineNewRowCount(null, null);
 
 			articles = dbUI.get_default().read_articles(m_selectedFeedListID,
-														m_selectedFeedListType,
-														m_state,
-														m_searchTerm,
-														m_dynamicRowThreshold,
-														offset);
+			                                            m_selectedFeedListType,
+			                                            m_state,
+			                                            m_searchTerm,
+			                                            m_dynamicRowThreshold,
+			                                            offset);
 			Logger.debug("actual articles loaded: " + articles.size.to_string());
 
 			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
@@ -277,8 +276,8 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 				if(m_handlerID2 != 0)
 				{
-					m_currentList.disconnect(m_handlerID2);
-					m_handlerID2 = 0;
+				    m_currentList.disconnect(m_handlerID2);
+				    m_handlerID2 = 0;
 				}
 			});
 		}
@@ -300,11 +299,11 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		ThreadFunc<void*> run = () => {
 			Logger.debug("load articles from db");
 			articles = dbUI.get_default().read_articles(m_selectedFeedListID,
-														m_selectedFeedListType,
-														m_state,
-														m_searchTerm,
-														newCount,
-														offset);
+			                                            m_selectedFeedListType,
+			                                            m_state,
+			                                            m_searchTerm,
+			                                            newCount,
+			                                            offset);
 			Logger.debug("actual articles loaded: " + articles.size.to_string());
 
 			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
@@ -332,8 +331,8 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 				if(m_handlerID3 != 0)
 				{
-					m_currentList.disconnect(m_handlerID3);
-					m_handlerID3 = 0;
+				    m_currentList.disconnect(m_handlerID3);
+				    m_handlerID3 = 0;
 				}
 			});
 		}
@@ -349,7 +348,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		Logger.debug(@"ArticleList: updateArticleList()");
 
 		if(m_stack.get_visible_child_name() == "empty"
-		|| m_stack.get_visible_child_name() == "syncing")
+		   || m_stack.get_visible_child_name() == "syncing")
 		{
 			Logger.debug("ArticleList: updateArticleList(): emtpy list -> create newList()");
 			newList.begin(Gtk.StackTransitionType.CROSSFADE, (obj, res) => {
@@ -382,21 +381,21 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 		for(int i = 1; i < length; i++)
 		{
-			articleRow? first = m_currentList.get_row_at_index(i-1) as articleRow;
-			articleRow? second = m_currentList.get_row_at_index(i) as articleRow;
+			articleRow ? first = m_currentList.get_row_at_index(i - 1) as articleRow;
+			articleRow ? second = m_currentList.get_row_at_index(i) as articleRow;
 
 			if(first == null
-			|| second == null)
+			   || second == null)
 				continue;
 
-			var insertArticles = dbUI.get_default().read_article_between(	m_selectedFeedListID,
-																			m_selectedFeedListType,
-																			m_state,
-																			m_searchTerm,
-																			first.getID(),
-																			first.getDate(),
-																			second.getID(),
-																			second.getDate());
+			var insertArticles = dbUI.get_default().read_article_between(   m_selectedFeedListID,
+			                                                                m_selectedFeedListType,
+			                                                                m_state,
+			                                                                m_searchTerm,
+			                                                                first.getID(),
+			                                                                first.getDate(),
+			                                                                second.getID(),
+			                                                                second.getDate());
 
 			foreach(article a in insertArticles)
 			{
@@ -411,19 +410,19 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		checkForNewRows();
 	}
 
-	private int determineNewRowCount(int? newCount, out int? offset)
+	private int determineNewRowCount(int ? newCount, out int ? offset)
 	{
 		int count = 0;
-		string? firstRowID = m_currentList.getFirstRowID();
+		string ? firstRowID = m_currentList.getFirstRowID();
 
 		if(firstRowID != null)
 		{
 			count = dbUI.get_default().getArticleCountNewerThanID(
-														firstRowID,
-														m_selectedFeedListID,
-														m_selectedFeedListType,
-														m_state,
-														m_searchTerm);
+				firstRowID,
+				m_selectedFeedListID,
+				m_selectedFeedListType,
+				m_state,
+				m_searchTerm);
 		}
 
 		if(newCount != null && newCount < count)
@@ -457,16 +456,16 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 				foreach(var r in children)
 				{
-					var row = r as articleRow;
-					if(row != null)
-					{
-						if(m_currentScroll.isVisible(row, m_dynamicRowThreshold) == 1)
-						{
-							m_currentList.removeRow(row, 0);
+				    var row = r as articleRow;
+				    if(row != null)
+				    {
+				        if(m_currentScroll.isVisible(row, m_dynamicRowThreshold) == 1)
+				        {
+				            m_currentList.removeRow(row, 0);
 						}
-						else
-						{
-							break;
+				        else
+				        {
+				            break;
 						}
 					}
 				}
@@ -506,25 +505,25 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 	{
 		switch(event.keyval)
 		{
-			case Gdk.Key.Down:
-				int diff = m_currentList.move(true);
-				if(m_state != ArticleListState.UNREAD)
-					m_currentScroll.scrollDiff(diff);
-				break;
+		case Gdk.Key.Down:
+			int diff = m_currentList.move(true);
+			if(m_state != ArticleListState.UNREAD)
+				m_currentScroll.scrollDiff(diff);
+			break;
 
-			case Gdk.Key.Up:
-				int diff = m_currentList.move(false);
-				if(m_state != ArticleListState.UNREAD)
-					m_currentScroll.scrollDiff(diff);
-				break;
+		case Gdk.Key.Up:
+			int diff = m_currentList.move(false);
+			if(m_state != ArticleListState.UNREAD)
+				m_currentScroll.scrollDiff(diff);
+			break;
 
-			case Gdk.Key.Page_Down:
-				m_currentScroll.scrollToPos(-1);
-				break;
+		case Gdk.Key.Page_Down:
+			m_currentScroll.scrollToPos(-1);
+			break;
 
-			case Gdk.Key.Page_Up:
-				m_currentScroll.scrollToPos(0);
-				break;
+		case Gdk.Key.Page_Up:
+			m_currentScroll.scrollToPos(0);
+			break;
 		}
 		return true;
 	}
@@ -549,7 +548,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 	private void showNotification()
 	{
 		if(m_overlay != null
-		|| m_state != ArticleListState.ALL)
+		   || m_state != ArticleListState.ALL)
 			return;
 
 		m_overlay = new InAppNotification.withIcon(
@@ -575,13 +574,13 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 	public string getSelectedArticle()
 	{
 		if(m_stack.get_visible_child_name() == "empty"
-		|| m_stack.get_visible_child_name() == "syncing")
+		   || m_stack.get_visible_child_name() == "syncing")
 			return "empty";
 
 		return m_currentList.getSelectedArticle();
 	}
 
-	public string? getFirstArticle()
+	public string ? getFirstArticle()
 	{
 		return m_currentList.getFirstRowID();
 	}
@@ -616,7 +615,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 			{
 				var height = tmpRow.get_allocated_height();
 
-				if((scrollPos-height) >= 0)
+				if((scrollPos - height) >= 0)
 				{
 					scrollPos -= height;
 					++rowOffset;
@@ -758,7 +757,7 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 
 	public void centerSelectedRow()
 	{
-		int scroll = -(int)(m_currentScroll.getPageSize()/2);
+		int scroll = -(int)(m_currentScroll.getPageSize() / 2);
 		scroll += m_currentList.selectedRowPosition();
 		m_currentScroll.scrollToPos(scroll);
 	}

--- a/src/Widgets/ArticleList/ArticleListBox.vala
+++ b/src/Widgets/ArticleList/ArticleListBox.vala
@@ -92,7 +92,6 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 			return;
 		}
 
-
 		var priority = GLib.Priority.DEFAULT_IDLE;
 		if(ColumnView.get_default().playingMedia())
 			priority = GLib.Priority.HIGH_IDLE;
@@ -112,9 +111,9 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 			// check if row is already there
 			if(m_articles.contains(item.getArticleID()))
 			{
-				Logger.warning(@"ArticleListbox$m_name: row with ID %s is already present".printf(item.getArticleID()));
-				checkQueue(item, balance, reverse, animate);
-				return false;
+			    Logger.warning(@"ArticleListbox$m_name: row with ID %s is already present".printf(item.getArticleID()));
+			    checkQueue(item, balance, reverse, animate);
+			    return false;
 			}
 
 			m_articles.add(item.getArticleID());
@@ -386,8 +385,8 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 					if(tmpRow != null && tmpRow.isBeingRevealed())
 					{
 						if((!tmpRow.isUnread() && m_state == ArticleListState.UNREAD)
-						|| (!tmpRow.isMarked() && m_state == ArticleListState.MARKED)
-						|| (m_selectedFeedListType == FeedListType.TAG && !tmpRow.hasTag(m_selectedFeedListID)))
+						   || (!tmpRow.isMarked() && m_state == ArticleListState.MARKED)
+						   || (m_selectedFeedListType == FeedListType.TAG && !tmpRow.hasTag(m_selectedFeedListID)))
 						{
 							if(tmpRow.getID() != selectedID)
 							{
@@ -407,34 +406,34 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		Logger.debug("state changed");
 		switch(status)
 		{
-			case ArticleStatus.UNREAD:
-			case ArticleStatus.MARKED:
-				return;
-			case ArticleStatus.READ:
-			case ArticleStatus.UNMARKED:
-				var selectedRow = this.get_selected_row() as articleRow;
-				var articleChildList = this.get_children();
-				foreach(Gtk.Widget row in articleChildList)
+		case ArticleStatus.UNREAD:
+		case ArticleStatus.MARKED:
+			return;
+		case ArticleStatus.READ:
+		case ArticleStatus.UNMARKED:
+			var selectedRow = this.get_selected_row() as articleRow;
+			var articleChildList = this.get_children();
+			foreach(Gtk.Widget row in articleChildList)
+			{
+				var tmpRow = row as articleRow;
+				if(tmpRow != null)
 				{
-					var tmpRow = row as articleRow;
-					if(tmpRow != null)
+					if((selectedRow != null && tmpRow.getID() != selectedRow.getID())
+					   || selectedRow == null)
 					{
-						if((selectedRow != null && tmpRow.getID() != selectedRow.getID())
-						|| selectedRow == null)
+						if(m_articles.contains(tmpRow.getID()))
 						{
-							if(m_articles.contains(tmpRow.getID()))
+							if((m_state == ArticleListState.UNREAD && !tmpRow.isUnread())
+							   || (m_state == ArticleListState.MARKED && !tmpRow.isMarked()))
 							{
-								if((m_state == ArticleListState.UNREAD && !tmpRow.isUnread())
-								|| (m_state == ArticleListState.MARKED && !tmpRow.isMarked()))
-								{
-									removeRow(tmpRow);
-									break;
-								}
+								removeRow(tmpRow);
+								break;
 							}
 						}
 					}
 				}
-				break;
+			}
+			break;
 		}
 	}
 
@@ -446,7 +445,7 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 			if(!visibleArticles.contains(id))
 				invisibleRows.add(id);
 			return true;
-		});
+		}) ;
 
 		m_visibleArticles = visibleArticles;
 
@@ -477,7 +476,7 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		selectedRow.removeTag(tagID);
 	}
 
-	public string? getFirstRowID()
+	public string ? getFirstRowID()
 	{
 		var children = this.get_children();
 
@@ -492,7 +491,7 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		return firstRow.getID();
 	}
 
-	private articleRow? getFirstRow()
+	private articleRow ? getFirstRow()
 	{
 		var children = this.get_children();
 
@@ -507,7 +506,7 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		return firstRow;
 	}
 
-	public string? getLastRowID()
+	public string ? getLastRowID()
 	{
 		var children = this.get_children();
 
@@ -581,7 +580,7 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 			{
 				if(tmpRow.getID() == selectedRow.getID())
 				{
-					scroll += tmpRow.get_allocated_height()/2;
+					scroll += tmpRow.get_allocated_height() / 2;
 					Logger.debug("scroll: %i".printf(scroll));
 					break;
 				}

--- a/src/Widgets/ArticleList/ArticleListEmptyLabel.vala
+++ b/src/Widgets/ArticleList/ArticleListEmptyLabel.vala
@@ -38,78 +38,78 @@ public class FeedReader.ArticleListEmptyLabel : Gtk.Label {
 		{
 			switch(type)
 			{
-				case FeedListType.FEED:
-					name = dbUI.get_default().getFeedName(selectedFeed);
-					if(state == ArticleListState.UNREAD)
-					{
-						if(searchTerm != "")
-							message = _(@"No unread articles that fit \"$search\" in feed \"$name\"");
-						else
-							message = _(@"No unread articles in feed \"$name\"");
-					}
-					else if(state == ArticleListState.MARKED)
-					{
-						if(searchTerm != "")
-							message = _(@"No starred articles that fit \"$search\" in feed \"$name\"");
-						else
-							message = _(@"No starred articles in feed \"$name\"");
-					}
-					else if(state == ArticleListState.ALL)
-					{
-						if(searchTerm != "")
-							message = _(@"No articles that fit \"$search\" in feed \"$name\"");
-						else
-							message = _(@"No articles in feed \"$name\"");
-					}
-					break;
-				case FeedListType.TAG:
-					name = dbUI.get_default().getTagName(selectedFeed);
-					if(state == ArticleListState.UNREAD)
-					{
-						if(searchTerm != "")
-							message = _(@"No unread articles that fit \"$search\" in tag \"$name\"");
-						else
-							message = _(@"No unread articles in tag \"$name\"");
-					}
-					else if(state == ArticleListState.MARKED)
-					{
-						if(searchTerm != "")
-							message = _(@"No starred articles that fit \"$search\" in tag \"$name\"");
-						else
-							message = _(@"No starred articles in tag \"$name\"");
-					}
-					else if(state == ArticleListState.ALL)
-					{
-						if(searchTerm != "")
-							message = _(@"No articles that fit \"$search\" in tag \"$name\"");
-						else
-							message = _(@"No articles in tag \"$name\"");
-					}
-					break;
-				case FeedListType.CATEGORY:
-					name = dbUI.get_default().getCategoryName(selectedFeed);
-					if(state == ArticleListState.UNREAD)
-					{
-						if(searchTerm != "")
-							message = _(@"No unread articles that fit \"$search\" in category \"$name\"");
-						else
-							message = _(@"No unread articles in category \"$name\"");
-					}
-					else if(state == ArticleListState.MARKED)
-					{
-						if(searchTerm != "")
-							message = _(@"No starred articles that fit \"$search\" in category \"$name\"");
-						else
-							message = _(@"No starred articles in category \"$name\"");
-					}
-					else if(state == ArticleListState.ALL)
-					{
-						if(searchTerm != "")
-							message = _(@"No articles that fit \"$search\" in category \"$name\"");
-						else
-							message = _(@"No articles in category \"$name\"");
-					}
-					break;
+			case FeedListType.FEED:
+				name = dbUI.get_default().getFeedName(selectedFeed);
+				if(state == ArticleListState.UNREAD)
+				{
+					if(searchTerm != "")
+						message = _(@"No unread articles that fit \"$search\" in feed \"$name\"");
+					else
+						message = _(@"No unread articles in feed \"$name\"");
+				}
+				else if(state == ArticleListState.MARKED)
+				{
+					if(searchTerm != "")
+						message = _(@"No starred articles that fit \"$search\" in feed \"$name\"");
+					else
+						message = _(@"No starred articles in feed \"$name\"");
+				}
+				else if(state == ArticleListState.ALL)
+				{
+					if(searchTerm != "")
+						message = _(@"No articles that fit \"$search\" in feed \"$name\"");
+					else
+						message = _(@"No articles in feed \"$name\"");
+				}
+				break;
+			case FeedListType.TAG:
+				name = dbUI.get_default().getTagName(selectedFeed);
+				if(state == ArticleListState.UNREAD)
+				{
+					if(searchTerm != "")
+						message = _(@"No unread articles that fit \"$search\" in tag \"$name\"");
+					else
+						message = _(@"No unread articles in tag \"$name\"");
+				}
+				else if(state == ArticleListState.MARKED)
+				{
+					if(searchTerm != "")
+						message = _(@"No starred articles that fit \"$search\" in tag \"$name\"");
+					else
+						message = _(@"No starred articles in tag \"$name\"");
+				}
+				else if(state == ArticleListState.ALL)
+				{
+					if(searchTerm != "")
+						message = _(@"No articles that fit \"$search\" in tag \"$name\"");
+					else
+						message = _(@"No articles in tag \"$name\"");
+				}
+				break;
+			case FeedListType.CATEGORY:
+				name = dbUI.get_default().getCategoryName(selectedFeed);
+				if(state == ArticleListState.UNREAD)
+				{
+					if(searchTerm != "")
+						message = _(@"No unread articles that fit \"$search\" in category \"$name\"");
+					else
+						message = _(@"No unread articles in category \"$name\"");
+				}
+				else if(state == ArticleListState.MARKED)
+				{
+					if(searchTerm != "")
+						message = _(@"No starred articles that fit \"$search\" in category \"$name\"");
+					else
+						message = _(@"No starred articles in category \"$name\"");
+				}
+				else if(state == ArticleListState.ALL)
+				{
+					if(searchTerm != "")
+						message = _(@"No articles that fit \"$search\" in category \"$name\"");
+					else
+						message = _(@"No articles in category \"$name\"");
+				}
+				break;
 			}
 		}
 		else

--- a/src/Widgets/ArticleList/ArticleListScroll.vala
+++ b/src/Widgets/ArticleList/ArticleListScroll.vala
@@ -40,8 +40,6 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 	private uint m_savetyFallbackID = 0;
 	private uint m_scrollCooldownID = 0;
 
-
-
 	public ArticleListScroll()
 	{
 		vadjustment.notify["upper"].connect(trackUpper);
@@ -91,8 +89,8 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 	private void checkScrolledTop()
 	{
 		if(m_allowSignals
-		&& vadjustment.value < 2.0
-		&& !m_scrolledTopOnCooldown)
+		   && vadjustment.value < 2.0
+		   && !m_scrolledTopOnCooldown)
 		{
 			m_scrolledTopOnCooldown = true;
 			scrolledTop();
@@ -109,9 +107,9 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 	{
 		double max = vadjustment.upper - vadjustment.page_size;
 		if(m_allowSignals
-		&& max > 0.0
-		&& vadjustment.value >= (max - m_bottomThreshold)
-		&& !m_scrolledBottomOnCooldown)
+		   && max > 0.0
+		   && vadjustment.value >= (max - m_bottomThreshold)
+		   && !m_scrolledBottomOnCooldown)
 		{
 			Logger.debug("ArticleListScroll: scrolled down");
 			m_scrolledBottomOnCooldown = true;
@@ -139,14 +137,14 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 			m_scrolledBottomOnCooldown = false;
 			if(m_savetyFallbackID != 0)
 			{
-				GLib.Source.remove(m_savetyFallbackID);
-				m_savetyFallbackID = 0;
+			    GLib.Source.remove(m_savetyFallbackID);
+			    m_savetyFallbackID = 0;
 			}
 			double max = vadjustment.upper - vadjustment.page_size;
 			if(vadjustment.value >= max - 5)
 			{
-				Logger.debug("ArticleListScroll: trigger scrolledBottom()");
-				scrolledBottom();
+			    Logger.debug("ArticleListScroll: trigger scrolledBottom()");
+			    scrolledBottom();
 			}
 
 			return GLib.Source.REMOVE;
@@ -187,12 +185,12 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 			}
 
 			Logger.debug(@"ArticleListScroll.scrollToPos: leftOverScroll $leftOverScroll");
-			Logger.debug(@"ArticleListScroll.scrollToPos: %f".printf(pos+leftOverScroll));
+			Logger.debug(@"ArticleListScroll.scrollToPos: %f".printf(pos + leftOverScroll));
 
 			if(pos == -1)
 				m_transitionDiff = (vadjustment.upper - vadjustment.page_size - vadjustment.value);
 			else
-				m_transitionDiff = (pos-this.vadjustment.value)+leftOverScroll;
+				m_transitionDiff = (pos - this.vadjustment.value) + leftOverScroll;
 
 			m_transitionStartValue = this.vadjustment.value;
 			Logger.debug(@"ArticleListScroll.scrollDiff: startValue $m_transitionStartValue");
@@ -231,7 +229,7 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 		row.translate_coordinates(this, 0, 0, out x, out y);
 
 		// row is (additionalRows * rowHeight) above the current viewport
-		if(y < -( (1+additionalRows) * rowHeight))
+		if(y < -( (1 + additionalRows) * rowHeight))
 			return -1;
 
 		// row is (additionalRows * rowHeight) below the current viewport
@@ -274,7 +272,7 @@ public class FeedReader.ArticleListScroll : Gtk.ScrolledWindow {
 	inline double easeOutCubic(double t)
 	{
 		double p = t - 1;
-		return p * p * p +1;
+		return p * p * p + 1;
 	}
 
 	public void allowSignals(bool allow)

--- a/src/Widgets/ArticleRow.vala
+++ b/src/Widgets/ArticleRow.vala
@@ -102,7 +102,6 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		m_unread_eventbox.leave_notify_event.connect(unreadIconLeave);
 		m_unread_eventbox.button_press_event.connect(unreadIconClicked);
 
-
 		m_marked_eventbox = new Gtk.EventBox();
 		m_marked_eventbox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK);
 		m_marked_eventbox.set_events(Gdk.EventMask.ENTER_NOTIFY_MASK);
@@ -120,7 +119,6 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		m_marked_eventbox.enter_notify_event.connect(markedIconEnter);
 		m_marked_eventbox.leave_notify_event.connect(markedIconLeave);
 		m_marked_eventbox.button_press_event.connect(markedIconClicked);
-
 
 		m_icon = getFeedIcon();
 		icon_box.pack_start(m_icon, true, true, 0);
@@ -140,7 +138,6 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 			else
 				short_preview = m_article.getPreview();
 		}
-
 
 		var body_label = new Gtk.Label(short_preview);
 		body_label.opacity = 0.7;
@@ -163,7 +160,6 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		var date_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);
 		date_box.pack_start(feedLabel, true, true, 0);
 		date_box.pack_end(dateLabel, true, true, 0);
-
 
 		var text_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 		text_box.margin_end = 15;
@@ -191,19 +187,19 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		{
 			// Make the this widget a DnD source.
 			if(!Settings.general().get_boolean("only-feeds")
-			&& DBusConnection.get_default().isOnline()
-			&& DBusConnection.get_default().supportTags())
+			   && DBusConnection.get_default().isOnline()
+			   && DBusConnection.get_default().supportTags())
 			{
 				const Gtk.TargetEntry[] provided_targets = {
 					{ "STRING",     0, DragTarget.TAG }
 				};
 
 				Gtk.drag_source_set(
-						this,
-						Gdk.ModifierType.BUTTON1_MASK,
-						provided_targets,
-						Gdk.DragAction.COPY
-				);
+					this,
+					Gdk.ModifierType.BUTTON1_MASK,
+					provided_targets,
+					Gdk.DragAction.COPY
+					);
 
 				this.drag_begin.connect(onDragBegin);
 				this.drag_data_get.connect(onDragDataGet);
@@ -255,7 +251,6 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		return new Gtk.Image.from_icon_name("feed-rss-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
 	}
 
-
 	private Gtk.Window getFeedIconWindow()
 	{
 		var window = new Gtk.Window(Gtk.WindowType.POPUP);
@@ -267,7 +262,6 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		return window;
 	}
 
-
 	private bool rowEnter(Gdk.EventCrossing event)
 	{
 		if(event.detail == Gdk.NotifyType.INFERIOR)
@@ -277,22 +271,22 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 
 		switch(m_article.getUnread())
 		{
-			case ArticleStatus.READ:
-				m_unread_stack.set_visible_child_name("read");
-				break;
-			case ArticleStatus.UNREAD:
-				m_unread_stack.set_visible_child_name("unread");
-				break;
+		case ArticleStatus.READ:
+			m_unread_stack.set_visible_child_name("read");
+			break;
+		case ArticleStatus.UNREAD:
+			m_unread_stack.set_visible_child_name("unread");
+			break;
 		}
 
 		switch(m_article.getMarked())
 		{
-			case ArticleStatus.MARKED:
-				m_marked_stack.set_visible_child_name("marked");
-				break;
-			case ArticleStatus.UNMARKED:
-				m_marked_stack.set_visible_child_name("unmarked");
-				break;
+		case ArticleStatus.MARKED:
+			m_marked_stack.set_visible_child_name("marked");
+			break;
+		case ArticleStatus.UNMARKED:
+			m_marked_stack.set_visible_child_name("unmarked");
+			break;
 		}
 
 		return true;
@@ -307,22 +301,22 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 
 		switch(m_article.getUnread())
 		{
-			case ArticleStatus.READ:
-				m_unread_stack.set_visible_child_name("empty");
-				break;
-			case ArticleStatus.UNREAD:
-				m_unread_stack.set_visible_child_name("unread");
-				break;
+		case ArticleStatus.READ:
+			m_unread_stack.set_visible_child_name("empty");
+			break;
+		case ArticleStatus.UNREAD:
+			m_unread_stack.set_visible_child_name("unread");
+			break;
 		}
 
 		switch(m_article.getMarked())
 		{
-			case ArticleStatus.MARKED:
-				m_marked_stack.set_visible_child_name("marked");
-				break;
-			case ArticleStatus.UNMARKED:
-				m_marked_stack.set_visible_child_name("empty");
-				break;
+		case ArticleStatus.MARKED:
+			m_marked_stack.set_visible_child_name("marked");
+			break;
+		case ArticleStatus.UNMARKED:
+			m_marked_stack.set_visible_child_name("empty");
+			break;
 		}
 
 		return true;
@@ -341,22 +335,21 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 		try{
 			Gtk.show_uri_on_window(MainWindow.get_default(), m_article.getURL(), Gdk.CURRENT_TIME);
 		}
-		catch(GLib.Error e){
+		catch(GLib.Error e) {
 			Logger.debug("could not open the link in an external browser: %s".printf(e.message));
 		}
 
 		return true;
 	}
 
-
 	private bool unreadIconClicked(Gdk.EventButton event)
 	{
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 		toggleUnread();
 		rowStateChanged(m_article.getUnread());
@@ -371,22 +364,22 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 
 		switch(m_article.getUnread())
 		{
-			case ArticleStatus.READ:
-				updateUnread(ArticleStatus.UNREAD);
-				unread = true;
-				if(articleID != "" && articleID == m_article.getArticleID())
-				{
-					view.getHeader().setRead(true);
-				}
-				break;
-			case ArticleStatus.UNREAD:
-				updateUnread(ArticleStatus.READ);
-				unread = false;
-				if(articleID != "" && articleID == m_article.getArticleID())
-				{
-					view.getHeader().setRead(false);
-				}
-				break;
+		case ArticleStatus.READ:
+			updateUnread(ArticleStatus.UNREAD);
+			unread = true;
+			if(articleID != "" && articleID == m_article.getArticleID())
+			{
+				view.getHeader().setRead(true);
+			}
+			break;
+		case ArticleStatus.UNREAD:
+			updateUnread(ArticleStatus.READ);
+			unread = false;
+			if(articleID != "" && articleID == m_article.getArticleID())
+			{
+				view.getHeader().setRead(false);
+			}
+			break;
 		}
 
 		try
@@ -434,21 +427,20 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 	private bool unreadIconEnter()
 	{
 		m_hovering_unread = true;
-		if(m_article.getUnread() == ArticleStatus.READ){
+		if(m_article.getUnread() == ArticleStatus.READ) {
 			m_unread_stack.set_visible_child_name("unread");
 		}
-		else if(m_article.getUnread() == ArticleStatus.UNREAD){
+		else if(m_article.getUnread() == ArticleStatus.UNREAD) {
 			m_unread_stack.set_visible_child_name("read");
 		}
 		this.show_all();
 		return true;
 	}
 
-
 	private bool unreadIconLeave()
 	{
 		m_hovering_unread = false;
-		if(m_article.getUnread() == ArticleStatus.READ){
+		if(m_article.getUnread() == ArticleStatus.READ) {
 			m_unread_stack.set_visible_child_name("read");
 		}
 		else{
@@ -462,10 +454,10 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 	{
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 		toggleMarked();
 		rowStateChanged(m_article.getMarked());
@@ -480,23 +472,23 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 
 		switch(m_article.getMarked())
 		{
-			case ArticleStatus.MARKED:
-				updateMarked(ArticleStatus.UNMARKED);
-				marked = false;
-				if(articleID != "" && articleID == m_article.getArticleID())
-				{
-					view.getHeader().setMarked(false);
-				}
-				break;
+		case ArticleStatus.MARKED:
+			updateMarked(ArticleStatus.UNMARKED);
+			marked = false;
+			if(articleID != "" && articleID == m_article.getArticleID())
+			{
+				view.getHeader().setMarked(false);
+			}
+			break;
 
-			case ArticleStatus.UNMARKED:
-				updateMarked(ArticleStatus.MARKED);
-				marked = true;
-				if(articleID != "" && articleID == m_article.getArticleID())
-				{
-					view.getHeader().setMarked(true);
-				}
-				break;
+		case ArticleStatus.UNMARKED:
+			updateMarked(ArticleStatus.MARKED);
+			marked = true;
+			if(articleID != "" && articleID == m_article.getArticleID())
+			{
+				view.getHeader().setMarked(true);
+			}
+			break;
 		}
 
 		try
@@ -518,20 +510,20 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 			m_article.setMarked(marked);
 			switch(m_article.getMarked())
 			{
-				case ArticleStatus.MARKED:
-					m_marked_stack.set_visible_child_name("marked");
-					break;
+			case ArticleStatus.MARKED:
+				m_marked_stack.set_visible_child_name("marked");
+				break;
 
-				case ArticleStatus.UNMARKED:
-					if(m_hovering_row)
-					{
-						m_marked_stack.set_visible_child_name("unmarked");
-					}
-					else
-					{
-						m_marked_stack.set_visible_child_name("empty");
-					}
-					break;
+			case ArticleStatus.UNMARKED:
+				if(m_hovering_row)
+				{
+					m_marked_stack.set_visible_child_name("unmarked");
+				}
+				else
+				{
+					m_marked_stack.set_visible_child_name("empty");
+				}
+				break;
 			}
 		}
 	}
@@ -539,24 +531,23 @@ public class FeedReader.articleRow : Gtk.ListBoxRow {
 	private bool markedIconEnter()
 	{
 		m_hovering_marked = true;
-		if(m_article.getMarked() == ArticleStatus.UNMARKED){
+		if(m_article.getMarked() == ArticleStatus.UNMARKED) {
 			m_marked_stack.set_visible_child_name("marked");
 		}
-		else if (m_article.getMarked() == ArticleStatus.MARKED){
+		else if (m_article.getMarked() == ArticleStatus.MARKED) {
 			m_marked_stack.set_visible_child_name("unmarked");
 		}
 		this.show_all();
 		return true;
 	}
 
-
 	private bool markedIconLeave()
 	{
 		m_hovering_marked = false;
-		if(m_article.getMarked() == ArticleStatus.UNMARKED){
+		if(m_article.getMarked() == ArticleStatus.UNMARKED) {
 			m_marked_stack.set_visible_child_name("unmarked");
 		}
-		else if(m_article.getMarked() == ArticleStatus.MARKED){
+		else if(m_article.getMarked() == ArticleStatus.MARKED) {
 			m_marked_stack.set_visible_child_name("marked");
 		}
 		this.show_all();

--- a/src/Widgets/ArticleView.vala
+++ b/src/Widgets/ArticleView.vala
@@ -26,16 +26,16 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	private Gtk.Overlay m_videoOverlay;
 	private ArticleViewUrlOverlay m_UrlOverlay;
 	private Gtk.Stack m_stack;
-	private WebKit.WebView? m_currentView = null;
-	private Gdk.RGBA? m_color = null;
+	private WebKit.WebView ? m_currentView = null;
+	private Gdk.RGBA ? m_color = null;
 	private FullscreenHeader m_fsHead;
 	private fullscreenButton m_prevButton;
 	private fullscreenButton m_nextButton;
 	private ArticleViewLoadProgress m_progress;
 	private string m_currentArticle;
-	private string? m_nextArticle = null;
+	private string ? m_nextArticle = null;
 	private bool m_busy = false;
-	private MediaPlayer? m_currentMedia = null;
+	private MediaPlayer ? m_currentMedia = null;
 	private bool m_firstTime = true;
 	private string m_searchTerm = "";
 	private double m_dragBuffer[10];
@@ -53,7 +53,6 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	private bool m_FullscreenArticle = false;
 	private double m_FullscreenZoomLevel = 1.25;
 	private uint m_animationDuration = 150;
-
 
 	public ArticleView()
 	{
@@ -84,7 +83,6 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		crashView.pack_start(crashLabelBox);
 		crashView.pack_start(crashButton);
 
-
 		m_UrlOverlay = new ArticleViewUrlOverlay();
 		m_stack = new Gtk.Stack();
 		m_stack.add_named(emptyView, "empty");
@@ -96,13 +94,13 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 
 		this.size_allocate.connect((allocation) => {
 			if(allocation.width != m_width
-			|| allocation.height != m_height)
+			   || allocation.height != m_height)
 			{
-				m_width = allocation.width;
-				m_height = allocation.height;
-				Logger.debug("ArticleView: size changed");
-				setBackgroundColor();
-				recalculate.begin((obj, res) => {
+			    m_width = allocation.width;
+			    m_height = allocation.height;
+			    Logger.debug("ArticleView: size changed");
+			    setBackgroundColor();
+			    recalculate.begin((obj, res) => {
 					recalculate.end(res);
 				});
 			}
@@ -150,7 +148,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		});
 
 		Bus.watch_name(BusType.SESSION, "org.gnome.FeedReader.ArticleView", GLib.BusNameWatcherFlags.NONE,
-		(connection, name, owner) => { on_extension_appeared(connection, name, owner); }, null);
+		               (connection, name, owner) => { on_extension_appeared(connection, name, owner); }, null);
 	}
 
 	private WebKit.WebView getNewView()
@@ -249,12 +247,12 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 
 			m_currentView.load_html(
 				UtilsUI.buildArticle(
-						Article.getHTML(),
-						Article.getTitle(),
-						Article.getURL(),
-						Article.getAuthor(),
-						Article.getDateNice(true),
-						Article.getFeedID()
+					Article.getHTML(),
+					Article.getTitle(),
+					Article.getURL(),
+					Article.getAuthor(),
+					Article.getDateNice(true),
+					Article.getFeedID()
 					)
 				, "file://" + GLib.Environment.get_user_data_dir() + "/feedreader/data/images/");
 			this.show_all();
@@ -268,45 +266,44 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 
 		switch(m_stack.get_visible_child_name())
 		{
-			case "empty":
-			case "crash":
-				Logger.debug("ArticleView: %s -> view1".printf(m_stack.get_visible_child_name()));
-				m_currentView = getNewView();
-				m_stack.add_named(m_currentView, "view1");
-				m_stack.set_visible_child_name("view1");
-				m_busy = false;
-				break;
+		case "empty":
+		case "crash":
+			Logger.debug("ArticleView: %s -> view1".printf(m_stack.get_visible_child_name()));
+			m_currentView = getNewView();
+			m_stack.add_named(m_currentView, "view1");
+			m_stack.set_visible_child_name("view1");
+			m_busy = false;
+			break;
 
+		case "view1":
+			Logger.debug("ArticleView: view1 -> view2");
+			m_currentView = getNewView();
+			m_stack.add_named(m_currentView, "view2");
+			m_stack.set_visible_child_name("view2");
+			GLib.Timeout.add((uint)(1.2 * m_animationDuration), () => {
+				var oldView = m_stack.get_child_by_name("view1");
+				if(oldView != null)
+					m_stack.remove(oldView);
 
-			case "view1":
-				Logger.debug("ArticleView: view1 -> view2");
-				m_currentView = getNewView();
-				m_stack.add_named(m_currentView, "view2");
-				m_stack.set_visible_child_name("view2");
-				GLib.Timeout.add((uint)(1.2*m_animationDuration), () => {
-					var oldView = m_stack.get_child_by_name("view1");
-					if(oldView != null)
-						m_stack.remove(oldView);
+				checkQueue();
+				return false;
+			}, GLib.Priority.HIGH);
+			break;
 
-					checkQueue();
-					return false;
-				}, GLib.Priority.HIGH);
-				break;
+		case "view2":
+			Logger.debug("ArticleView: view2 -> view1");
+			m_currentView = getNewView();
+			m_stack.add_named(m_currentView, "view1");
+			m_stack.set_visible_child_name("view1");
+			GLib.Timeout.add((uint)(1.2 * m_animationDuration), () => {
+				var oldView = m_stack.get_child_by_name("view2");
+				if(oldView != null)
+					m_stack.remove(oldView);
 
-			case "view2":
-				Logger.debug("ArticleView: view2 -> view1");
-				m_currentView = getNewView();
-				m_stack.add_named(m_currentView, "view1");
-				m_stack.set_visible_child_name("view1");
-				GLib.Timeout.add((uint)(1.2*m_animationDuration), () => {
-					var oldView = m_stack.get_child_by_name("view2");
-					if(oldView != null)
-						m_stack.remove(oldView);
-
-					checkQueue();
-					return false;
-				}, GLib.Priority.HIGH);
-				break;
+				checkQueue();
+				return false;
+			}, GLib.Priority.HIGH);
+			break;
 		}
 
 		if(m_FullscreenArticle)
@@ -338,13 +335,13 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	public void clearContent()
 	{
 		m_busy = true;
-		Gtk.Widget? oldView = null;
+		Gtk.Widget ? oldView = null;
 		if(m_stack.get_visible_child_name() != "empty"
-		&& m_stack.get_visible_child_name() != "crash")
+		   && m_stack.get_visible_child_name() != "crash")
 			oldView = m_stack.get_visible_child();
 		m_progress.reveal(false);
 		m_stack.set_visible_child_name("empty");
-		GLib.Timeout.add((uint)(1.2*m_animationDuration), () => {
+		GLib.Timeout.add((uint)(1.2 * m_animationDuration), () => {
 			if(oldView != null)
 				m_stack.remove(oldView);
 			checkQueue();
@@ -362,76 +359,76 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	{
 		switch (load_event)
 		{
-			case WebKit.LoadEvent.STARTED:
-				Logger.debug("ArticleView: load STARTED");
-				string url = m_currentView.get_uri();
-				if(url != "file://" + GLib.Environment.get_user_data_dir() + "/feedreader/data/images/")
+		case WebKit.LoadEvent.STARTED:
+			Logger.debug("ArticleView: load STARTED");
+			string url = m_currentView.get_uri();
+			if(url != "file://" + GLib.Environment.get_user_data_dir() + "/feedreader/data/images/")
+			{
+				Logger.debug(@"ArticleView: open external url: $url");
+				try
 				{
-					Logger.debug(@"ArticleView: open external url: $url");
-					try
-					{
-						Gtk.show_uri(Gdk.Screen.get_default(), url, Gdk.CURRENT_TIME);
-					}
-					catch(GLib.Error e)
-					{
-						Logger.debug("could not open the link in an external browser: %s".printf(e.message));
-					}
-					m_currentView.stop_loading();
+					Gtk.show_uri(Gdk.Screen.get_default(), url, Gdk.CURRENT_TIME);
 				}
-				break;
-			case WebKit.LoadEvent.COMMITTED:
-				Logger.debug("ArticleView: load COMMITTED");
-				if(m_searchTerm != "")
-					m_currentView.get_find_controller().search(m_searchTerm, WebKit.FindOptions.CASE_INSENSITIVE, 99);
-				break;
-			case WebKit.LoadEvent.FINISHED:
-				Logger.debug("ArticleView: load FINISHED");
-				if(m_firstTime)
+				catch(GLib.Error e)
 				{
-					setScrollPos(Settings.state().get_int("articleview-scrollpos"));
-					Settings.state().set_int("articleview-scrollpos", 0);
-					m_currentView.grab_focus();
-					m_firstTime = false;
+					Logger.debug("could not open the link in an external browser: %s".printf(e.message));
 				}
-				recalculate.begin((obj, res) => {
-					recalculate.end(res);
-				});
-				break;
-			default:
-				Logger.debug("ArticleView: load ??????");
-				break;
+				m_currentView.stop_loading();
+			}
+			break;
+		case WebKit.LoadEvent.COMMITTED:
+			Logger.debug("ArticleView: load COMMITTED");
+			if(m_searchTerm != "")
+				m_currentView.get_find_controller().search(m_searchTerm, WebKit.FindOptions.CASE_INSENSITIVE, 99);
+			break;
+		case WebKit.LoadEvent.FINISHED:
+			Logger.debug("ArticleView: load FINISHED");
+			if(m_firstTime)
+			{
+				setScrollPos(Settings.state().get_int("articleview-scrollpos"));
+				Settings.state().set_int("articleview-scrollpos", 0);
+				m_currentView.grab_focus();
+				m_firstTime = false;
+			}
+			recalculate.begin((obj, res) => {
+				recalculate.end(res);
+			});
+			break;
+		default:
+			Logger.debug("ArticleView: load ??????");
+			break;
 		}
 	}
 
 	/*private bool loadFailed(WebKit.LoadEvent event, string failing_uri, void* error)
-	{
-		GLib.Error e = (GLib.Error)error;
-		Logger.error("ArticleView: load failed: message: \"%s\", domain \"%s\", code \"%i\"".printf(e.message, e.domain.to_string(), e.code));
-		if(e.matches(WebKit.NetworkError.quark(), 302))
-		{
-			Logger.debug("ArticleView: loading canceled " + m_currentArticle);
-			WebKit.WebContext.get_default().clear_cache();
-			load();
-		}
-		return true;
-	}*/
+	   {
+	    GLib.Error e = (GLib.Error)error;
+	    Logger.error("ArticleView: load failed: message: \"%s\", domain \"%s\", code \"%i\"".printf(e.message, e.domain.to_string(), e.code));
+	    if(e.matches(WebKit.NetworkError.quark(), 302))
+	    {
+	        Logger.debug("ArticleView: loading canceled " + m_currentArticle);
+	        WebKit.WebContext.get_default().clear_cache();
+	        load();
+	    }
+	    return true;
+	   }*/
 
 	public void setScrollPos(int pos)
 	{
 		if(m_stack.get_visible_child_name() == "empty"
-		|| m_stack.get_visible_child_name() == "crash"
-		|| m_currentView == null)
+		   || m_stack.get_visible_child_name() == "crash"
+		   || m_currentView == null)
 			return;
 
 		m_busy = true;
 		m_currentView.run_javascript.begin("window.scrollTo(0,%i);".printf(pos), null, (obj, res) => {
 			try
 			{
-				m_currentView.run_javascript.end(res);
+			    m_currentView.run_javascript.end(res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("ArticleView.setScrollPos: %s".printf(e.message));
+			    Logger.error("ArticleView.setScrollPos: %s".printf(e.message));
 			}
 			checkQueue();
 		});
@@ -440,8 +437,8 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	private int getScollUpper()
 	{
 		if(m_stack.get_visible_child_name() == "empty"
-		|| m_stack.get_visible_child_name() == "crash"
-		|| m_currentView == null)
+		   || m_stack.get_visible_child_name() == "crash"
+		   || m_currentView == null)
 			return 0;
 
 		string javascript = """
@@ -460,11 +457,11 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		m_currentView.run_javascript.begin(javascript, null, (obj, res) => {
 			try
 			{
-				m_currentView.run_javascript.end(res);
+			    m_currentView.run_javascript.end(res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("ArticleView.setScrollPos: %s".printf(e.message));
+			    Logger.error("ArticleView.setScrollPos: %s".printf(e.message));
 			}
 			upper = int.parse(m_currentView.get_title());
 			checkQueue();
@@ -478,8 +475,8 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	public int getScrollPos()
 	{
 		if(m_stack.get_visible_child_name() == "empty"
-		|| m_stack.get_visible_child_name() == "crash"
-		|| m_currentView == null)
+		   || m_stack.get_visible_child_name() == "crash"
+		   || m_currentView == null)
 			return 0;
 
 		// use mainloop to prevent app from shutting down before the result can be fetched
@@ -493,11 +490,11 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		m_currentView.run_javascript.begin("document.title = window.scrollY;", null, (obj, res) => {
 			try
 			{
-				m_currentView.run_javascript.end(res);
+			    m_currentView.run_javascript.end(res);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("ArticleView: could not get scroll-pos, javascript error: " + e.message);
+			    Logger.error("ArticleView: could not get scroll-pos, javascript error: " + e.message);
 			}
 			scrollPos = int.parse(m_currentView.get_title());
 			checkQueue();
@@ -508,12 +505,10 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		return scrollPos;
 	}
 
-
 	public void setSearchTerm(string searchTerm)
 	{
 		m_searchTerm = Utils.parseSearchTerm(searchTerm);
 	}
-
 
 	private void on_extension_appeared(GLib.DBusConnection connection, string name, string owner)
 	{
@@ -543,17 +538,17 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		SourceFunc callback = recalculate.callback;
 		ThreadFunc<void*> run = () => {
 			try
-	    	{
-	    		if(m_connected
-				&& m_stack.get_visible_child_name() != "empty"
-				&& m_stack.get_visible_child_name() != "crash"
-				&& m_currentView != null)
-	    			m_messenger.recalculate();
-	    	}
-	    	catch(GLib.IOError e)
-	    	{
-	    		Logger.warning("ArticleView: recalculate " + e.message);
-	    	}
+			{
+				if(m_connected
+				   && m_stack.get_visible_child_name() != "empty"
+				   && m_stack.get_visible_child_name() != "crash"
+				   && m_currentView != null)
+					m_messenger.recalculate();
+			}
+			catch(GLib.IOError e)
+			{
+				Logger.warning("ArticleView: recalculate " + e.message);
+			}
 			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
 			return null;
 		};
@@ -584,7 +579,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 				cursor,
 				null,
 				null
-			);
+				);
 
 			Gtk.device_grab_add(this, pointer, false);
 			GLib.Timeout.add(10, updateDragMomentum, GLib.Priority.HIGH);
@@ -628,17 +623,17 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		{
 			switch(event.direction)
 			{
-				case Gdk.ScrollDirection.UP:
-					m_currentView.zoom_level -= 0.25;
-					break;
+			case Gdk.ScrollDirection.UP:
+				m_currentView.zoom_level -= 0.25;
+				break;
 
-				case Gdk.ScrollDirection.DOWN:
-					m_currentView.zoom_level += 0.25;
-					break;
+			case Gdk.ScrollDirection.DOWN:
+				m_currentView.zoom_level += 0.25;
+				break;
 
-				case Gdk.ScrollDirection.SMOOTH:
-					m_currentView.zoom_level -= 10 * (event.delta_y / event.y_root);
-					break;
+			case Gdk.ScrollDirection.SMOOTH:
+				m_currentView.zoom_level -= 10 * (event.delta_y / event.y_root);
+				break;
 			}
 
 			return true;
@@ -653,20 +648,20 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		{
 			switch(event.keyval)
 			{
-				case Gdk.Key.KP_0:
-					if(m_FullscreenArticle)
-						m_currentView.zoom_level = m_FullscreenZoomLevel;
-					else
-						m_currentView.zoom_level = 1.0;
-					return true;
+			case Gdk.Key.KP_0:
+				if(m_FullscreenArticle)
+					m_currentView.zoom_level = m_FullscreenZoomLevel;
+				else
+					m_currentView.zoom_level = 1.0;
+				return true;
 
-				case Gdk.Key.KP_Add:
-					m_currentView.zoom_level += 0.25;
-					return true;
+			case Gdk.Key.KP_Add:
+				m_currentView.zoom_level += 0.25;
+				return true;
 
-				case Gdk.Key.KP_Subtract:
-					m_currentView.zoom_level -= 0.25;
-					return true;
+			case Gdk.Key.KP_Subtract:
+				m_currentView.zoom_level -= 0.25;
+				return true;
 			}
 		}
 
@@ -682,7 +677,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		return false;
 	}
 
-	public void load(string? id = null)
+	public void load(string ? id = null)
 	{
 		string articleID = (id == null) ? m_currentArticle : id;
 		fillContent.begin(articleID, (obj, res) => {
@@ -697,7 +692,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 
 		for(int i = 9; i > 0; --i)
 		{
-			m_dragBuffer[i] = m_dragBuffer[i-1];
+			m_dragBuffer[i] = m_dragBuffer[i - 1];
 		}
 
 		m_dragBuffer[0] = m_posY;
@@ -722,7 +717,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		double upper = getScollUpper() * m_currentView.zoom_level;
 
 		if ((oldAdj + adjValue) > (upper - pageSize)
-		|| (oldAdj + adjValue) < 0)
+		    || (oldAdj + adjValue) < 0)
 		{
 			m_momentum = 0;
 		}
@@ -762,9 +757,9 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 			}
 
 			if((menuItem.get_action().name != "context-menu-action-3")  // copy link location
-			&& (menuItem.get_action().name != "context-menu-action-9")  // copy text
-			&& (menuItem.get_action().name != "context-menu-action-6")  // copy image
-			&& (menuItem.get_action().name != "context-menu-action-7")) // copy image address
+			   && (menuItem.get_action().name != "context-menu-action-9") // copy text
+			   && (menuItem.get_action().name != "context-menu-action-6") // copy image
+			   && (menuItem.get_action().name != "context-menu-action-7")) // copy image address
 			{
 				menu.remove(menuItem);
 			}
@@ -791,8 +786,8 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		if(hitTest.context_is_link())
 		{
 			var align = Gtk.Align.START;
-			double relX = m_posX2/this.get_allocated_height();
-			double relY = m_posY2/this.get_allocated_width();
+			double relX = m_posX2 / this.get_allocated_height();
+			double relY = m_posY2 / this.get_allocated_width();
 
 			if(relY >= 0.85 && relX <= 0.5)
 				align = Gtk.Align.END;
@@ -881,7 +876,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 	private void printProgress()
 	{
 		double progress = m_currentView.estimated_load_progress;
-		Logger.debug("ArticleView: loading %u %%".printf((uint)(progress*100)));
+		Logger.debug("ArticleView: loading %u %%".printf((uint)(progress * 100)));
 
 		m_progress.setPercentageF(progress);
 
@@ -914,11 +909,11 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		m_busy = true;
 		m_progress.setPercentage(0);
 		m_progress.reveal(false);
-		Gtk.Widget? oldView = null;
+		Gtk.Widget ? oldView = null;
 		if(m_stack.get_visible_child_name() != "crash")
 			oldView = m_stack.get_visible_child();
 		m_stack.set_visible_child_name("crash");
-		GLib.Timeout.add((uint)(1.2*m_animationDuration), () => {
+		GLib.Timeout.add((uint)(1.2 * m_animationDuration), () => {
 			if(oldView != null)
 				m_stack.remove(oldView);
 			checkQueue();
@@ -976,7 +971,7 @@ public class FeedReader.ArticleView : Gtk.Overlay {
 		op.set_page_setup(setup);
 
 		op.failed.connect((error) => {
-			Logger.debug("ArticleView: print failed: "+ error.message);
+			Logger.debug("ArticleView: print failed: " + error.message);
 		});
 
 		op.finished.connect(() => {

--- a/src/Widgets/ArticleViewHeader.vala
+++ b/src/Widgets/ArticleViewHeader.vala
@@ -13,7 +13,6 @@
 //	You should have received a copy of the GNU General Public License
 //	along with FeedReader.  If not, see <http://www.gnu.org/licenses/>.
 
-
 public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 
 	private Gtk.Button m_share_button;
@@ -23,7 +22,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 	private HoverButton m_mark_button;
 	private HoverButton m_read_button;
 	private Gtk.Button m_fullscreen_button;
-	private SharePopover? m_sharePopover = null;
+	private SharePopover ? m_sharePopover = null;
 	public signal void toggledMarked();
 	public signal void toggledRead();
 	public signal void fsClick();
@@ -75,7 +74,6 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 			});
 		});
 
-
 		m_print_button = new Gtk.Button.from_icon_name("printer-symbolic");
 		m_print_button.set_relief(Gtk.ReliefStyle.NONE);
 		m_print_button.set_focus_on_click(false);
@@ -84,7 +82,6 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 		m_print_button.clicked.connect(() => {
 			ColumnView.get_default().print();
 		});
-
 
 		m_share_button = new Gtk.Button();
 		m_share_button.add(share_icon);
@@ -148,7 +145,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 		try
 		{
 			if(DBusConnection.get_default().supportTags()
-			&& UtilsUI.canManipulateContent())
+			   && UtilsUI.canManipulateContent())
 			{
 				m_tag_button.sensitive = (show && FeedReaderApp.get_default().isOnline());
 			}
@@ -185,7 +182,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 		{
 			m_share_button.sensitive = false;
 			if(UtilsUI.canManipulateContent()
-			&& DBusConnection.get_default().supportTags())
+			   && DBusConnection.get_default().supportTags())
 				m_tag_button.sensitive = false;
 		}
 		catch(GLib.Error e)
@@ -202,7 +199,7 @@ public class FeedReader.ArticleViewHeader : Gtk.HeaderBar {
 			{
 				m_share_button.sensitive = true;
 				if(UtilsUI.canManipulateContent()
-				&& DBusConnection.get_default().supportTags())
+				   && DBusConnection.get_default().supportTags())
 					m_tag_button.sensitive = true;
 			}
 		}

--- a/src/Widgets/ArticleViewLoadProgress.vala
+++ b/src/Widgets/ArticleViewLoadProgress.vala
@@ -52,9 +52,9 @@ public class FeedReader.ArticleViewLoadProgress : Gtk.Revealer {
 			this.visible = true;
 			m_progress.show();
 			m_timeout_source_id = Timeout.add(300, () => {
-				  this.set_reveal_child(true);
-				  m_timeout_source_id = 0;
-				  return false;
+				this.set_reveal_child(true);
+				m_timeout_source_id = 0;
+				return false;
 			});
 		}
 		else
@@ -67,6 +67,5 @@ public class FeedReader.ArticleViewLoadProgress : Gtk.Revealer {
 	{
 		reveal(false);
 	}
-
 
 }

--- a/src/Widgets/ArticleViewUrlOverlay.vala
+++ b/src/Widgets/ArticleViewUrlOverlay.vala
@@ -38,7 +38,7 @@ public class FeedReader.ArticleViewUrlOverlay : Gtk.Revealer {
 		string url = uri;
 		if(url.length >= length)
 		{
-			url = url.substring(0, length-3) + "...";
+			url = url.substring(0, length - 3) + "...";
 		}
 		m_label.label = url;
 		m_label.width_chars = url.length;

--- a/src/Widgets/BackendInfoPopover.vala
+++ b/src/Widgets/BackendInfoPopover.vala
@@ -29,18 +29,15 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 		typeLabel.get_style_context().add_class("h3");
 		typeLabel.set_alignment(0.0f, 0.5f);
 
-
 		var licenseLabel = new Gtk.Label("License:");
 		licenseLabel.hexpand = true;
 		licenseLabel.get_style_context().add_class("h3");
 		licenseLabel.set_alignment(0.0f, 0.5f);
 
-
 		var priceLabel = new Gtk.Label("Price:");
 		priceLabel.hexpand = true;
 		priceLabel.get_style_context().add_class("h3");
 		priceLabel.set_alignment(0.0f, 0.5f);
-
 
 		var grid = new Gtk.Grid();
 		grid.set_column_spacing(20);
@@ -49,8 +46,6 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 		grid.attach(typeLabel, 0, 0, 1, 1);
 		grid.attach(licenseLabel, 0, 1, 1, 1);
 		grid.attach(priceLabel, 0, 2, 1, 1);
-
-
 
 		if(BackendFlags.LOCAL in flags)
 		{
@@ -73,7 +68,6 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 				space = 50;
 			}
 		}
-
 
 		if(BackendFlags.FREE_SOFTWARE in flags)
 		{
@@ -102,7 +96,6 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 			grid.attach(icon, 1, 2, 1, 1);
 		}
 
-
 		var nameLabel = new Gtk.Label(m_ext.serviceName());
 		nameLabel.get_style_context().add_class("h2");
 		nameLabel.set_alignment(0.0f, 0.5f);
@@ -125,7 +118,6 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 		box.pack_start(separator, false, false, 0);
 		box.pack_start(grid, true, true, 0);
 
-
 		this.add(box);
 		this.set_relative_to(widget);
 		this.set_position(Gtk.PositionType.BOTTOM);
@@ -143,10 +135,10 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 
 		try
@@ -167,6 +159,5 @@ public class FeedReader.BackendInfoPopover : Gtk.Popover {
 		icon.set_tooltip_text(tooltip);
 		return icon;
 	}
-
 
 }

--- a/src/Widgets/CategorieRow.vala
+++ b/src/Widgets/CategorieRow.vala
@@ -57,7 +57,6 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		var rowhight = 30;
 		m_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 
-
 		m_icon_collapsed = new Gtk.Image.from_icon_name("feed-sidebar-arrow-side-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		m_icon_collapsed.get_style_context().add_class("fr-sidebar-symbolic");
 		m_icon_collapsed.opacity = m_opacity;
@@ -65,8 +64,6 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		m_icon_expanded = new Gtk.Image.from_icon_name("feed-sidebar-arrow-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		m_icon_expanded.get_style_context().add_class("fr-sidebar-symbolic");
 		m_icon_expanded.opacity = m_opacity;
-
-
 
 		m_stack = new Gtk.Stack();
 		m_stack.set_transition_type(Gtk.StackTransitionType.NONE);
@@ -78,7 +75,7 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		m_expandBox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK);
 		m_expandBox.set_events(Gdk.EventMask.ENTER_NOTIFY_MASK);
 		m_expandBox.set_events(Gdk.EventMask.LEAVE_NOTIFY_MASK);
-		m_expandBox.margin_start = (level-1) * 24;
+		m_expandBox.margin_start = (level - 1) * 24;
 		m_expandBox.add(m_stack);
 		m_expandBox.set_size_request(32, 0);
 		m_expandBox.button_press_event.connect(onExpandClick);
@@ -89,7 +86,6 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		m_label.set_size_request (0, rowhight);
 		m_label.set_ellipsize (Pango.EllipsizeMode.END);
 		m_label.set_alignment(0, 0.5f);
-
 
 		m_unread = new Gtk.Label("");
 		m_unread.set_size_request (0, rowhight);
@@ -119,7 +115,7 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 
 		m_eventBox = new Gtk.EventBox();
 		if(m_categorieID != CategoryID.MASTER.to_string()
-		&& m_categorieID != CategoryID.TAGS.to_string())
+		   && m_categorieID != CategoryID.TAGS.to_string())
 		{
 			m_eventBox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK);
 			m_eventBox.button_press_event.connect(onClick);
@@ -143,39 +139,39 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		if(UtilsUI.canManipulateContent())
 		{
 			if(m_categorieID != CategoryID.MASTER.to_string()
-			&& m_categorieID != CategoryID.TAGS.to_string())
+			   && m_categorieID != CategoryID.TAGS.to_string())
 			{
 				const Gtk.TargetEntry[] accepted_targets = {
-				    { "text/plain",	0, DragTarget.FEED },
-					{ "STRING",		0, DragTarget.CAT }
+					{ "text/plain", 0, DragTarget.FEED },
+					{ "STRING",     0, DragTarget.CAT }
 				};
 
 				Gtk.drag_dest_set (
-			            this,
-			            Gtk.DestDefaults.MOTION,
-			            accepted_targets,
-			            Gdk.DragAction.MOVE
-			    );
+					this,
+					Gtk.DestDefaults.MOTION,
+					accepted_targets,
+					Gdk.DragAction.MOVE
+					);
 
-			    this.drag_motion.connect(onDragMotion);
-			    this.drag_leave.connect(onDragLeave);
-			    this.drag_drop.connect(onDragDrop);
-			    this.drag_data_received.connect(onDragDataReceived);
+				this.drag_motion.connect(onDragMotion);
+				this.drag_leave.connect(onDragLeave);
+				this.drag_drop.connect(onDragDrop);
+				this.drag_data_received.connect(onDragDataReceived);
 
 				try
 				{
 					if(DBusConnection.get_default().supportMultiLevelCategories())
 					{
 						const Gtk.TargetEntry[] provided_targets = {
-						    { "STRING",     0, DragTarget.CAT }
+							{ "STRING",     0, DragTarget.CAT }
 						};
 
 						Gtk.drag_source_set (
-								this,
-								Gdk.ModifierType.BUTTON1_MASK,
-								provided_targets,
-								Gdk.DragAction.MOVE
-						);
+							this,
+							Gdk.ModifierType.BUTTON1_MASK,
+							provided_targets,
+							Gdk.DragAction.MOVE
+							);
 
 						this.drag_begin.connect(onDragBegin);
 						this.drag_data_get.connect(onDragDataGet);
@@ -189,20 +185,20 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 			else if(m_categorieID == CategoryID.MASTER.to_string())
 			{
 				const Gtk.TargetEntry[] accepted_targets = {
-				    { "STRING",     0, DragTarget.CAT }
+					{ "STRING",     0, DragTarget.CAT }
 				};
 
 				Gtk.drag_dest_set (
-			            this,
-			            Gtk.DestDefaults.MOTION,
-			            accepted_targets,
-			            Gdk.DragAction.MOVE
-			    );
+					this,
+					Gtk.DestDefaults.MOTION,
+					accepted_targets,
+					Gdk.DragAction.MOVE
+					);
 
-			    this.drag_motion.connect(onDragMotion);
-			    this.drag_leave.connect(onDragLeave);
-			    this.drag_drop.connect(onDragDrop);
-			    this.drag_data_received.connect(onDragDataReceived);
+				this.drag_motion.connect(onDragMotion);
+				this.drag_leave.connect(onDragLeave);
+				this.drag_drop.connect(onDragDrop);
+				this.drag_data_received.connect(onDragDataReceived);
 			}
 		}
 	}
@@ -226,7 +222,6 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		}
 	}
 
-
 //------------- Drag Target Functions ----------------------------------------------
 
 	private bool onDragMotion(Gtk.Widget widget, Gdk.DragContext context, int x, int y, uint time)
@@ -239,7 +234,6 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 	{
 		this.unset_state_flags(Gtk.StateFlags.PRELIGHT);
 	}
-
 
 	private bool onDragDrop(Gtk.Widget widget, Gdk.DragContext context, int x, int y, uint time)
 	{
@@ -259,14 +253,14 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 	}
 
 	private void onDragDataReceived(Gtk.Widget widget, Gdk.DragContext context, int x, int y,
-									Gtk.SelectionData selection_data, uint target_type, uint time)
+	                                Gtk.SelectionData selection_data, uint target_type, uint time)
 	{
 		Logger.debug("categoryRow: onDragDataReceived");
 
 		var dataString = selection_data.get_text();
 
 		if(dataString != null
-		&& selection_data.get_length() >= 0)
+		   && selection_data.get_length() >= 0)
 		{
 			if(m_categorieID == CategoryID.NEW.to_string())
 			{
@@ -311,7 +305,7 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 					}
 
 					Gtk.drag_finish(context, true, false, time);
-		        }
+				}
 				else if(target_type == DragTarget.CAT)
 				{
 					Logger.debug("drag catID: " + dataString);
@@ -365,13 +359,12 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		if(!UtilsUI.canManipulateContent())
 			return false;
 
-
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 
 		var remove_action = new GLib.SimpleAction("deleteCat", null);
@@ -380,8 +373,8 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 
 			if(!m_collapsed)
 			{
-				wasExpanded = true;
-				expand_collapse();
+			    wasExpanded = true;
+			    expand_collapse();
 			}
 
 			if(this.is_selected())
@@ -395,11 +388,11 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 			ulong eventID = notification.dismissed.connect(() => {
 				try
 				{
-					DBusConnection.get_default().removeCategory(m_categorieID);
+				    DBusConnection.get_default().removeCategory(m_categorieID);
 				}
 				catch(GLib.Error e)
 				{
-					Logger.error("categoryRow.onClick: %s".printf(e.message));
+				    Logger.error("categoryRow.onClick: %s".printf(e.message));
 				}
 			});
 			notification.action.connect(() => {
@@ -423,11 +416,11 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 			GLib.Timeout.add(time, () => {
 				try
 				{
-					DBusConnection.get_default().removeCategoryWithChildren(m_categorieID);
+				    DBusConnection.get_default().removeCategoryWithChildren(m_categorieID);
 				}
 				catch(GLib.Error e)
 				{
-					Logger.error("categoryRow.onClick: %s".printf(e.message));
+				    Logger.error("categoryRow.onClick: %s".printf(e.message));
 				}
 				return false;
 			});
@@ -473,7 +466,7 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		return true;
 	}
 
-	private void showRenamePopover(Gdk.DragContext? context = null, uint time = 0, string? id1 = null, string? id2 = null)
+	private void showRenamePopover(Gdk.DragContext ? context = null, uint time = 0, string ? id1 = null, string ? id2 = null)
 	{
 		var popRename = new Gtk.Popover(this);
 		popRename.set_position(Gtk.PositionType.BOTTOM);
@@ -481,7 +474,7 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 			this.unset_state_flags(Gtk.StateFlags.PRELIGHT);
 			if(m_categorieID == CategoryID.NEW.to_string() && context != null)
 			{
-				this.drag_failed(context, Gtk.DragResult.NO_TARGET);
+			    this.drag_failed(context, Gtk.DragResult.NO_TARGET);
 			}
 		});
 
@@ -490,30 +483,30 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 		renameEntry.activate.connect(() => {
 			try
 			{
-				if(m_categorieID != CategoryID.NEW.to_string())
-				{
-					DBusConnection.get_default().renameCategory(m_categorieID, renameEntry.get_text());
+			    if(m_categorieID != CategoryID.NEW.to_string())
+			    {
+			        DBusConnection.get_default().renameCategory(m_categorieID, renameEntry.get_text());
 				}
-				else if(context != null)
-				{
-					Logger.debug("categoryRow: create new category " + renameEntry.get_text());
-					m_categorieID = DBusConnection.get_default().addCategory(renameEntry.get_text(), "", true);
+			    else if(context != null)
+			    {
+			        Logger.debug("categoryRow: create new category " + renameEntry.get_text());
+			        m_categorieID = DBusConnection.get_default().addCategory(renameEntry.get_text(), "", true);
 
-					if(id2 == null) // move feed
-					{
-						DBusConnection.get_default().moveCategory(id1, m_categorieID);
+			        if(id2 == null) // move feed
+			        {
+			            DBusConnection.get_default().moveCategory(id1, m_categorieID);
 					}
-					else // move category
-					{
-						DBusConnection.get_default().moveFeed(id1, id2, m_categorieID);
+			        else // move category
+			        {
+			            DBusConnection.get_default().moveFeed(id1, id2, m_categorieID);
 					}
 
-					Gtk.drag_finish(context, true, false, time);
+			        Gtk.drag_finish(context, true, false, time);
 				}
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("categoryRow.showRenamePopover: %s".printf(e.message));
+			    Logger.error("categoryRow.showRenamePopover: %s".printf(e.message));
 			}
 
 			popRename.hide();
@@ -580,10 +573,10 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 		expand_collapse();
 		return true;
@@ -617,7 +610,7 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 	private bool onExpandLeave(Gdk.EventCrossing event)
 	{
 		if(event.detail != Gdk.NotifyType.VIRTUAL
-		&& event.mode != Gdk.CrossingMode.NORMAL)
+		   && event.mode != Gdk.CrossingMode.NORMAL)
 			return false;
 
 		m_hovered = false;
@@ -648,13 +641,13 @@ public class FeedReader.CategoryRow : Gtk.ListBoxRow {
 
 	public void upUnread()
 	{
-		set_unread_count(m_unread_count+1);
+		set_unread_count(m_unread_count + 1);
 	}
 
 	public void downUnread()
 	{
 		if(m_unread_count > 0)
-			set_unread_count(m_unread_count-1);
+			set_unread_count(m_unread_count - 1);
 	}
 
 	public string getID()

--- a/src/Widgets/ColorCircle.vala
+++ b/src/Widgets/ColorCircle.vala
@@ -49,7 +49,6 @@ public class FeedReader.ColorCircle : Gtk.EventBox {
 		m_icon_light.set_from_surface(drawIcon(true));
 	}
 
-
 	private bool IconEnter()
 	{
 		this.remove(m_icon);
@@ -73,17 +72,16 @@ public class FeedReader.ColorCircle : Gtk.EventBox {
 
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 
 		Logger.debug("ColorCircle: click");
 		clicked(m_color);
 		return true;
 	}
-
 
 	private Cairo.Surface drawIcon(bool light = false)
 	{
@@ -101,13 +99,13 @@ public class FeedReader.ColorCircle : Gtk.EventBox {
 		context.set_line_width(2);
 		context.set_fill_rule(Cairo.FillRule.EVEN_ODD);
 
-		double half = size/(2*scaleFactor);
-		context.set_source_rgba(color.red, color.green, color.blue, 0.6*lighten);
-		context.arc(half, half, half, 0, 2*Math.PI);
+		double half = size / (2 * scaleFactor);
+		context.set_source_rgba(color.red, color.green, color.blue, 0.6 * lighten);
+		context.arc(half, half, half, 0, 2 * Math.PI);
 		context.fill_preserve();
 
-		context.arc(half, half, half-(half/4), 0, 2*Math.PI);
-		context.set_source_rgba(color.red, color.green, color.blue, 0.6*lighten);
+		context.arc(half, half, half - (half / 4), 0, 2 * Math.PI);
+		context.set_source_rgba(color.red, color.green, color.blue, 0.6 * lighten);
 		context.fill_preserve();
 
 		return surface;

--- a/src/Widgets/ColorPopover.vala
+++ b/src/Widgets/ColorPopover.vala
@@ -17,7 +17,6 @@ public class FeedReader.ColorPopover : Gtk.Popover {
 	private Gtk.Grid m_grid;
 	public signal void newColorSelected(int color);
 
-
 	public ColorPopover(Gtk.Widget widget)
 	{
 		m_grid = new Gtk.Grid();
@@ -29,7 +28,7 @@ public class FeedReader.ColorPopover : Gtk.Popover {
 		m_grid.set_valign(Gtk.Align.CENTER);
 		m_grid.margin = 5;
 		int columns = 4;
-		int rows = Constants.COLORS.length/4;
+		int rows = Constants.COLORS.length / 4;
 		int color = 0;
 		ColorCircle tmpCircle;
 

--- a/src/Widgets/ColumnView.vala
+++ b/src/Widgets/ColumnView.vala
@@ -22,7 +22,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 	private FeedListFooter m_footer;
 	private ColumnViewHeader m_headerbar;
 
-	private static ColumnView? m_columnView = null;
+	private static ColumnView ? m_columnView = null;
 
 	public static ColumnView get_default()
 	{
@@ -31,7 +31,6 @@ public class FeedReader.ColumnView : Gtk.Paned {
 
 		return m_columnView;
 	}
-
 
 	private ColumnView()
 	{
@@ -56,27 +55,27 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			m_articleList.setSelectedType(FeedListType.FEED);
 			m_article_view.clearContent();
 			m_headerbar.showArticleButtons(false);
-						m_headerbar.clearTitle();
+			m_headerbar.clearTitle();
 			m_articleList.setSelectedFeed(feedID);
 			newArticleList();
 
 			if(feedID == FeedID.ALL.to_string())
 			{
-				m_footer.setRemoveButtonSensitive(false);
+			    m_footer.setRemoveButtonSensitive(false);
 			}
 			else
 			{
-				m_footer.setRemoveButtonSensitive(true);
-				m_footer.setSelectedRow(FeedListType.FEED, feedID);
+			    m_footer.setRemoveButtonSensitive(true);
+			    m_footer.setSelectedRow(FeedListType.FEED, feedID);
 			}
- 		});
+		});
 
 		m_feedList.newTagSelected.connect((tagID) => {
 			Logger.debug("ContentPage: new Tag selected");
 			m_articleList.setSelectedType(FeedListType.TAG);
 			m_article_view.clearContent();
 			m_headerbar.showArticleButtons(false);
-						m_headerbar.clearTitle();
+			m_headerbar.clearTitle();
 			m_articleList.setSelectedFeed(tagID);
 			newArticleList();
 			m_footer.setRemoveButtonSensitive(true);
@@ -88,24 +87,23 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			m_articleList.setSelectedType(FeedListType.CATEGORY);
 			m_article_view.clearContent();
 			m_headerbar.showArticleButtons(false);
-						m_headerbar.clearTitle();
+			m_headerbar.clearTitle();
 			m_articleList.setSelectedFeed(categorieID);
 			newArticleList();
 
 			if(categorieID != CategoryID.MASTER.to_string()
-			&& categorieID != CategoryID.TAGS.to_string())
+			   && categorieID != CategoryID.TAGS.to_string())
 			{
-				m_footer.setRemoveButtonSensitive(true);
-				m_footer.setSelectedRow(FeedListType.CATEGORY, categorieID);
+			    m_footer.setRemoveButtonSensitive(true);
+			    m_footer.setSelectedRow(FeedListType.CATEGORY, categorieID);
 			}
 			else
 			{
-				m_footer.setRemoveButtonSensitive(false);
+			    m_footer.setRemoveButtonSensitive(false);
 			}
 		});
 
 		m_feedList.markAllArticlesAsRead.connect(markAllArticlesAsRead);
-
 
 		m_articleList = new ArticleList();
 		m_articleList.drag_begin.connect((context) => {
@@ -131,23 +129,21 @@ public class FeedReader.ColumnView : Gtk.Paned {
 
 		m_pane.pack2(m_articleList, false, false);
 
-
 		m_articleList.row_activated.connect((row) => {
 			if(m_article_view.getCurrentArticle() != row.getID())
 			{
-				m_article_view.load(row.getID());
-				m_headerbar.showArticleButtons(true);
-								m_headerbar.setTitle(row.getName());
-				Logger.debug("ContentPage: set headerbar");
-				m_headerbar.setRead(row.isUnread());
-				m_headerbar.setMarked(row.isMarked());
-				m_headerbar.showMediaButton(row.haveMedia());
-				m_article_view.showMediaButton(row.haveMedia());
+			    m_article_view.load(row.getID());
+			    m_headerbar.showArticleButtons(true);
+			    m_headerbar.setTitle(row.getName());
+			    Logger.debug("ContentPage: set headerbar");
+			    m_headerbar.setRead(row.isUnread());
+			    m_headerbar.setMarked(row.isMarked());
+			    m_headerbar.showMediaButton(row.haveMedia());
+			    m_article_view.showMediaButton(row.haveMedia());
 			}
 		});
 
 		m_article_view = new ArticleView();
-
 
 		this.orientation = Gtk.Orientation.HORIZONTAL;
 		this.set_position(Settings.state().get_int("feeds-and-articles-width"));
@@ -272,7 +268,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 
 	public void updateArticleList()
 	{
-		m_articleList.updateArticleList.begin((obj,res) => {
+		m_articleList.updateArticleList.begin((obj, res) => {
 			m_articleList.updateArticleList.end(res);
 		});
 	}
@@ -283,7 +279,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 		m_articleList.setState(state);
 
 		if(oldState == ArticleListState.MARKED
-		|| state == ArticleListState.MARKED)
+		   || state == ArticleListState.MARKED)
 			m_feedList.refreshCounters(state);
 	}
 
@@ -296,7 +292,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 	private void clearArticleView()
 	{
 		m_headerbar.showArticleButtons(false);
-				m_headerbar.clearTitle();
+		m_headerbar.clearTitle();
 		m_article_view.clearContent();
 	}
 
@@ -397,11 +393,11 @@ public class FeedReader.ColumnView : Gtk.Paned {
 	}
 
 	/*
-	public void updateAccountInfo()
-	{
-		m_feedList.updateAccountInfo();
-	}
-	*/
+	   public void updateAccountInfo()
+	   {
+	    m_feedList.updateAccountInfo();
+	   }
+	 */
 
 	public Gdk.RGBA getBackgroundColor()
 	{
@@ -439,7 +435,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 			string[] selected = selected_row.split(" ");
 
 			if((selected[0] == "feed" && selected[1] == FeedID.ALL.to_string())
-			|| (selected[0] == "cat" && (selected[1] == CategoryID.MASTER.to_string() || selected[1] == CategoryID.TAGS.to_string())))
+			   || (selected[0] == "cat" && (selected[1] == CategoryID.MASTER.to_string() || selected[1] == CategoryID.TAGS.to_string())))
 			{
 				m_footer.setRemoveButtonSensitive(false);
 			}
@@ -521,7 +517,7 @@ public class FeedReader.ColumnView : Gtk.Paned {
 		return m_article_view.playingMedia();
 	}
 
-	public string? displayedArticle()
+	public string ? displayedArticle()
 	{
 		return m_article_view.getCurrentArticle();
 	}

--- a/src/Widgets/ColumnViewHeader.vala
+++ b/src/Widgets/ColumnViewHeader.vala
@@ -28,7 +28,6 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 	public signal void toggledMarked();
 	public signal void toggledRead();
 
-
 	public ColumnViewHeader()
 	{
 		m_state = (ArticleListState)Settings.state().get_enum("show-articles");
@@ -42,14 +41,14 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 		m_modeButton.mode_changed.connect(() => {
 			var transition = Gtk.StackTransitionType.CROSSFADE;
 			if(m_state == ArticleListState.ALL
-			|| (ArticleListState)m_modeButton.selected == ArticleListState.MARKED)
+			   || (ArticleListState)m_modeButton.selected == ArticleListState.MARKED)
 			{
-				transition = Gtk.StackTransitionType.SLIDE_LEFT;
+			    transition = Gtk.StackTransitionType.SLIDE_LEFT;
 			}
 			else if(m_state == ArticleListState.MARKED
-			|| (ArticleListState)m_modeButton.selected == ArticleListState.ALL)
+			        || (ArticleListState)m_modeButton.selected == ArticleListState.ALL)
 			{
-				transition = Gtk.StackTransitionType.SLIDE_RIGHT;
+			    transition = Gtk.StackTransitionType.SLIDE_RIGHT;
 			}
 
 			m_state = (ArticleListState)m_modeButton.selected;
@@ -64,12 +63,10 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 				refresh();
 			else
 			{
-				cancel();
-				m_refresh_button.setSensitive(false);
+			    cancel();
+			    m_refresh_button.setSensitive(false);
 			}
 		});
-
-
 
 		m_search = new Gtk.SearchEntry();
 		m_search.placeholder_text = _("Search Articles");
@@ -109,7 +106,6 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 			FeedReaderApp.get_default().app_menu = UtilsUI.getMenu();
 		}
 
-
 		m_header_left.pack_end(m_search);
 		m_header_left.pack_start(m_modeButton);
 		m_header_left.pack_start(m_refresh_button);
@@ -135,7 +131,6 @@ public class FeedReader.ColumnViewHeader : Gtk.Paned {
 		Gtk.Settings.get_default().notify["gtk-decoration-layout"].connect(set_window_buttons);
 		realize.connect(set_window_buttons);
 		set_window_buttons();
-
 
 		this.pack1(m_header_left, true, false);
 		this.pack2(m_header_right, true, false);

--- a/src/Widgets/FeedList.vala
+++ b/src/Widgets/FeedList.vala
@@ -16,9 +16,9 @@
 public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 	private Gtk.ListBox m_list;
-	private string? m_selectedID = null;
+	private string ? m_selectedID = null;
 	private FeedListType m_selectedType = FeedListType.ALL_FEEDS;
-	private TagRow? m_emptyTagRow = null;
+	private TagRow ? m_emptyTagRow = null;
 	private Gtk.Spinner m_spinner;
 	private ServiceInfo m_branding;
 	private uint m_expand_collapse_time = 150;
@@ -47,43 +47,42 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			FeedRow selected_feed = m_list.get_selected_row() as FeedRow;
 			if(selected_feed != null)
 			{
-				if(selected_feed.getID() == m_selectedID
-				&& m_selectedType == FeedListType.FEED)
+			    if(selected_feed.getID() == m_selectedID
+			       && m_selectedType == FeedListType.FEED)
 					return;
 
-				m_selectedID = selected_feed.getID();
-				m_selectedType = FeedListType.FEED;
-				newFeedSelected(selected_feed.getID());
-				return;
+			    m_selectedID = selected_feed.getID();
+			    m_selectedType = FeedListType.FEED;
+			    newFeedSelected(selected_feed.getID());
+			    return;
 			}
 
 			CategoryRow selected_categorie = m_list.get_selected_row() as CategoryRow;
 			if(selected_categorie != null)
 			{
-				if(selected_categorie.getID() == m_selectedID
-				&& m_selectedType == FeedListType.CATEGORY)
+			    if(selected_categorie.getID() == m_selectedID
+			       && m_selectedType == FeedListType.CATEGORY)
 					return;
 
-				m_selectedID = selected_categorie.getID();
-				m_selectedType = FeedListType.CATEGORY;
-				newCategorieSelected(selected_categorie.getID());
-				return;
+			    m_selectedID = selected_categorie.getID();
+			    m_selectedType = FeedListType.CATEGORY;
+			    newCategorieSelected(selected_categorie.getID());
+			    return;
 			}
 
 			TagRow selected_tag = m_list.get_selected_row() as TagRow;
 			if(selected_tag != null)
 			{
-				if(selected_tag.getID() == m_selectedID
-				&& m_selectedType == FeedListType.TAG)
+			    if(selected_tag.getID() == m_selectedID
+			       && m_selectedType == FeedListType.TAG)
 					return;
 
-				m_selectedID = selected_tag.getID();
-				m_selectedType = FeedListType.TAG;
-				newTagSelected(selected_tag.getID());
-				return;
+			    m_selectedID = selected_tag.getID();
+			    m_selectedType = FeedListType.TAG;
+			    newTagSelected(selected_tag.getID());
+			    return;
 			}
 		});
-
 
 		m_list.key_press_event.connect((event) => {
 			if(event.keyval == Gdk.Key.Down)
@@ -92,10 +91,10 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 				move(false);
 			else if(event.keyval == Gdk.Key.Left || event.keyval == Gdk.Key.Right)
 			{
-				CategoryRow selected_categorie = m_list.get_selected_row() as CategoryRow;
-				if(selected_categorie != null)
-				{
-					selected_categorie.expand_collapse();
+			    CategoryRow selected_categorie = m_list.get_selected_row() as CategoryRow;
+			    if(selected_categorie != null)
+			    {
+			        selected_categorie.expand_collapse();
 				}
 
 			}
@@ -120,10 +119,9 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 		var FeedListChildren = m_list.get_children();
 
-		if(!down){
+		if(!down) {
 			FeedListChildren.reverse();
 		}
-
 
 		int current = -1;
 		if(selected_feed != null)
@@ -180,7 +178,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		}
 	}
 
-
 	public void newFeedlist(ArticleListState state, bool defaultSettings, bool masterCat = false)
 	{
 		Logger.debug("FeedList: new FeedList");
@@ -228,7 +225,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 		return false;
 	}
-
 
 	private void createFeedlist(ArticleListState state, bool defaultSettings, bool masterCat)
 	{
@@ -286,15 +282,15 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 					if(tmpRow != null)
 					{
 						if(Utils.arrayContains(item.getCatIDs(), tmpRow.getID())
-						|| tmpRow.getID() == "" && item.isUncategorized())
+						   || tmpRow.getID() == "" && item.isUncategorized())
 						{
 							var feedrow = new FeedRow(
-													   item.getTitle(),
-													   item.getUnread(),
-													   item.getFeedID(),
-									                   tmpRow.getID(),
-									                   tmpRow.getLevel()
-													  );
+								item.getTitle(),
+								item.getUnread(),
+								item.getFeedID(),
+								tmpRow.getID(),
+								tmpRow.getLevel()
+								);
 							m_list.insert(feedrow, pos);
 							feedrow.setAsRead.connect(markSelectedRead);
 							feedrow.moveUP.connect(moveUP);
@@ -314,13 +310,13 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			}
 			else
 			{
-				var feedrow = new FeedRow	(
-												item.getTitle(),
-												item.getUnread(),
-												item.getFeedID(),
-												item.getCatIDs()[0],
-												0
-											);
+				var feedrow = new FeedRow   (
+					item.getTitle(),
+					item.getUnread(),
+					item.getFeedID(),
+					item.getCatIDs()[0],
+					0
+					);
 				m_list.insert(feedrow, 3);
 				feedrow.setAsRead.connect(markSelectedRead);
 				feedrow.moveUP.connect(moveUP);
@@ -394,7 +390,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			}
 		}
 
-
 		// row not found: default select "ALL ARTICLES"
 		Logger.debug("FeedList: restoreSelectedRow: no selected row found, selectin default");
 		foreach(Gtk.Widget row in FeedChildList)
@@ -410,7 +405,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		}
 	}
 
-
 	void restoreScrollPos(Object sender, ParamSpec property)
 	{
 		vadjustment.notify["upper"].disconnect(restoreScrollPos);
@@ -420,23 +414,23 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 	private void addMasterCategory(int length, string name)
 	{
 		var CategoryRow = new CategoryRow(
-												name,
-												CategoryID.MASTER.to_string(),
-												0,
-												0,
-												CategoryID.NONE.to_string(),
-												1,
-												// expand the category "categories" if either it is inserted for the first time (no tag before)
-												// or if it has to be done to restore the state of the feedrow
-												getCatState(CategoryID.MASTER.to_string())
-												);
+			name,
+			CategoryID.MASTER.to_string(),
+			0,
+			0,
+			CategoryID.NONE.to_string(),
+			1,
+			// expand the category "categories" if either it is inserted for the first time (no tag before)
+			// or if it has to be done to restore the state of the feedrow
+			getCatState(CategoryID.MASTER.to_string())
+			);
 		CategoryRow.collapse.connect((collapse, catID, selectParent) => {
 			if(collapse)
 				collapseCategorieInternal(catID, selectParent);
 			else
 				expandCategorieInternal(catID);
 		});
-		m_list.insert(CategoryRow, length+1);
+		m_list.insert(CategoryRow, length + 1);
 		CategoryRow.setAsRead.connect(markSelectedRead);
 		CategoryRow.moveUP.connect(moveUP);
 		CategoryRow.reveal(true, 0);
@@ -445,28 +439,27 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 	private void addTagCategory(int length)
 	{
 		var tagrow = new CategoryRow(
-												_("Tags"),
-												CategoryID.TAGS.to_string(),
-												0,
-												0,
-												CategoryID.NONE.to_string(),
-												1,
-												// expand the category "tags" if either it is inserted for the first time (no tag before)
-												// or if it has to be done to restore the state of the feedrow
-												getCatState(CategoryID.TAGS.to_string())
-												);
+			_("Tags"),
+			CategoryID.TAGS.to_string(),
+			0,
+			0,
+			CategoryID.NONE.to_string(),
+			1,
+			// expand the category "tags" if either it is inserted for the first time (no tag before)
+			// or if it has to be done to restore the state of the feedrow
+			getCatState(CategoryID.TAGS.to_string())
+			);
 		tagrow.collapse.connect((collapse, catID, selectParent) => {
 			if(collapse)
 				collapseCategorieInternal(catID, selectParent);
 			else
 				expandCategorieInternal(catID);
 		});
-		m_list.insert(tagrow, length+2);
+		m_list.insert(tagrow, length + 2);
 		tagrow.setAsRead.connect(markSelectedRead);
 		tagrow.reveal(true, 0);
 		m_TagsDisplayed = true;
 	}
-
 
 	private void createCategories(ref Gee.ArrayList<feed> feeds, bool masterCat, ArticleListState state)
 	{
@@ -490,8 +483,8 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		}
 
 		if((supportTags
-		&& !dbUI.get_default().isTableEmpty("tags"))
-		|| masterCat)
+		    && !dbUI.get_default().isTableEmpty("tags"))
+		   || masterCat)
 		{
 			addMasterCategory(length, _("Categories"));
 			addTagCategory(length);
@@ -522,8 +515,8 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 						(int)(categories.size + 10),
 						CategoryID.MASTER.to_string(),
 						1
-					)
-				);
+						)
+					);
 			}
 
 			foreach(var item in categories)
@@ -535,8 +528,8 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 					pos++;
 					var tmpRow = existing_row as CategoryRow;
 					if((tmpRow != null && tmpRow.getID() == item.getParent()) ||
-						(item.getParent() == CategoryID.MASTER.to_string() && pos > length-1 && !m_TagsDisplayed) ||
-						(item.getParent() == CategoryID.MASTER.to_string() && pos > length && m_TagsDisplayed))
+					   (item.getParent() == CategoryID.MASTER.to_string() && pos > length - 1 && !m_TagsDisplayed) ||
+					   (item.getParent() == CategoryID.MASTER.to_string() && pos > length && m_TagsDisplayed))
 					{
 						int level = item.getLevel();
 						string parent = item.getParent();
@@ -548,15 +541,15 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 						}
 
 						var CategoryRow = new CategoryRow(
-					                                item.getTitle(),
-					                                item.getCatID(),
-					                                item.getOrderID(),
-					                                item.getUnreadCount(),
-					                                parent,
-							                        level,
-							                        getCatState(item.getCatID())
-					                                );
-					    expand = false;
+							item.getTitle(),
+							item.getCatID(),
+							item.getOrderID(),
+							item.getUnreadCount(),
+							parent,
+							level,
+							getCatState(item.getCatID())
+							);
+						expand = false;
 						CategoryRow.collapse.connect((collapse, catID, selectParent) => {
 							if(collapse)
 								collapseCategorieInternal(catID, selectParent);
@@ -582,7 +575,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			}
 		}
 	}
-
 
 	private void createTags()
 	{
@@ -653,7 +645,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 								tmpFeedRow.reveal(true);
 						}
 
-
 						break;
 					}
 				}
@@ -712,8 +703,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		}
 	}
 
-
-
 	private void initCollapseCategories()
 	{
 		Logger.debug("initCollapseCategories");
@@ -727,7 +716,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			}
 		}
 	}
-
 
 	private void collapseCategorieInternal(string catID, bool selectParent, bool animate = true)
 	{
@@ -762,8 +750,8 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			var selected_tag = selected_row as TagRow;
 
 			if((selected_feed != null && !selected_feed.isRevealed())
-			|| (selected_cat != null && !selected_cat.isRevealed())
-			|| (selected_tag != null && !selected_tag.isRevealed()))
+			   || (selected_cat != null && !selected_cat.isRevealed())
+			   || (selected_tag != null && !selected_tag.isRevealed()))
 			{
 				foreach(Gtk.Widget row in FeedChildList)
 				{
@@ -779,7 +767,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			}
 		}
 	}
-
 
 	private void expandCategorieInternal(string catID)
 	{
@@ -820,12 +807,11 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			if(tmpCatRow != null && tmpCatRow.getID() == catID)
 			{
 				if((!expand && tmpCatRow.isExpanded())
-				||(expand && !tmpCatRow.isExpanded()))
+				   || (expand && !tmpCatRow.isExpanded()))
 					tmpCatRow.expand_collapse(false);
 			}
 		}
 	}
-
 
 	private bool isCategorieExpanded(string catID)
 	{
@@ -841,7 +827,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		return false;
 	}
 
-
 	public string getSelectedFeed()
 	{
 		FeedRow selected_row = m_list.get_selected_row() as FeedRow;
@@ -850,7 +835,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 		return "";
 	}
-
 
 	public string[] getExpandedCategories()
 	{
@@ -870,7 +854,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		}
 		return e;
 	}
-
 
 	public string getSelectedRow()
 	{
@@ -893,7 +876,6 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 		return "";
 	}
-
 
 	private void markSelectedRead(FeedListType type, string id)
 	{
@@ -949,11 +931,11 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 	}
 
 	/*
-	public void updateAccountInfo()
-	{
-		m_branding.refresh();
-	}
-	*/
+	   public void updateAccountInfo()
+	   {
+	    m_branding.refresh();
+	   }
+	 */
 
 	public void setOffline()
 	{
@@ -976,39 +958,39 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 
 		switch(type)
 		{
-			case FeedListType.CATEGORY:
-				foreach(Gtk.Widget row in FeedChildList)
+		case FeedListType.CATEGORY:
+			foreach(Gtk.Widget row in FeedChildList)
+			{
+				var tmpRow = row as CategoryRow;
+				if(tmpRow != null && tmpRow.getID() == id)
 				{
-					var tmpRow = row as CategoryRow;
-					if(tmpRow != null && tmpRow.getID() == id)
-					{
-						tmpRow.reveal(reveal, time);
-						return;
-					}
+					tmpRow.reveal(reveal, time);
+					return;
 				}
-				break;
-			case FeedListType.FEED:
-				foreach(Gtk.Widget row in FeedChildList)
+			}
+			break;
+		case FeedListType.FEED:
+			foreach(Gtk.Widget row in FeedChildList)
+			{
+				var tmpRow = row as FeedRow;
+				if(tmpRow != null && tmpRow.getID() == id)
 				{
-					var tmpRow = row as FeedRow;
-					if(tmpRow != null && tmpRow.getID() == id)
-					{
-						tmpRow.reveal(reveal, time);
-						return;
-					}
+					tmpRow.reveal(reveal, time);
+					return;
 				}
-				break;
-			case FeedListType.TAG:
-				foreach(Gtk.Widget row in FeedChildList)
+			}
+			break;
+		case FeedListType.TAG:
+			foreach(Gtk.Widget row in FeedChildList)
+			{
+				var tmpRow = row as TagRow;
+				if(tmpRow != null && tmpRow.getID() == id)
 				{
-					var tmpRow = row as TagRow;
-					if(tmpRow != null && tmpRow.getID() == id)
-					{
-						tmpRow.reveal(reveal, time);
-						return;
-					}
+					tmpRow.reveal(reveal, time);
+					return;
 				}
-				break;
+			}
+			break;
 		}
 	}
 
@@ -1047,7 +1029,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 		clearSelected();
 	}
 
-	private void removeRow(Gtk.Widget? row, int duration = 700)
+	private void removeRow(Gtk.Widget ? row, int duration = 700)
 	{
 		if(row != null)
 		{
@@ -1059,7 +1041,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			{
 				tagRow.reveal(false, duration);
 				GLib.Timeout.add(duration + 20, () => {
-				    m_list.remove(tagRow);
+					m_list.remove(tagRow);
 					return false;
 				});
 			}
@@ -1067,7 +1049,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			{
 				catRow.reveal(false, duration);
 				GLib.Timeout.add(duration + 20, () => {
-				    m_list.remove(catRow);
+					m_list.remove(catRow);
 					return false;
 				});
 			}
@@ -1075,7 +1057,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			{
 				feedRow.reveal(false, duration);
 				GLib.Timeout.add(duration + 20, () => {
-				    m_list.remove(feedRow);
+					m_list.remove(feedRow);
 					return false;
 				});
 			}
@@ -1104,7 +1086,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			else if(tmpFeed != null)
 			{
 				if(tmpFeed.getID() != FeedID.SEPARATOR.to_string()
-				&& tmpFeed.getID() != FeedID.ALL.to_string())
+				   && tmpFeed.getID() != FeedID.ALL.to_string())
 				{
 					tmpFeed.reveal(false);
 				}
@@ -1173,9 +1155,9 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 				}
 
 				if(tmpCat.getID() != CategoryID.MASTER.to_string()
-				&& tmpCat.getID() != CategoryID.TAGS.to_string()
-				&& tmpCat.getParent() != CategoryID.MASTER.to_string()
-				&& !isCategorieExpanded(tmpCat.getParent()))
+				   && tmpCat.getID() != CategoryID.TAGS.to_string()
+				   && tmpCat.getParent() != CategoryID.MASTER.to_string()
+				   && !isCategorieExpanded(tmpCat.getParent()))
 				{
 					tmpCat.reveal(false);
 				}
@@ -1183,7 +1165,7 @@ public class FeedReader.feedList : Gtk.ScrolledWindow {
 			else if(tmpFeed != null)
 			{
 				if(tmpFeed.getID() != FeedID.SEPARATOR.to_string()
-				&& tmpFeed.getID() != FeedID.ALL.to_string())
+				   && tmpFeed.getID() != FeedID.ALL.to_string())
 				{
 					if(isCategorieExpanded(tmpFeed.getCatID()))
 						tmpFeed.reveal(true);

--- a/src/Widgets/FeedListFooter.vala
+++ b/src/Widgets/FeedListFooter.vala
@@ -120,7 +120,6 @@ public class FeedReader.FeedListFooter : Gtk.Box {
 	}
 }
 
-
 public class FeedReader.AddButton : Gtk.Button {
 	public AddButton()
 	{

--- a/src/Widgets/FeedRow.vala
+++ b/src/Widgets/FeedRow.vala
@@ -35,7 +35,7 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 	public signal void moveUP();
 	public signal void deselectRow();
 
-	public FeedRow(string? text, uint unread_count, string feedID, string catID, int level)
+	public FeedRow(string ? text, uint unread_count, string feedID, string catID, int level)
 	{
 		m_level = level;
 		m_catID = catID;
@@ -79,7 +79,6 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 			m_unreadBox.enter_notify_event.connect(onUnreadEnter);
 			m_unreadBox.leave_notify_event.connect(onUnreadLeave);
 
-
 			if(!UtilsUI.onlyShowFeeds() && feedID != FeedID.ALL.to_string())
 				this.get_style_context().add_class("fr-sidebar-feed");
 			else
@@ -110,20 +109,20 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 			try
 			{
 				if(m_feedID != FeedID.ALL.to_string()
-				&& !Settings.general().get_boolean("only-feeds")
-				&& UtilsUI.canManipulateContent()
-				&& DBusConnection.get_default().supportCategories())
+				   && !Settings.general().get_boolean("only-feeds")
+				   && UtilsUI.canManipulateContent()
+				   && DBusConnection.get_default().supportCategories())
 				{
 					const Gtk.TargetEntry[] provided_targets = {
 						{ "text/plain",     0, DragTarget.FEED }
 					};
 
 					Gtk.drag_source_set (
-							this,
-							Gdk.ModifierType.BUTTON1_MASK,
-							provided_targets,
-							Gdk.DragAction.MOVE
-					);
+						this,
+						Gdk.ModifierType.BUTTON1_MASK,
+						provided_targets,
+						Gdk.DragAction.MOVE
+						);
 
 					this.drag_begin.connect(onDragBegin);
 					this.drag_data_get.connect(onDragDataGet);
@@ -186,10 +185,10 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 
 		var remove_action = new GLib.SimpleAction("deleteFeed", null);
@@ -204,11 +203,11 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 			ulong eventID = notification.dismissed.connect(() => {
 				try
 				{
-					DBusConnection.get_default().removeFeed(m_feedID);
+				    DBusConnection.get_default().removeFeed(m_feedID);
 				}
 				catch(GLib.Error e)
 				{
-					Logger.error("FeedRow.onClick: %s".printf(e.message));
+				    Logger.error("FeedRow.onClick: %s".printf(e.message));
 				}
 			});
 			notification.action.connect(() => {
@@ -256,7 +255,6 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 		pop.show();
 		this.set_state_flags(Gtk.StateFlags.PRELIGHT, false);
 
-
 		return true;
 	}
 
@@ -274,11 +272,11 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 			popRename.hide();
 			try
 			{
-				DBusConnection.get_default().renameFeed(m_feedID, renameEntry.get_text());
+			    DBusConnection.get_default().renameFeed(m_feedID, renameEntry.get_text());
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("FeedRow.showRenamePopover: %s".printf(e.message));
+			    Logger.error("FeedRow.showRenamePopover: %s".printf(e.message));
 			}
 		});
 
@@ -352,18 +350,18 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 
 	public void upUnread()
 	{
-		set_unread_count(m_unread_count+1);
+		set_unread_count(m_unread_count + 1);
 	}
 
 	public void downUnread()
 	{
 		if(m_unread_count > 0)
-			set_unread_count(m_unread_count-1);
+			set_unread_count(m_unread_count - 1);
 	}
 
 	public void update(string text, uint unread_count)
 	{
-		m_label.set_text(text.replace("&","&amp;"));
+		m_label.set_text(text.replace("&", "&amp;"));
 		set_unread_count(unread_count);
 	}
 

--- a/src/Widgets/FullscreenHeader.vala
+++ b/src/Widgets/FullscreenHeader.vala
@@ -68,13 +68,12 @@ public class FeedReader.FullscreenHeader : Gtk.EventBox {
 				return false;
 
 			if(event.detail == Gdk.NotifyType.NONLINEAR_VIRTUAL)
-		        return false;
+				return false;
 
 			m_hover = false;
 
 			if(m_popover)
 				return false;
-
 
 			removeTimeout();
 			m_timeout_source_id = GLib.Timeout.add(500, () => {

--- a/src/Widgets/HoverButton.vala
+++ b/src/Widgets/HoverButton.vala
@@ -45,8 +45,6 @@ public class FeedReader.HoverButton : Gtk.EventBox {
 		else
 			m_stack.set_visible_child_name("inactive");
 
-
-
 		this.set_events(Gdk.EventMask.ENTER_NOTIFY_MASK);
 		this.set_events(Gdk.EventMask.LEAVE_NOTIFY_MASK);
 		this.set_size_request(16, 16);
@@ -87,7 +85,6 @@ public class FeedReader.HoverButton : Gtk.EventBox {
 		}
 	}
 
-
 	private bool onEnter(Gdk.EventCrossing event)
 	{
 		if(m_isActive)
@@ -117,6 +114,5 @@ public class FeedReader.HoverButton : Gtk.EventBox {
 
 		return true;
 	}
-
 
 }

--- a/src/Widgets/ImagePopup.vala
+++ b/src/Widgets/ImagePopup.vala
@@ -44,7 +44,7 @@ public class FeedReader.imagePopup : Gtk.Window {
 	private double m_minZoom = 0.2;
 	private double m_initZoom = 1.0;
 
-	public imagePopup(string imagePath, string? url, Gtk.Window parent, double img_height, double img_width)
+	public imagePopup(string imagePath, string ? url, Gtk.Window parent, double img_height, double img_width)
 	{
 		this.title = "";
 		this.decorated = false;
@@ -56,8 +56,8 @@ public class FeedReader.imagePopup : Gtk.Window {
 		this.button_press_event.connect((evt) => {
 			if(!m_hoverImage && !m_hoverHeader)
 			{
-				closeWindow();
-				return true;
+			    closeWindow();
+			    return true;
 			}
 			return false;
 		});
@@ -83,14 +83,13 @@ public class FeedReader.imagePopup : Gtk.Window {
 		m_scaleRevealer.add(m_scale);
 
 		var geo = Gdk.Display.get_default().get_monitor_at_window(this.get_root_window()).get_geometry();
-		double win_width  = (int)(geo.width*0.8);
-		double win_height = (int)(geo.height*0.8);
+		double win_width  = (int)(geo.width * 0.8);
+		double win_height = (int)(geo.height * 0.8);
 		double min_height = 300;
 		double min_widht = 500;
 
 		m_scroll = new Gtk.ScrolledWindow(null, null);
 		m_scroll.add(m_image);
-
 
 		if(img_width <= win_width)
 		{
@@ -105,7 +104,7 @@ public class FeedReader.imagePopup : Gtk.Window {
 		}
 		else if(img_width > win_width)
 		{
-			m_initZoom = win_width/img_width;
+			m_initZoom = win_width / img_width;
 			m_image.scale = m_initZoom;
 		}
 
@@ -134,19 +133,19 @@ public class FeedReader.imagePopup : Gtk.Window {
 				m_image.notify["scale"].disconnect(onImageScrolled);
 			if(m_zoomButton.get_active())
 			{
-				m_scale.set_value(m_image.scale);
-				m_scaleRevealer.set_reveal_child(true);
+			    m_scale.set_value(m_image.scale);
+			    m_scaleRevealer.set_reveal_child(true);
 			}
 			else
 			{
-				m_image.scale = m_initZoom;
-				m_scaleRevealer.set_reveal_child(false);
+			    m_image.scale = m_initZoom;
+			    m_scaleRevealer.set_reveal_child(false);
 			}
 
 			if(!m_zoomButton.get_active())
 			{
-				GLib.Timeout.add(150, () => {
-				    m_image.notify["scale"].connect(onImageScrolled);
+			    GLib.Timeout.add(150, () => {
+					m_image.notify["scale"].connect(onImageScrolled);
 					return false;
 				});
 			}
@@ -183,10 +182,10 @@ public class FeedReader.imagePopup : Gtk.Window {
 			urlButton.get_style_context().add_class("headerbutton");
 			urlButton.clicked.connect(() => {
 				try{
-					Gtk.show_uri_on_window(MainWindow.get_default(), url, Gdk.CURRENT_TIME);
+				    Gtk.show_uri_on_window(MainWindow.get_default(), url, Gdk.CURRENT_TIME);
 				}
-				catch(GLib.Error e){
-					Logger.debug("could not open the link in an external browser: %s".printf(e.message));
+				catch(GLib.Error e) {
+				    Logger.debug("could not open the link in an external browser: %s".printf(e.message));
 				}
 			});
 			header.pack_start(urlButton);
@@ -200,7 +199,6 @@ public class FeedReader.imagePopup : Gtk.Window {
 		m_overlay = new Gtk.Overlay();
 		m_overlay.add(m_scroll);
 		m_overlay.add_overlay(m_revealer);
-
 
 		m_eventBox = new Gtk.EventBox();
 		m_eventBox.button_press_event.connect(eventButtonPressed);
@@ -268,9 +266,9 @@ public class FeedReader.imagePopup : Gtk.Window {
 			{
 				if(m_OngoingScrollID > 0)
 				{
-		            GLib.Source.remove(m_OngoingScrollID);
-		            m_OngoingScrollID = 0;
-		        }
+					GLib.Source.remove(m_OngoingScrollID);
+					m_OngoingScrollID = 0;
+				}
 				m_posX = evt.x;
 				m_posY = evt.y;
 				for(int i = 0; i < 10; ++i)
@@ -291,7 +289,7 @@ public class FeedReader.imagePopup : Gtk.Window {
 					cursor,
 					null,
 					null
-				);
+					);
 
 				Gtk.device_grab_add(m_eventBox, pointer, false);
 
@@ -330,7 +328,6 @@ public class FeedReader.imagePopup : Gtk.Window {
 		return false;
 	}
 
-
 	private bool keyPressed(Gdk.EventKey evt)
 	{
 		if(evt.keyval == Gdk.Key.Escape)
@@ -368,14 +365,14 @@ public class FeedReader.imagePopup : Gtk.Window {
 
 		for(int i = 9; i > 0; --i)
 		{
-			m_dragBufferX[i] = m_dragBufferX[i-1];
-			m_dragBufferY[i] = m_dragBufferY[i-1];
+			m_dragBufferX[i] = m_dragBufferX[i - 1];
+			m_dragBufferY[i] = m_dragBufferY[i - 1];
 		}
 
 		m_dragBufferX[0] = m_posX;
 		m_dragBufferY[0] = m_posY;
-		m_momentumX = (m_dragBufferX[9] - m_dragBufferX[0])/2;
-		m_momentumY = (m_dragBufferY[9] - m_dragBufferY[0])/2;
+		m_momentumX = (m_dragBufferX[9] - m_dragBufferX[0]) / 2;
+		m_momentumY = (m_dragBufferY[9] - m_dragBufferY[0]) / 2;
 
 		return true;
 	}
@@ -396,7 +393,7 @@ public class FeedReader.imagePopup : Gtk.Window {
 			double oldhAdj = m_scroll.hadjustment.value;
 			double upperH = m_scroll.hadjustment.upper;
 			if ((oldhAdj + adjhValue) > (upperH - pageWidth)
-			|| (oldhAdj + adjhValue) < 0)
+			    || (oldhAdj + adjhValue) < 0)
 			{
 				m_momentumX = 0;
 			}
@@ -412,7 +409,7 @@ public class FeedReader.imagePopup : Gtk.Window {
 			double oldvAdj = m_scroll.vadjustment.value;
 			double upperV = m_scroll.vadjustment.upper;
 			if ((oldvAdj + adjvValue) > (upperV - pageHeight)
-			|| (oldvAdj + adjvValue) < 0)
+			    || (oldvAdj + adjvValue) < 0)
 			{
 				m_momentumY = 0;
 			}

--- a/src/Widgets/InAppNotification.vala
+++ b/src/Widgets/InAppNotification.vala
@@ -19,27 +19,26 @@ public class FeedReader.InAppNotification : Gd.Notification {
 	private Gtk.Button m_Button;
 	public signal void action();
 
-	public InAppNotification(string message, string buttonText, string? tooltip = null, int timeout = 5)
+	public InAppNotification(string message, string buttonText, string ? tooltip = null, int timeout = 5)
 	{
 		m_Button = new Gtk.Button.with_label(buttonText);
 		setup(message, tooltip);
 	}
 
-	public InAppNotification.withIcon(string message, string icon, string? tooltip = null, int timeout = 5)
+	public InAppNotification.withIcon(string message, string icon, string ? tooltip = null, int timeout = 5)
 	{
 		m_Button = new Gtk.Button.from_icon_name(icon, Gtk.IconSize.BUTTON);
 		setup(message, tooltip);
 	}
 
-	public InAppNotification.withIcon_from_resource(string message, string icon, string? tooltip = null, int timeout = 5)
+	public InAppNotification.withIcon_from_resource(string message, string icon, string ? tooltip = null, int timeout = 5)
 	{
 		m_Button = new Gtk.Button();
 		m_Button.set_image(new Gtk.Image.from_resource(icon));
 		setup(message, tooltip);
 	}
 
-
-	private void setup(string message, string? tooltip)
+	private void setup(string message, string ? tooltip)
 	{
 		m_Button.set_tooltip_text(tooltip);
 		m_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);

--- a/src/Widgets/LoginPage.vala
+++ b/src/Widgets/LoginPage.vala
@@ -19,11 +19,10 @@ public class FeedReader.LoginPage : Gtk.Stack {
 	private Peas.ExtensionSet m_extensions;
 	private Peas.Engine m_engine;
 	private WebLoginPage m_page;
-	private string? m_activeExtension = null;
-	private Gtk.Box? m_activeWidget = null;
+	private string ? m_activeExtension = null;
+	private Gtk.Box ? m_activeWidget = null;
 	public signal void submit_data();
 	public signal void loginError(LoginResponse errorCode);
-
 
 	public LoginPage()
 	{
@@ -44,7 +43,6 @@ public class FeedReader.LoginPage : Gtk.Stack {
 			m_engine.try_load_plugin(plugin);
 		}
 
-
 		m_layout = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 		m_layout.set_size_request(700, 410);
 		m_layout.set_halign(Gtk.Align.CENTER);
@@ -61,21 +59,19 @@ public class FeedReader.LoginPage : Gtk.Stack {
 		welcomeText2.set_justify(Gtk.Justification.CENTER);
 		welcomeText2.set_lines(3);
 
-
 		var accountList = new Gtk.ListBox();
 		accountList.set_selection_mode(Gtk.SelectionMode.NONE);
 		accountList.row_activated.connect(serviceSelected);
 
 		m_extensions.foreach((extSet, info, ext) => {
 			accountList.add(new LoginRow(ext as LoginInterface));
-		});
+		}) ;
 
 		var scroll = new Gtk.ScrolledWindow(null, null);
 		scroll.set_size_request(450, 0);
 		scroll.set_halign(Gtk.Align.CENTER);
 		scroll.get_style_context().add_class(Gtk.STYLE_CLASS_FRAME);
 		scroll.add(accountList);
-
 
 		m_layout.pack_start(welcomeText, false, true, 0);
 		m_layout.pack_start(welcomeText2, false, true, 2);
@@ -96,7 +92,7 @@ public class FeedReader.LoginPage : Gtk.Stack {
 		m_activeExtension = null;
 
 		if(visible == "loginWidget"
-		&& m_activeWidget != null)
+		   && m_activeWidget != null)
 		{
 			this.remove(m_activeWidget);
 			m_activeWidget = null;
@@ -147,30 +143,29 @@ public class FeedReader.LoginPage : Gtk.Stack {
 				window.getSimpleHeader().showBackButton(false);
 				if(m_activeWidget != null)
 				{
-					this.remove(m_activeWidget);
-					m_activeWidget = null;
+				    this.remove(m_activeWidget);
+				    m_activeWidget = null;
 				}
 				m_activeExtension = null;
 			});
 		}
 	}
 
-
 	public void showHtAccess()
 	{
 		getActiveExtension().showHtAccess();
 	}
 
-	private LoginInterface? getActiveExtension()
+	private LoginInterface ? getActiveExtension()
 	{
-		LoginInterface? e = null;
+		LoginInterface ? e = null;
 		m_extensions.foreach((extSet, info, ext) => {
 			var extension = (ext as LoginInterface);
 			if(extension.getID() == m_activeExtension)
 			{
-				e = extension;
+			    e = extension;
 			}
-		});
+		}) ;
 		return e;
 	}
 
@@ -196,11 +191,11 @@ public class FeedReader.LoginPage : Gtk.Stack {
 					submit_data();
 					try
 					{
-						DBusConnection.get_default().startSync(true);
+					    DBusConnection.get_default().startSync(true);
 					}
 					catch(GLib.Error e)
 					{
-						Logger.error("LoginPage: failed to start the initial sync - " + e.message);
+					    Logger.error("LoginPage: failed to start the initial sync - " + e.message);
 					}
 
 				});

--- a/src/Widgets/LoginRow.vala
+++ b/src/Widgets/LoginRow.vala
@@ -90,13 +90,12 @@ public class FeedReader.LoginRow : Gtk.ListBoxRow {
 	private bool rowLeave(Gdk.EventCrossing event)
 	{
 		if(event.detail == Gdk.NotifyType.INFERIOR
-		|| event.detail == Gdk.NotifyType.VIRTUAL)
+		   || event.detail == Gdk.NotifyType.VIRTUAL)
 		{
 			if(event.detail == Gdk.NotifyType.VIRTUAL)
 				m_hovered = false;
 			return true;
 		}
-
 
 		m_hovered = false;
 		m_infoStack.set_visible_child_name("empty");

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -29,7 +29,7 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 	private Gtk.CssProvider m_cssProvider;
 	private uint m_stackTransitionTime = 100;
 
-	private static MainWindow? m_window = null;
+	private static MainWindow ? m_window = null;
 
 	public static MainWindow get_default()
 	{
@@ -65,10 +65,10 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 		var reportBugAction = new SimpleAction("bugs", null);
 		reportBugAction.activate.connect(() => {
 			try{
-				Gtk.show_uri_on_window(this, "https://github.com/jangernert/FeedReader/issues", Gdk.CURRENT_TIME);
+			    Gtk.show_uri_on_window(this, "https://github.com/jangernert/FeedReader/issues", Gdk.CURRENT_TIME);
 			}
-			catch(GLib.Error e){
-				Logger.debug("could not open the link in an external browser: %s".printf(e.message));
+			catch(GLib.Error e) {
+			    Logger.debug("could not open the link in an external browser: %s".printf(e.message));
 			}
 		});
 		this.add_action(reportBugAction);
@@ -77,10 +77,10 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 		var bountyAction = new SimpleAction("bounty", null);
 		bountyAction.activate.connect(() => {
 			try{
-				Gtk.show_uri_on_window(this, "https://www.bountysource.com/teams/jangernert-feedreader/issues", Gdk.CURRENT_TIME);
+			    Gtk.show_uri_on_window(this, "https://www.bountysource.com/teams/jangernert-feedreader/issues", Gdk.CURRENT_TIME);
 			}
-			catch(GLib.Error e){
-				Logger.debug("could not open the link in an external browser: %s".printf(e.message));
+			catch(GLib.Error e) {
+			    Logger.debug("could not open the link in an external browser: %s".printf(e.message));
 			}
 		});
 		this.add_action(bountyAction);
@@ -122,7 +122,7 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 			dialog.response.connect((response_id) => {
 				if (response_id == Gtk.ResponseType.CANCEL || response_id == Gtk.ResponseType.DELETE_EVENT)
 				{
-					dialog.hide_on_delete();
+				    dialog.hide_on_delete();
 				}
 			});
 
@@ -189,7 +189,7 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 			{
 				Logger.debug("MainWindow: fullscreen event");
 				if(ColumnView.get_default().getSelectedArticle() == ""
-				|| ColumnView.get_default().getSelectedArticle() == "empty")
+				   || ColumnView.get_default().getSelectedArticle() == "empty")
 					return true;
 
 				if(ColumnView.get_default().isFullscreenVideo())
@@ -200,7 +200,6 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 					base.window_state_event(event);
 					return true;
 				}
-
 
 				if((event.new_window_state & Gdk.WindowState.FULLSCREEN) == Gdk.WindowState.FULLSCREEN)
 				{
@@ -308,21 +307,21 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 
 		switch(theme)
 		{
-			case FeedListTheme.GTK:
-				m_cssProvider = addProvider(path + "gtk.css");
-				break;
+		case FeedListTheme.GTK:
+			m_cssProvider = addProvider(path + "gtk.css");
+			break;
 
-			case FeedListTheme.DARK:
-				m_cssProvider = addProvider(path + "dark.css");
-				break;
+		case FeedListTheme.DARK:
+			m_cssProvider = addProvider(path + "dark.css");
+			break;
 
-			case FeedListTheme.ELEMENTARY:
-				m_cssProvider = addProvider(path + "elementary.css");
-				break;
+		case FeedListTheme.ELEMENTARY:
+			m_cssProvider = addProvider(path + "elementary.css");
+			break;
 		}
 	}
 
-	private Gtk.CssProvider? addProvider(string path)
+	private Gtk.CssProvider ? addProvider(string path)
 	{
 		Gtk.CssProvider provider = new Gtk.CssProvider();
 		provider.load_from_resource(path);
@@ -357,15 +356,15 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 		m_error_bar.response.connect((response_id) => {
 			switch(response_id)
 			{
-				case Gtk.ResponseType.CLOSE:
-					m_error_bar.set_visible(false);
-					break;
-				case Gtk.ResponseType.APPLY:
-					Settings.tweaks().set_boolean("ignore-tls-errors", true);
-					m_ignore_tls_errors.set_visible(false);
-					m_error_bar.set_visible(false);
-					m_login.writeLoginData();
-					break;
+			case Gtk.ResponseType.CLOSE:
+				m_error_bar.set_visible(false);
+				break;
+			case Gtk.ResponseType.APPLY:
+				Settings.tweaks().set_boolean("ignore-tls-errors", true);
+				m_ignore_tls_errors.set_visible(false);
+				m_error_bar.set_visible(false);
+				m_login.writeLoginData();
+				break;
 			}
 		});
 
@@ -416,55 +415,55 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 		Logger.debug("MainWindow: show error bar - errorCode = " + ErrorCode.to_string());
 		switch(ErrorCode)
 		{
-			case LoginResponse.NO_BACKEND:
-				m_ErrorMessage.set_label(_("Please select a service first"));
-				break;
-			case LoginResponse.MISSING_USER:
-				m_ErrorMessage.set_label(_("Please enter a valid username"));
-				break;
-			case LoginResponse.MISSING_PASSWD:
-				m_ErrorMessage.set_label(_("Please enter a valid password"));
-				break;
-			case LoginResponse.INVALID_URL:
-			case LoginResponse.MISSING_URL:
-				m_ErrorMessage.set_label(_("Please enter a valid URL"));
-				break;
-			case LoginResponse.ALL_EMPTY:
-				m_ErrorMessage.set_label(_("Please enter your Login details"));
-				break;
-			case LoginResponse.UNKNOWN_ERROR:
-				m_ErrorMessage.set_label(_("Sorry, something went wrong."));
-				break;
-			case LoginResponse.API_ERROR:
-				m_ErrorMessage.set_label(_("The server reported an API-error."));
-				break;
-			case LoginResponse.WRONG_LOGIN:
-				m_ErrorMessage.set_label(_("Either your username or the password are not correct."));
-				break;
-			case LoginResponse.NO_CONNECTION:
-				m_ErrorMessage.set_label(_("No connection to the server. Check your internet connection and the server URL!"));
-				break;
-			case LoginResponse.NO_API_ACCESS:
-				m_ErrorMessage.set_label(_("API access is disabled on the server. Please enable it first!"));
-				break;
-			case LoginResponse.UNAUTHORIZED:
-				m_ErrorMessage.set_label(_("Not authorized to access URL"));
-				m_login.showHtAccess();
-				break;
-			case LoginResponse.CA_ERROR:
-				m_ErrorMessage.set_label(_("No valid CA certificate available!"));
-				m_ignore_tls_errors.set_visible(true);
-				break;
-			case LoginResponse.PLUGIN_NEEDED:
-				m_ErrorMessage.set_label(_("Please install the \"api_feedreader\"-plugin on your tt-rss instance!"));
-				m_ignore_tls_errors.set_visible(true);
-				break;
-			case LoginResponse.SUCCESS:
-			case LoginResponse.FIRST_TRY:
-			default:
-				Logger.debug("MainWindow: dont show error bar");
-				m_error_bar.set_visible(false);
-				return;
+		case LoginResponse.NO_BACKEND:
+			m_ErrorMessage.set_label(_("Please select a service first"));
+			break;
+		case LoginResponse.MISSING_USER:
+			m_ErrorMessage.set_label(_("Please enter a valid username"));
+			break;
+		case LoginResponse.MISSING_PASSWD:
+			m_ErrorMessage.set_label(_("Please enter a valid password"));
+			break;
+		case LoginResponse.INVALID_URL:
+		case LoginResponse.MISSING_URL:
+			m_ErrorMessage.set_label(_("Please enter a valid URL"));
+			break;
+		case LoginResponse.ALL_EMPTY:
+			m_ErrorMessage.set_label(_("Please enter your Login details"));
+			break;
+		case LoginResponse.UNKNOWN_ERROR:
+			m_ErrorMessage.set_label(_("Sorry, something went wrong."));
+			break;
+		case LoginResponse.API_ERROR:
+			m_ErrorMessage.set_label(_("The server reported an API-error."));
+			break;
+		case LoginResponse.WRONG_LOGIN:
+			m_ErrorMessage.set_label(_("Either your username or the password are not correct."));
+			break;
+		case LoginResponse.NO_CONNECTION:
+			m_ErrorMessage.set_label(_("No connection to the server. Check your internet connection and the server URL!"));
+			break;
+		case LoginResponse.NO_API_ACCESS:
+			m_ErrorMessage.set_label(_("API access is disabled on the server. Please enable it first!"));
+			break;
+		case LoginResponse.UNAUTHORIZED:
+			m_ErrorMessage.set_label(_("Not authorized to access URL"));
+			m_login.showHtAccess();
+			break;
+		case LoginResponse.CA_ERROR:
+			m_ErrorMessage.set_label(_("No valid CA certificate available!"));
+			m_ignore_tls_errors.set_visible(true);
+			break;
+		case LoginResponse.PLUGIN_NEEDED:
+			m_ErrorMessage.set_label(_("Please install the \"api_feedreader\"-plugin on your tt-rss instance!"));
+			m_ignore_tls_errors.set_visible(true);
+			break;
+		case LoginResponse.SUCCESS:
+		case LoginResponse.FIRST_TRY:
+		default:
+			Logger.debug("MainWindow: dont show error bar");
+			m_error_bar.set_visible(false);
+			return;
 		}
 
 		Logger.debug("MainWindow: show error bar");
@@ -478,11 +477,11 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 		dbUI.get_default().updateBadge.connect(() => {
 			try
 			{
-				DBusConnection.get_default().updateBadge();
+			    DBusConnection.get_default().updateBadge();
 			}
 			catch(Error e)
 			{
-				Logger.error("MainWindow.loadContent: %s".printf(e.message));
+			    Logger.error("MainWindow.loadContent: %s".printf(e.message));
 			}
 
 		});
@@ -532,11 +531,10 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 		}
 	}
 
-
 	private bool checkShortcut(Gdk.EventKey event, string gsettingKey)
 	{
-		uint? key;
-		Gdk.ModifierType? mod;
+		uint ? key;
+		Gdk.ModifierType ? mod;
 		string setting = Settings.keybindings().get_string(gsettingKey);
 		Gtk.accelerator_parse(setting, out key, out mod);
 
@@ -545,7 +543,7 @@ public class FeedReader.MainWindow : Gtk.ApplicationWindow
 			if(mod == null || mod == 0)
 			{
 				if(event.state == 16
-				|| event.state == 0)
+				   || event.state == 0)
 					return true;
 			}
 			else if(mod in event.state)

--- a/src/Widgets/MediaButton.vala
+++ b/src/Widgets/MediaButton.vala
@@ -32,7 +32,7 @@ public class FeedReader.AttachedMediaButton : Gtk.Button {
 		m_filesIcon = new Gtk.Image.from_icon_name("mail-attachment-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		m_playIcon = new Gtk.Image.from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		m_spinner = new Gtk.Spinner();
-		m_spinner.set_size_request(16,16);
+		m_spinner.set_size_request(16, 16);
 
 		m_stack = new Gtk.Stack();
 		m_stack.set_transition_duration(100);
@@ -51,7 +51,7 @@ public class FeedReader.AttachedMediaButton : Gtk.Button {
 		m_list.row_activated.connect((row) => {
 			m_spinner.start();
 			m_pop.hide();
-			mediaRow? mRow = row as mediaRow;
+			mediaRow ? mRow = row as mediaRow;
 			if(mRow != null)
 				playMedia(mRow.getURL());
 			else

--- a/src/Widgets/MediaPlayer.vala
+++ b/src/Widgets/MediaPlayer.vala
@@ -57,22 +57,22 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 
 		ThreadFunc<void*> run = () => {
 			try
-		    {
-		        var discoverer = new Gst.PbUtils.Discoverer((Gst.ClockTime)(10*Gst.SECOND));
-		        var info = discoverer.discover_uri(m_URL);
+			{
+				var discoverer = new Gst.PbUtils.Discoverer((Gst.ClockTime)(10 * Gst.SECOND));
+				var info = discoverer.discover_uri(m_URL);
 
-		        foreach(Gst.PbUtils.DiscovererStreamInfo i in info.get_stream_list())
+				foreach(Gst.PbUtils.DiscovererStreamInfo i in info.get_stream_list())
 				{
 					if(i is Gst.PbUtils.DiscovererVideoInfo)
 					{
 						var v = (Gst.PbUtils.DiscovererVideoInfo)i;
-						m_aspectRatio = ((double)v.get_width())/((double)v.get_height());
+						m_aspectRatio = ((double)v.get_width()) / ((double)v.get_height());
 						m_type = MediaType.VIDEO;
 					}
 				}
-		    }
-		    catch (Error e)
-		    {
+			}
+			catch (Error e)
+			{
 				Logger.error("Unable discover_uri: " + e.message);
 			}
 			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
@@ -106,16 +106,16 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 			m_player.get_state(out state, out pending, 1000);
 			if(state == Gst.State.PLAYING)
 			{
-				int64 pos;
-				int64 dur;
-				m_player.query_position(Gst.Format.TIME, out pos);
-				m_player.query_duration(Gst.Format.TIME, out dur);
-				double position = (double)pos/1000000000;
-				double duration = (double)dur/1000000000;
-				double percent = position*100.0/duration;
-				if(m_seek_source_id == 0)
+			    int64 pos;
+			    int64 dur;
+			    m_player.query_position(Gst.Format.TIME, out pos);
+			    m_player.query_duration(Gst.Format.TIME, out dur);
+			    double position = (double)pos / 1000000000;
+			    double duration = (double)dur / 1000000000;
+			    double percent = position * 100.0 / duration;
+			    if(m_seek_source_id == 0)
 					m_scale.set_value(percent);
-				calcTime();
+			    calcTime();
 			}
 			return true;
 		}, GLib.Priority.LOW);
@@ -207,19 +207,19 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 
 		switch(state)
 		{
-			case Gst.State.PLAYING:
-				m_playButton.set_image(m_playIcon);
-				m_playButton.set_tooltip_text(MediaButton.PLAY);
-				m_player.set_state(Gst.State.PAUSED);
-				break;
+		case Gst.State.PLAYING:
+			m_playButton.set_image(m_playIcon);
+			m_playButton.set_tooltip_text(MediaButton.PLAY);
+			m_player.set_state(Gst.State.PAUSED);
+			break;
 
-			case Gst.State.PAUSED:
-			case Gst.State.READY:
-			default:
-				m_playButton.set_image(m_pauseIcon);
-				m_playButton.set_tooltip_text(MediaButton.PAUSE);
-				m_player.set_state(Gst.State.PLAYING);
-				break;
+		case Gst.State.PAUSED:
+		case Gst.State.READY:
+		default:
+			m_playButton.set_image(m_pauseIcon);
+			m_playButton.set_tooltip_text(MediaButton.PAUSE);
+			m_player.set_state(Gst.State.PLAYING);
+			break;
 		}
 
 		if(m_muted)
@@ -232,17 +232,17 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 	{
 		switch(m_display)
 		{
-			case DisplayPosition.ALL:
-				m_display = DisplayPosition.POS;
-				break;
+		case DisplayPosition.ALL:
+			m_display = DisplayPosition.POS;
+			break;
 
-			case DisplayPosition.POS:
-				m_display = DisplayPosition.LEFT;
-				break;
+		case DisplayPosition.POS:
+			m_display = DisplayPosition.LEFT;
+			break;
 
-			case DisplayPosition.LEFT:
-				m_display = DisplayPosition.ALL;
-				break;
+		case DisplayPosition.LEFT:
+			m_display = DisplayPosition.ALL;
+			break;
 		}
 		calcTime();
 	}
@@ -253,56 +253,54 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 		int64 dur;
 		m_player.query_position(Gst.Format.TIME, out pos);
 		m_player.query_duration(Gst.Format.TIME, out dur);
-		double position = (int)((double)pos/1000000000);
-		double duration = (int)((double)dur/1000000000);
+		double position = (int)((double)pos / 1000000000);
+		double duration = (int)((double)dur / 1000000000);
 
-
-
-		double? sd = duration;
-		double? md = null;
-		double? hd = null;
+		double ? sd = duration;
+		double ? md = null;
+		double ? hd = null;
 
 		if( ((int)sd) >= 60)
 		{
-			md = (int)(sd/60);
-			sd = sd - (md*60);
+			md = (int)(sd / 60);
+			sd = sd - (md * 60);
 
 			if( ((int)md) >= 60)
 			{
-				hd = (int)(md/60);
-				md = md - (hd*60);
+				hd = (int)(md / 60);
+				md = md - (hd * 60);
 			}
 		}
 
-		double? sp = position;
-		double? mp = null;
-		double? hp = null;
+		double ? sp = position;
+		double ? mp = null;
+		double ? hp = null;
 
 		if( ((int)sp) >= 60)
 		{
-			mp = (int)(sp/60);
-			sp = sp - (mp*60);
+			mp = (int)(sp / 60);
+			sp = sp - (mp * 60);
 
 			if( ((int)mp) >= 60)
 			{
-				hp = (int)(mp/60);
-				mp = mp - (hp*60);
+				hp = (int)(mp / 60);
+				mp = mp - (hp * 60);
 			}
 		}
 
-		double? sr = duration - position;
-		double? mr = null;
-		double? hr = null;
+		double ? sr = duration - position;
+		double ? mr = null;
+		double ? hr = null;
 
 		if( ((int)sr) >= 60)
 		{
-			mr = (int)(sr/60);
-			sr = sr - (mr*60);
+			mr = (int)(sr / 60);
+			sr = sr - (mr * 60);
 
 			if( ((int)mr) >= 60)
 			{
-				hr = (int)(mr/60);
-				mr = mr - (hr*60);
+				hr = (int)(mr / 60);
+				mr = mr - (hr * 60);
 			}
 		}
 
@@ -330,20 +328,19 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 			return;
 		}
 
-
 		switch(m_display)
 		{
-			case DisplayPosition.ALL:
-				m_labelButton.set_label(pLabel + " / " + dLabel);
-				break;
+		case DisplayPosition.ALL:
+			m_labelButton.set_label(pLabel + " / " + dLabel);
+			break;
 
-			case DisplayPosition.POS:
-				m_labelButton.set_label(pLabel);
-				break;
+		case DisplayPosition.POS:
+			m_labelButton.set_label(pLabel);
+			break;
 
-			case DisplayPosition.LEFT:
-				m_labelButton.set_label(rLabel);
-				break;
+		case DisplayPosition.LEFT:
+			m_labelButton.set_label(rLabel);
+			break;
 		}
 	}
 
@@ -358,14 +355,14 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 			m_seek_source_id = GLib.Timeout.add_full(GLib.Priority.DEFAULT, 500, () => {
 				if(m_scale.get_value() != startValue)
 				{
-					startValue = m_scale.get_value();
-					return true;
+				    startValue = m_scale.get_value();
+				    return true;
 				}
 				else
 				{
-					m_seek_source_id = 0;
-					seek(startValue);
-					return false;
+				    m_seek_source_id = 0;
+				    seek(startValue);
+				    return false;
 				}
 			});
 		}
@@ -375,7 +372,7 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 	private void seek(double new_value)
 	{
 		int64 dur;
-		double percent = new_value/100.0;
+		double percent = new_value / 100.0;
 		m_player.query_duration(Gst.Format.TIME, out dur);
 		int64 pos = (int64)(percent * (double)dur);
 		m_player.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH | Gst.SeekFlags.KEY_UNIT,  pos);
@@ -406,53 +403,53 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 	{
 		switch (message.type)
 		{
-			case Gst.MessageType.ERROR:
-				GLib.Error err;
-				string debug;
-				message.parse_error(out err, out debug);
-				Logger.error("MediaPlayer: " + err.message);
-				m_player.set_state(Gst.State.NULL);
-				break;
+		case Gst.MessageType.ERROR:
+			GLib.Error err;
+			string debug;
+			message.parse_error(out err, out debug);
+			Logger.error("MediaPlayer: " + err.message);
+			m_player.set_state(Gst.State.NULL);
+			break;
 
-			case Gst.MessageType.EOS:
-				m_player.set_state(Gst.State.READY);
-				m_playButton.set_image(m_playIcon);
-				break;
+		case Gst.MessageType.EOS:
+			m_player.set_state(Gst.State.READY);
+			m_playButton.set_image(m_playIcon);
+			break;
 
-			case Gst.MessageType.BUFFERING:
-				int percent = 0;
-				message.parse_buffering(out percent);
-				if(percent < 100)
+		case Gst.MessageType.BUFFERING:
+			int percent = 0;
+			message.parse_buffering(out percent);
+			if(percent < 100)
+			{
+				m_player.set_state(Gst.State.PAUSED);
+
+				if(m_type == MediaType.VIDEO)
 				{
-					m_player.set_state(Gst.State.PAUSED);
-
-					if(m_type == MediaType.VIDEO)
-					{
-						m_bufferLabel.set_text(percent.to_string() + "%");
-						m_bufferLabel.show();
-					}
-					else
-					{
-						m_playStack.set_visible_child_name("spinner");
-						m_playSpinner.start();
-					}
+					m_bufferLabel.set_text(percent.to_string() + "%");
+					m_bufferLabel.show();
 				}
 				else
 				{
-					m_player.set_state(Gst.State.PLAYING);
-					if(m_type == MediaType.VIDEO)
-						m_bufferLabel.hide();
-					else
-						m_playStack.set_visible_child_name("button");
+					m_playStack.set_visible_child_name("spinner");
+					m_playSpinner.start();
 				}
-				break;
+			}
+			else
+			{
+				m_player.set_state(Gst.State.PLAYING);
+				if(m_type == MediaType.VIDEO)
+					m_bufferLabel.hide();
+				else
+					m_playStack.set_visible_child_name("button");
+			}
+			break;
 
-			case Gst.MessageType.STATE_CHANGED:
-				Gst.State oldstate;
-				Gst.State newstate;
-				Gst.State pending;
-				message.parse_state_changed(out oldstate, out newstate, out pending);
-		        break;
+		case Gst.MessageType.STATE_CHANGED:
+			Gst.State oldstate;
+			Gst.State newstate;
+			Gst.State pending;
+			message.parse_state_changed(out oldstate, out newstate, out pending);
+			break;
 		}
 		return true;
 	}
@@ -462,7 +459,7 @@ public class FeedReader.MediaPlayer : Gtk.Box {
 		if(m_aspectRatio != 0)
 		{
 			double width = (double)allocation.width;
-			int height = (int)(width/m_aspectRatio);
+			int height = (int)(width / m_aspectRatio);
 			m_videoWidget.set_size_request(-1, height);
 		}
 	}

--- a/src/Widgets/ModeButton.vala
+++ b/src/Widgets/ModeButton.vala
@@ -114,7 +114,7 @@ namespace FeedReader {
 		 */
 		public int append (Gtk.Widget w, string tooltip) {
 			int index;
-			for (index = item_map.size; item_map.has_key (index); index++);
+			for (index = item_map.size; item_map.has_key (index); index++) ;
 			assert (item_map[index] == null);
 
 			w.set_tooltip_text(tooltip);
@@ -231,16 +231,16 @@ namespace FeedReader {
 			int offset;
 
 			switch (ev.direction) {
-				case Gdk.ScrollDirection.DOWN:
-				case Gdk.ScrollDirection.RIGHT:
-					offset = 1;
-					break;
-				case Gdk.ScrollDirection.UP:
-				case Gdk.ScrollDirection.LEFT:
-					offset = -1;
-					break;
-				default:
-					return false;
+			case Gdk.ScrollDirection.DOWN:
+			case Gdk.ScrollDirection.RIGHT:
+				offset = 1;
+				break;
+			case Gdk.ScrollDirection.UP:
+			case Gdk.ScrollDirection.LEFT:
+				offset = -1;
+				break;
+			default:
+				return false;
 			}
 
 			// Try to find a valid item, since there could be invisible items in

--- a/src/Widgets/RemovePopover.vala
+++ b/src/Widgets/RemovePopover.vala
@@ -30,17 +30,17 @@ public class FeedReader.RemovePopover : Gtk.Popover {
 
 		switch(m_type)
 		{
-			case FeedListType.TAG:
-				m_name = dbUI.get_default().getTagName(m_id);
-				break;
+		case FeedListType.TAG:
+			m_name = dbUI.get_default().getTagName(m_id);
+			break;
 
-			case FeedListType.FEED:
-				m_name = dbUI.get_default().getFeedName(m_id);
-				break;
+		case FeedListType.FEED:
+			m_name = dbUI.get_default().getFeedName(m_id);
+			break;
 
-			case FeedListType.CATEGORY:
-				m_name = dbUI.get_default().getCategoryName(m_id);
-				break;
+		case FeedListType.CATEGORY:
+			m_name = dbUI.get_default().getCategoryName(m_id);
+			break;
 		}
 
 		var removeButton = new Gtk.Button.with_label(_("Remove \"%s\"").printf(m_name));
@@ -59,17 +59,17 @@ public class FeedReader.RemovePopover : Gtk.Popover {
 
 		switch(m_type)
 		{
-			case FeedListType.TAG:
-				removeTag();
-				break;
+		case FeedListType.TAG:
+			removeTag();
+			break;
 
-			case FeedListType.FEED:
-				removeFeed();
-				break;
+		case FeedListType.FEED:
+			removeFeed();
+			break;
 
-			case FeedListType.CATEGORY:
-				removeCategory();
-				break;
+		case FeedListType.CATEGORY:
+			removeCategory();
+			break;
 		}
 
 		this.hide();
@@ -83,11 +83,11 @@ public class FeedReader.RemovePopover : Gtk.Popover {
 		ulong eventID = notification.dismissed.connect(() => {
 			try
 			{
-				DBusConnection.get_default().deleteTag(m_id);
+			    DBusConnection.get_default().deleteTag(m_id);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("RemovePopover.removeTag: %s".printf(e.message));
+			    Logger.error("RemovePopover.removeTag: %s".printf(e.message));
 			}
 		});
 		notification.action.connect(() => {
@@ -105,11 +105,11 @@ public class FeedReader.RemovePopover : Gtk.Popover {
 		ulong eventID = notification.dismissed.connect(() => {
 			try
 			{
-				DBusConnection.get_default().removeFeed(m_id);
+			    DBusConnection.get_default().removeFeed(m_id);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("RemovePopover.removeFeed: %s".printf(e.message));
+			    Logger.error("RemovePopover.removeFeed: %s".printf(e.message));
 			}
 		});
 		notification.action.connect(() => {
@@ -128,11 +128,11 @@ public class FeedReader.RemovePopover : Gtk.Popover {
 		ulong eventID = notification.dismissed.connect(() => {
 			try
 			{
-				DBusConnection.get_default().removeCategory(m_id);
+			    DBusConnection.get_default().removeCategory(m_id);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("RemovePopover.removeCategory: %s".printf(e.message));
+			    Logger.error("RemovePopover.removeCategory: %s".printf(e.message));
 			}
 		});
 		notification.action.connect(() => {

--- a/src/Widgets/ResetPage.vala
+++ b/src/Widgets/ResetPage.vala
@@ -61,14 +61,12 @@ public class FeedReader.ResetPage : Gtk.Bin {
 		m_layout.pack_start(describtionText, true, true, 0);
 		m_layout.pack_end(buttonBox, false, true, 0);
 
-
 		this.set_halign(Gtk.Align.CENTER);
 		this.set_valign(Gtk.Align.CENTER);
 		this.margin = 20;
 		this.add(m_layout);
 		this.show_all();
 	}
-
 
 	private void resetAllData()
 	{

--- a/src/Widgets/ServiceInfo.vala
+++ b/src/Widgets/ServiceInfo.vala
@@ -38,7 +38,7 @@ public class FeedReader.ServiceInfo : Gtk.Overlay {
 		m_box.margin_bottom = 5;
 
 		m_spinner = new Gtk.Spinner();
-		m_spinner.set_size_request(32,32);
+		m_spinner.set_size_request(32, 32);
 
 		m_stack = new Gtk.Stack();
 		m_stack.add_named(m_box, "info");
@@ -60,9 +60,9 @@ public class FeedReader.ServiceInfo : Gtk.Overlay {
 	{
 		try
 		{
-			string? service_icon = DBusConnection.get_default().symbolicIcon();
-			string? user_name = DBusConnection.get_default().accountName();
-			string? server = DBusConnection.get_default().getServerURL();
+			string ? service_icon = DBusConnection.get_default().symbolicIcon();
+			string ? user_name = DBusConnection.get_default().accountName();
+			string ? server = DBusConnection.get_default().getServerURL();
 
 			if(this.is_visible())
 			{

--- a/src/Widgets/ServiceSettingsPopover.vala
+++ b/src/Widgets/ServiceSettingsPopover.vala
@@ -17,7 +17,6 @@ public class FeedReader.ServiceSettingsPopover : Gtk.Popover {
 
 	public signal void newAccount(string type);
 
-
 	public ServiceSettingsPopover(Gtk.Widget widget)
 	{
 		var list = new Gtk.ListBox();
@@ -42,7 +41,6 @@ public class FeedReader.ServiceSettingsPopover : Gtk.Popover {
 	}
 
 }
-
 
 public class FeedReader.ServiceSettingsPopoverRow : Gtk.ListBoxRow {
 

--- a/src/Widgets/Setting.vala
+++ b/src/Widgets/Setting.vala
@@ -18,8 +18,7 @@ public class FeedReader.Setting : Gtk.Box {
 	public signal void changed();
 	private Gtk.Label m_label;
 
-
-	public Setting(string name, string? tooltip = null)
+	public Setting(string name, string ? tooltip = null)
 	{
 		this.orientation = Gtk.Orientation.HORIZONTAL;
 		this.spacing = 0;
@@ -32,9 +31,7 @@ public class FeedReader.Setting : Gtk.Box {
 		this.pack_start(m_label, true, true, 0);
 	}
 
-
 }
-
 
 public class FeedReader.SettingFont : FeedReader.Setting {
 
@@ -55,7 +52,7 @@ public class FeedReader.SettingFont : FeedReader.Setting {
 
 public class FeedReader.SettingDropbox : FeedReader.Setting {
 
-	public SettingDropbox(string name, GLib.Settings settings, string key, string[] values, string? tooltip = null)
+	public SettingDropbox(string name, GLib.Settings settings, string key, string[] values, string ? tooltip = null)
 	{
 		base(name, tooltip);
 		var liststore = new Gtk.ListStore(1, typeof(string));
@@ -81,10 +78,9 @@ public class FeedReader.SettingDropbox : FeedReader.Setting {
 	}
 }
 
-
 public class FeedReader.SettingSwitch : FeedReader.Setting {
 
-	public SettingSwitch(string name, GLib.Settings settings, string key, string? tooltip = null)
+	public SettingSwitch(string name, GLib.Settings settings, string key, string ? tooltip = null)
 	{
 		base(name, tooltip);
 
@@ -100,10 +96,9 @@ public class FeedReader.SettingSwitch : FeedReader.Setting {
 	}
 }
 
-
 public class FeedReader.SettingSpin : FeedReader.Setting {
 
-	public SettingSpin(string name, GLib.Settings settings, string key, int min, int max, int step, string? tooltip = null)
+	public SettingSpin(string name, GLib.Settings settings, string key, int min, int max, int step, string ? tooltip = null)
 	{
 		base(name, tooltip);
 

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -19,7 +19,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 	private Gtk.Stack m_stack;
 	private InfoBar m_errorBar;
 	private Gtk.HeaderBar m_headerbar;
-	private static SettingsDialog? m_dialog = null;
+	private static SettingsDialog ? m_dialog = null;
 
 	public static SettingsDialog get_default()
 	{
@@ -113,10 +113,10 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 			ColumnView.get_default().reloadArticleView();
 		});
 
-	   var fontfamilly = new SettingFont(_("Font Familly"), Settings.general(), "font");
-	   fontfamilly.changed.connect(() => {
+		var fontfamilly = new SettingFont(_("Font Familly"), Settings.general(), "font");
+		fontfamilly.changed.connect(() => {
 			ColumnView.get_default().reloadArticleView();
-	   });
+		});
 
 		var uiBox = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
 		uiBox.expand = true;
@@ -135,7 +135,6 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 		return uiBox;
 	}
 
-
 	private Gtk.Box setup_Internal()
 	{
 		var sync_settings = headline(_("Sync:"));
@@ -146,27 +145,26 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 		sync_time.changed.connect(() => {
 			try
 			{
-				DBusConnection.get_default().scheduleSync(Settings.general().get_int("sync"));
+			    DBusConnection.get_default().scheduleSync(Settings.general().get_int("sync"));
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("SettingsDialog.setup_Internal: scheduleSync %s".printf(e.message));
+			    Logger.error("SettingsDialog.setup_Internal: scheduleSync %s".printf(e.message));
 			}
 		});
 
 		var db_settings = headline(_("Database:"));
 
 		var drop_articles = new SettingDropbox(_("Delete articles after"), Settings.general(), "drop-articles-after",
-												{_("Never"), _("1 Week"), _("1 Month"), _("6 Months")});
+		                                       {_("Never"), _("1 Week"), _("1 Month"), _("6 Months")});
 
 		var service_settings = headline(_("Additional Functionality:"));
 
-		var grabber = new SettingSwitch(_("Content Grabber"), Settings.general(),"content-grabber");
+		var grabber = new SettingSwitch(_("Content Grabber"), Settings.general(), "content-grabber");
 
-		var images = new SettingSwitch(_("Download Images"), Settings.general(),"download-images");
+		var images = new SettingSwitch(_("Download Images"), Settings.general(), "download-images");
 
-		var mediaplayer = new SettingSwitch(_("Internal Media Player"), Settings.general(),"mediaplayer");
-
+		var mediaplayer = new SettingSwitch(_("Internal Media Player"), Settings.general(), "mediaplayer");
 
 		var internalsBox = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
 		internalsBox.expand = true;
@@ -174,7 +172,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 		try
 		{
 			if(DBusConnection.get_default().useMaxArticles())
-			      internalsBox.pack_start(sync_count, false, true, 0);
+				internalsBox.pack_start(sync_count, false, true, 0);
 		}
 		catch(GLib.Error e)
 		{
@@ -190,7 +188,6 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 
 		return internalsBox;
 	}
-
 
 	private Gtk.Box setup_Service()
 	{
@@ -265,11 +262,11 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 			children = m_serviceList.get_children();
 			foreach(Gtk.Widget row in children)
 			{
-				var tmpRow = row as ServiceSetup;
-				if(tmpRow != null && !tmpRow.isLoggedIn())
-				{
-					Share.get_default().refreshAccounts();
-					removeRow(tmpRow, m_serviceList);
+			    var tmpRow = row as ServiceSetup;
+			    if(tmpRow != null && !tmpRow.isLoggedIn())
+			    {
+			        Share.get_default().refreshAccounts();
+			        removeRow(tmpRow, m_serviceList);
 				}
 			}
 
@@ -295,7 +292,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 	{
 		row.unreveal();
 		GLib.Timeout.add(700, () => {
-		    list.remove(row);
+			list.remove(row);
 			return false;
 		});
 	}
@@ -313,7 +310,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 			return -1;
 
 		if(r1.getUserName() == ""
-		&& r2.getUserName() == "")
+		   && r2.getUserName() == "")
 			return 0;
 		else if(r1.getUserName() == "")
 			return 1;
@@ -331,7 +328,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 		return 1;
 	}
 
-	private void headerFunc(Gtk.ListBoxRow row, Gtk.ListBoxRow? before)
+	private void headerFunc(Gtk.ListBoxRow row, Gtk.ListBoxRow ? before)
 	{
 		var label = new Gtk.Label(_("System Accounts"));
 		label.get_style_context().add_class("bold");
@@ -365,7 +362,6 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 				return;
 			}
 		}
-
 
 		var r2 = before as ServiceSetup;
 		bool sys2 = r2.isSystemAccount();

--- a/src/Widgets/SharePopover.vala
+++ b/src/Widgets/SharePopover.vala
@@ -74,7 +74,7 @@ public class FeedReader.SharePopover : Gtk.Popover {
 		{
 			var seperatorBox = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
 			seperatorBox.pack_start(new Gtk.Separator(Gtk.Orientation.HORIZONTAL), false, false, 0);
-	        seperatorBox.pack_start(addBox, true, true, 0);
+			seperatorBox.pack_start(addBox, true, true, 0);
 			addRow.add(seperatorBox);
 		}
 		else
@@ -88,7 +88,7 @@ public class FeedReader.SharePopover : Gtk.Popover {
 
 	private void clicked(Gtk.ListBoxRow row)
 	{
-		ShareRow? shareRow = row as ShareRow;
+		ShareRow ? shareRow = row as ShareRow;
 
 		if(shareRow == null)
 		{

--- a/src/Widgets/ShortcutsWindow.vala
+++ b/src/Widgets/ShortcutsWindow.vala
@@ -32,7 +32,6 @@ public class FeedReader.ShortcutsWindow : Gtk.ShortcutsWindow {
 		general.add(quit);
 		//--------------------------------------------------
 
-
 		//--------------------------------------------------
 		var feedList = newGroup(_("Feed List"));
 		//--------------------------------------------------
@@ -48,7 +47,6 @@ public class FeedReader.ShortcutsWindow : Gtk.ShortcutsWindow {
 		feedList.add(expCol);
 		feedList.add(flmark);
 		//--------------------------------------------------
-
 
 		//--------------------------------------------------
 		var articleList = newGroup(_("Article List"));
@@ -74,7 +72,6 @@ public class FeedReader.ShortcutsWindow : Gtk.ShortcutsWindow {
 		articleList.add(centerSelected);
 		//--------------------------------------------------
 
-
 		//--------------------------------------------------
 		var articleView = newGroup(_("Article View"));
 		//--------------------------------------------------
@@ -85,7 +82,6 @@ public class FeedReader.ShortcutsWindow : Gtk.ShortcutsWindow {
 		articleView.add(AVupdown);
 		//--------------------------------------------------
 
-
 		//--------------------------------------------------
 		var section = newSection("test", "section", 10);
 		//--------------------------------------------------
@@ -95,7 +91,6 @@ public class FeedReader.ShortcutsWindow : Gtk.ShortcutsWindow {
 		section.add(articleView);
 		//--------------------------------------------------
 
-
 		this.add(section);
 		this.set_transient_for(parent);
 		this.set_modal(true);
@@ -104,21 +99,21 @@ public class FeedReader.ShortcutsWindow : Gtk.ShortcutsWindow {
 
 	private Gtk.ShortcutsSection newSection(string title, string section_name, int maxHeight)
 	{
-		var section = (Gtk.ShortcutsSection)Object.new(typeof(Gtk.ShortcutsSection), title: title, section_name: section_name, max_height: maxHeight);
+		var section = (Gtk.ShortcutsSection)Object.new(typeof(Gtk.ShortcutsSection), title : title, section_name : section_name, max_height : maxHeight);
 		section.show();
 		return section;
 	}
 
 	private Gtk.ShortcutsGroup newGroup(string title)
 	{
-		var group = (Gtk.ShortcutsGroup)Object.new(typeof(Gtk.ShortcutsGroup), title: title);
+		var group = (Gtk.ShortcutsGroup)Object.new(typeof(Gtk.ShortcutsGroup), title : title);
 		group.show();
 		return group;
 	}
 
 	private Gtk.ShortcutsShortcut newShortcut(string title, string key)
 	{
-		var shortcut = (Gtk.ShortcutsShortcut)Object.new(typeof(Gtk.ShortcutsShortcut), title: title, accelerator: key);
+		var shortcut = (Gtk.ShortcutsShortcut)Object.new(typeof(Gtk.ShortcutsShortcut), title : title, accelerator : key);
 		shortcut.show();
 		return shortcut;
 	}

--- a/src/Widgets/TagPopover.vala
+++ b/src/Widgets/TagPopover.vala
@@ -57,10 +57,8 @@ public class FeedReader.TagPopover : Gtk.Popover {
 		box.pack_start(m_viewport);
 		m_stack.add_named(box, "tags");
 
-
 		setupEntry();
 		populateList();
-
 
 		m_box.pack_start(m_stack);
 		m_box.pack_start(m_entry);
@@ -75,7 +73,6 @@ public class FeedReader.TagPopover : Gtk.Popover {
 		else
 			m_stack.set_visible_child_name("tags");
 	}
-
 
 	private void populateList()
 	{
@@ -127,7 +124,7 @@ public class FeedReader.TagPopover : Gtk.Popover {
 		m_entry.icon_press.connect((pos, event) => {
 			if(pos == Gtk.EntryIconPosition.SECONDARY)
 			{
-				m_entry.set_text("");
+			    m_entry.set_text("");
 			}
 		});
 		m_entry.activate.connect(() => {
@@ -139,39 +136,38 @@ public class FeedReader.TagPopover : Gtk.Popover {
 
 			foreach(tag Tag in m_tags)
 			{
-				if(str == Tag.getTitle())
-				{
-					Logger.debug("TagPopover: article already tagged");
-					m_entry.set_text("");
-					return;
+			    if(str == Tag.getTitle())
+			    {
+			        Logger.debug("TagPopover: article already tagged");
+			        m_entry.set_text("");
+			        return;
 				}
 			}
 
 			foreach(tag Tag in m_availableTags)
 			{
-				if(str == Tag.getTitle())
-				{
-					Logger.debug("TagPopover: tag available");
-					tagID = Tag.getTagID();
-					available = true;
-					break;
+			    if(str == Tag.getTitle())
+			    {
+			        Logger.debug("TagPopover: tag available");
+			        tagID = Tag.getTagID();
+			        available = true;
+			        break;
 				}
 			}
 
 			try
 			{
-				if(!available)
-				{
-					tagID = DBusConnection.get_default().createTag(str);
-					Logger.debug("TagPopover: " + str + " created with id " + tagID);
+			    if(!available)
+			    {
+			        tagID = DBusConnection.get_default().createTag(str);
+			        Logger.debug("TagPopover: " + str + " created with id " + tagID);
 				}
-				DBusConnection.get_default().tagArticle(getActiveArticleID(), tagID, true);
+			    DBusConnection.get_default().tagArticle(getActiveArticleID(), tagID, true);
 			}
 			catch(GLib.Error e)
 			{
-				Logger.error("TagPopover.setupEntry: %s".printf(e.message));
+			    Logger.error("TagPopover.setupEntry: %s".printf(e.message));
 			}
-
 
 			var new_tag = dbUI.get_default().read_tag(tagID);
 			var row = new TagPopoverRow(new_tag);

--- a/src/Widgets/TagRow.vala
+++ b/src/Widgets/TagRow.vala
@@ -34,7 +34,7 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 		this.get_style_context().add_class("fr-sidebar-row");
 		m_exits = true;
 		m_color = color;
-		m_name = name.replace("&","&amp;");
+		m_name = name.replace("&", "&amp;");
 		m_tagID = tagID;
 		m_catID = CategoryID.TAGS.to_string();
 
@@ -53,12 +53,12 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 			m_circle.newColor(color);
 			try
 			{
-				DBusConnection.get_default().updateTagColor(m_tagID, color);
+			    DBusConnection.get_default().updateTagColor(m_tagID, color);
 			}
-	        catch(GLib.Error e)
-	        {
-	            Logger.error("TagRow.constructor: %s".printf(e.message));
-	        }
+			catch(GLib.Error e)
+			{
+			    Logger.error("TagRow.constructor: %s".printf(e.message));
+			}
 		});
 
 		m_label = new Gtk.Label(m_name);
@@ -86,20 +86,20 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 		if(UtilsUI.canManipulateContent())
 		{
 			const Gtk.TargetEntry[] accepted_targets = {
-			    { "STRING",     0, DragTarget.TAG }
+				{ "STRING",     0, DragTarget.TAG }
 			};
 
-	        Gtk.drag_dest_set (
-	                this,
-	                Gtk.DestDefaults.MOTION,
-	                accepted_targets,
-	                Gdk.DragAction.COPY
-	        );
+			Gtk.drag_dest_set (
+				this,
+				Gtk.DestDefaults.MOTION,
+				accepted_targets,
+				Gdk.DragAction.COPY
+				);
 
-	        this.drag_motion.connect(onDragMotion);
-	        this.drag_leave.connect(onDragLeave);
-	        this.drag_drop.connect(onDragDrop);
-	        this.drag_data_received.connect(onDragDataReceived);
+			this.drag_motion.connect(onDragMotion);
+			this.drag_leave.connect(onDragLeave);
+			this.drag_drop.connect(onDragDrop);
+			this.drag_data_received.connect(onDragDataReceived);
 		}
 	}
 
@@ -130,13 +130,13 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 	}
 
 	private void onDragDataReceived(Gtk.Widget widget, Gdk.DragContext context, int x, int y,
-									Gtk.SelectionData selection_data, uint target_type, uint time)
+	                                Gtk.SelectionData selection_data, uint target_type, uint time)
 	{
 		try
 		{
 			if(selection_data != null
-			&& selection_data.get_length() >= 0
-			&& target_type == DragTarget.TAG)
+			   && selection_data.get_length() >= 0
+			   && target_type == DragTarget.TAG)
 			{
 				if(m_tagID != TagID.NEW)
 				{
@@ -148,7 +148,7 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 				{
 					showRenamePopover(context, time, (string)selection_data.get_data());
 				}
-	        }
+			}
 		}
 		catch(GLib.Error e)
 		{
@@ -167,10 +167,10 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 
 		switch(event.type)
 		{
-			case Gdk.EventType.BUTTON_RELEASE:
-			case Gdk.EventType.@2BUTTON_PRESS:
-			case Gdk.EventType.@3BUTTON_PRESS:
-				return false;
+		case Gdk.EventType.BUTTON_RELEASE:
+		case Gdk.EventType.@2BUTTON_PRESS:
+		case Gdk.EventType.@3BUTTON_PRESS:
+			return false;
 		}
 
 		var remove_action = new GLib.SimpleAction("deleteTag", null);
@@ -186,7 +186,7 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 			ulong eventID = notification.dismissed.connect(() => {
 				Logger.debug("TagRow: delete Tag");
 				try{DBusConnection.get_default().deleteTag(m_tagID);}
-				catch(GLib.Error e){Logger.error("TagRow.remove_action: %s".printf(e.message));}
+				catch(GLib.Error e) {Logger.error("TagRow.remove_action: %s".printf(e.message));}
 			});
 			notification.action.connect(() => {
 				notification.disconnect(eventID);
@@ -221,7 +221,7 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 
 	public void update(string name)
 	{
-		m_label.set_text(name.replace("&","&amp;"));
+		m_label.set_text(name.replace("&", "&amp;"));
 		m_label.set_use_markup (true);
 	}
 
@@ -251,7 +251,7 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 		m_revealer.set_reveal_child(reveal);
 	}
 
-	private void showRenamePopover(Gdk.DragContext? context = null, uint time = 0, string? articleID = null)
+	private void showRenamePopover(Gdk.DragContext ? context = null, uint time = 0, string ? articleID = null)
 	{
 		var popRename = new Gtk.Popover(this);
 		popRename.set_position(Gtk.PositionType.BOTTOM);
@@ -259,8 +259,8 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 			this.unset_state_flags(Gtk.StateFlags.PRELIGHT);
 			if(m_tagID == TagID.NEW && context != null)
 			{
-				Logger.debug("TagRow: cancel drag");
-				Gtk.drag_finish(context, false, false, time);
+			    Logger.debug("TagRow: cancel drag");
+			    Gtk.drag_finish(context, false, false, time);
 			}
 		});
 
@@ -269,32 +269,31 @@ public class FeedReader.TagRow : Gtk.ListBoxRow {
 		renameEntry.activate.connect(() => {
 			if(m_tagID != TagID.NEW)
 			{
-				popRename.hide();
-				try
-				{
-					DBusConnection.get_default().renameTag(m_tagID, renameEntry.get_text());
+			    popRename.hide();
+			    try
+			    {
+			        DBusConnection.get_default().renameTag(m_tagID, renameEntry.get_text());
 				}
-				catch(GLib.Error e)
-				{
-					Logger.error("TagRow.showRenamePopover: %s".printf(e.message));
+			    catch(GLib.Error e)
+			    {
+			        Logger.error("TagRow.showRenamePopover: %s".printf(e.message));
 				}
 			}
 			else if(context != null)
 			{
-				try
-				{
-					m_tagID = DBusConnection.get_default().createTag(renameEntry.get_text());
-					popRename.hide();
-					DBusConnection.get_default().tagArticle(articleID, m_tagID, true);
-					Gtk.drag_finish(context, true, false, time);
+			    try
+			    {
+			        m_tagID = DBusConnection.get_default().createTag(renameEntry.get_text());
+			        popRename.hide();
+			        DBusConnection.get_default().tagArticle(articleID, m_tagID, true);
+			        Gtk.drag_finish(context, true, false, time);
 				}
-				catch(GLib.Error e)
-				{
-					Logger.error("TagRow.showRenamePopover: %s".printf(e.message));
+			    catch(GLib.Error e)
+			    {
+			        Logger.error("TagRow.showRenamePopover: %s".printf(e.message));
 				}
 			}
 		});
-
 
 		string label = _("rename");
 		if(m_tagID == TagID.NEW && context != null)

--- a/src/Widgets/UpdateButton.vala
+++ b/src/Widgets/UpdateButton.vala
@@ -43,7 +43,7 @@ public class FeedReader.UpdateButton : Gtk.Button {
 		m_isCancellable = cancellable;
 		m_tooltip = tooltip;
 		m_spinner = new Gtk.Spinner();
-		m_spinner.set_size_request(16,16);
+		m_spinner.set_size_request(16, 16);
 
 		m_stack = new Gtk.Stack();
 		m_stack.set_transition_duration(100);

--- a/src/Widgets/WebLoginPage.vala
+++ b/src/Widgets/WebLoginPage.vala
@@ -20,7 +20,6 @@ public class FeedReader.WebLoginPage : Gtk.Bin {
 	public signal bool getApiCode(string url);
 	public signal void success();
 
-
 	public WebLoginPage()
 	{
 		var settings = new WebKit.Settings();
@@ -33,7 +32,6 @@ public class FeedReader.WebLoginPage : Gtk.Bin {
 		this.show_all();
 	}
 
-
 	public void loadPage(string url)
 	{
 		Logger.debug("WebLoginPage: load URL: " + url);
@@ -44,16 +42,16 @@ public class FeedReader.WebLoginPage : Gtk.Bin {
 	{
 		switch(load_event)
 		{
-			case WebKit.LoadEvent.STARTED:
-				check();
-				break;
-			case WebKit.LoadEvent.REDIRECTED:
-				check();
-				break;
-			case WebKit.LoadEvent.COMMITTED:
-				break;
-			case WebKit.LoadEvent.FINISHED:
-				break;
+		case WebKit.LoadEvent.STARTED:
+			check();
+			break;
+		case WebKit.LoadEvent.REDIRECTED:
+			check();
+			break;
+		case WebKit.LoadEvent.COMMITTED:
+			break;
+		case WebKit.LoadEvent.FINISHED:
+			break;
 		}
 	}
 

--- a/src/dbBase.vala
+++ b/src/dbBase.vala
@@ -63,7 +63,7 @@ public class FeedReader.dbBase : GLib.Object {
 		executeSQL("PRAGMA journal_mode = WAL");
 		executeSQL("PRAGMA page_size = 4096");
 
-		executeSQL(					"""CREATE  TABLE  IF NOT EXISTS "main"."feeds"
+		executeSQL(                 """CREATE  TABLE  IF NOT EXISTS "main"."feeds"
 										(
 											"feed_id" TEXT PRIMARY KEY NOT NULL UNIQUE,
 											"name" TEXT NOT NULL,
@@ -73,7 +73,7 @@ public class FeedReader.dbBase : GLib.Object {
 											"xmlURL" TEXT
 										)""");
 
-		executeSQL(					"""CREATE  TABLE  IF NOT EXISTS "main"."categories"
+		executeSQL(                 """CREATE  TABLE  IF NOT EXISTS "main"."categories"
 										(
 											"categorieID" TEXT PRIMARY KEY NOT NULL UNIQUE,
 											"title" TEXT NOT NULL,
@@ -83,7 +83,7 @@ public class FeedReader.dbBase : GLib.Object {
 											"Level" INTEGER
 											)""");
 
-		executeSQL(					"""CREATE  TABLE  IF NOT EXISTS "main"."articles"
+		executeSQL(                 """CREATE  TABLE  IF NOT EXISTS "main"."articles"
 										(
 											"articleID" TEXT PRIMARY KEY NOT NULL UNIQUE,
 											"feedID" TEXT NOT NULL,
@@ -102,7 +102,7 @@ public class FeedReader.dbBase : GLib.Object {
 											"contentFetched" INTEGER NOT NULL
 										)""");
 
-		executeSQL(					   """CREATE  TABLE  IF NOT EXISTS "main"."tags"
+		executeSQL(                    """CREATE  TABLE  IF NOT EXISTS "main"."tags"
 										(
 											"tagID" TEXT PRIMARY KEY NOT NULL UNIQUE,
 											"title" TEXT NOT NULL,
@@ -110,18 +110,18 @@ public class FeedReader.dbBase : GLib.Object {
 											"color" INTEGER
 										)""");
 
-		executeSQL(					   """CREATE  TABLE  IF NOT EXISTS "main"."CachedActions"
+		executeSQL(                    """CREATE  TABLE  IF NOT EXISTS "main"."CachedActions"
 										(
 											"action" INTEGER NOT NULL,
 											"id" TEXT NOT NULL,
 											"argument" INTEGER
 										)""");
 
-		executeSQL(			 			"""CREATE INDEX IF NOT EXISTS "index_articles" ON "articles" ("feedID" DESC, "unread" ASC, "marked" ASC)""");
-		executeSQL(						"""CREATE VIRTUAL TABLE IF NOT EXISTS fts_table USING fts4 (content='articles', articleID, preview, title, author)""");
+		executeSQL(                     """CREATE INDEX IF NOT EXISTS "index_articles" ON "articles" ("feedID" DESC, "unread" ASC, "marked" ASC)""");
+		executeSQL(                     """CREATE VIRTUAL TABLE IF NOT EXISTS fts_table USING fts4 (content='articles', articleID, preview, title, author)""");
 	}
 
-	protected void executeSQL(string sql, Sqlite.Callback? callback = null)
+	protected void executeSQL(string sql, Sqlite.Callback ? callback = null)
 	{
 		string errmsg;
 		int ec = sqlite_db.exec(sql, null, out errmsg);
@@ -424,8 +424,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return result;
 	}
 
-
-	public string? getTagName(string tagID)
+	public string ? getTagName(string tagID)
 	{
 		var query = new QueryBuilder(QueryType.SELECT, "tags");
 		query.selectField("title");
@@ -472,7 +471,6 @@ public class FeedReader.dbBase : GLib.Object {
 		return result;
 	}
 
-
 	public string getCategoryName(string catID)
 	{
 		if(catID == CategoryID.TAGS.to_string())
@@ -503,8 +501,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return result;
 	}
 
-
-	public string? getCategoryID(string catname)
+	public string ? getCategoryID(string catname)
 	{
 		var query = new QueryBuilder(QueryType.SELECT, "categories");
 		query.selectField("categorieID");
@@ -519,7 +516,7 @@ public class FeedReader.dbBase : GLib.Object {
 			Logger.error(sqlite_db.errmsg());
 		}
 
-		string? result = null;
+		string ? result = null;
 
 		while (stmt.step () == Sqlite.ROW) {
 			result = stmt.column_text(0);
@@ -527,7 +524,6 @@ public class FeedReader.dbBase : GLib.Object {
 
 		return result;
 	}
-
 
 	public bool preview_empty(string articleID)
 	{
@@ -595,25 +591,25 @@ public class FeedReader.dbBase : GLib.Object {
 		while (stmt.step () == Sqlite.ROW)
 		{
 			if(stmt.column_text(2) == id1
-			|| stmt.column_text(2) == id2)
+			   || stmt.column_text(2) == id2)
 				continue;
 
 			tmp.add(new article(
-								stmt.column_text(2),								// articleID
-								stmt.column_text(3),								// title
-								stmt.column_text(5),								// url
-								stmt.column_text(1),								// feedID
-								(ArticleStatus)stmt.column_int(7),					// unread
-								(ArticleStatus)stmt.column_int(8),					// marked
-								"",													// html
-								stmt.column_text(6),								// preview
-								stmt.column_text(4),								// author
-								new GLib.DateTime.from_unix_local(stmt.column_int(10)),	// date
-								stmt.column_int(0),									// sortID
-								stmt.column_text(9),								// tags
-								stmt.column_text(12),								// media
-								stmt.column_text(11)								// guid
-							));
+						stmt.column_text(2),                                        // articleID
+						stmt.column_text(3),                                        // title
+						stmt.column_text(5),                                        // url
+						stmt.column_text(1),                                        // feedID
+						(ArticleStatus)stmt.column_int(7),                          // unread
+						(ArticleStatus)stmt.column_int(8),                          // marked
+						"",                                                         // html
+						stmt.column_text(6),                                        // preview
+						stmt.column_text(4),                                        // author
+						new GLib.DateTime.from_unix_local(stmt.column_int(10)),         // date
+						stmt.column_int(0),                                         // sortID
+						stmt.column_text(9),                                        // tags
+						stmt.column_text(12),                                       // media
+						stmt.column_text(11)                                        // guid
+						));
 		}
 		stmt.reset();
 		return tmp;
@@ -639,17 +635,17 @@ public class FeedReader.dbBase : GLib.Object {
 		while(stmt.step() == Sqlite.ROW)
 		{
 			articles.set(stmt.column_text(0),
-								new article(stmt.column_text(0), "", "", "", (ArticleStatus)stmt.column_int(1),
-								(ArticleStatus)stmt.column_int(2), "", "", null, new GLib.DateTime.now_local(), 0, "", ""));
+			             new article(stmt.column_text(0), "", "", "", (ArticleStatus)stmt.column_int(1),
+			                         (ArticleStatus)stmt.column_int(2), "", "", null, new GLib.DateTime.now_local(), 0, "", ""));
 		}
 		stmt.reset();
 		return articles;
 	}
 
-	public article? read_article(string articleID)
+	public article ? read_article(string articleID)
 	{
 		Logger.debug(@"dbBase.read_article(): $articleID");
-		article? tmp = null;
+		article ? tmp = null;
 		var query = new QueryBuilder(QueryType.SELECT, "articles");
 		query.selectField("ROWID");
 		query.selectField("*");
@@ -666,28 +662,27 @@ public class FeedReader.dbBase : GLib.Object {
 
 		while(stmt.step() == Sqlite.ROW)
 		{
-			string? author = (stmt.column_text(4) == "") ? null : stmt.column_text(4);
+			string ? author = (stmt.column_text(4) == "") ? null : stmt.column_text(4);
 			tmp = new article(
-								articleID,
-								stmt.column_text(3),
-								stmt.column_text(5),
-								stmt.column_text(2),
-								(ArticleStatus)stmt.column_int(8),
-								(ArticleStatus)stmt.column_int(9),
-								stmt.column_text(6),
-								stmt.column_text(7),
-								author,
-								new GLib.DateTime.from_unix_local(stmt.column_int(11)),
-								stmt.column_int(0), // rowid (sortid)
-								stmt.column_text(10), // tags
-								stmt.column_text(14), // media
-								stmt.column_text(12)  // guid
-							);
+				articleID,
+				stmt.column_text(3),
+				stmt.column_text(5),
+				stmt.column_text(2),
+				(ArticleStatus)stmt.column_int(8),
+				(ArticleStatus)stmt.column_int(9),
+				stmt.column_text(6),
+				stmt.column_text(7),
+				author,
+				new GLib.DateTime.from_unix_local(stmt.column_int(11)),
+				stmt.column_int(0),                 // rowid (sortid)
+				stmt.column_text(10),                 // tags
+				stmt.column_text(14),                 // media
+				stmt.column_text(12)                  // guid
+				);
 		}
 		stmt.reset();
 		return tmp;
 	}
-
 
 	public string read_article_tags(string articleID)
 	{
@@ -829,7 +824,6 @@ public class FeedReader.dbBase : GLib.Object {
 		return false;
 	}
 
-
 	public int getRowCountHeadlineByDate(string date)
 	{
 		int result = 0;
@@ -854,7 +848,6 @@ public class FeedReader.dbBase : GLib.Object {
 		return result;
 	}
 
-
 	public int getArticleCountNewerThanID(string articleID, string feedID, FeedListType selectedType, ArticleListState state, string searchTerm, int searchRows = 0)
 	{
 		int result = 0;
@@ -866,7 +859,6 @@ public class FeedReader.dbBase : GLib.Object {
 		var query2 = new QueryBuilder(QueryType.SELECT, "articles");
 		query2.selectField("count(*)");
 
-
 		query.selectField(orderBy);
 		query.build();
 
@@ -874,7 +866,6 @@ public class FeedReader.dbBase : GLib.Object {
 			query2.addCustomCondition(@"$orderBy < (%s)".printf(query.get()));
 		else
 			query2.addCustomCondition(@"$orderBy > (%s)".printf(query.get()));
-
 
 		if(selectedType == FeedListType.FEED && feedID != FeedID.ALL.to_string())
 		{
@@ -902,7 +893,7 @@ public class FeedReader.dbBase : GLib.Object {
 			query2.addEqualsCondition("marked", ArticleStatus.MARKED.to_string());
 		}
 
-		if(searchTerm != ""){
+		if(searchTerm != "") {
 			if(searchTerm.has_prefix("title: "))
 			{
 				query2.addCustomCondition("articleID IN (SELECT articleID FROM fts_table WHERE title MATCH '%s')".printf(Utils.prepareSearchQuery(searchTerm)));
@@ -951,7 +942,6 @@ public class FeedReader.dbBase : GLib.Object {
 		return result;
 	}
 
-
 	public Gee.ArrayList<string> getFeedIDofCategorie(string categorieID)
 	{
 		var feedIDs = new Gee.ArrayList<string>();
@@ -975,7 +965,7 @@ public class FeedReader.dbBase : GLib.Object {
 			if(categorieID == "")
 			{
 				if((categories.length == 0)
-				||(categories.length == 1 && categories[0].contains("global.must")))
+				   || (categories.length == 1 && categories[0].contains("global.must")))
 				{
 					feedIDs.add(stmt.column_text(0));
 				}
@@ -1001,7 +991,7 @@ public class FeedReader.dbBase : GLib.Object {
 
 	protected virtual bool showCategory(string catID, Gee.ArrayList<feed> feeds)
 	{
-        return true;
+		return true;
 	}
 
 	protected string getUncategorizedFeedsQuery()
@@ -1026,9 +1016,8 @@ public class FeedReader.dbBase : GLib.Object {
 			feedIDs += "\"" + stmt.column_text(0) + "\"" + ",";
 		}
 
-		return sql.printf(feedIDs.substring(0, feedIDs.length-1));
+		return sql.printf(feedIDs.substring(0, feedIDs.length - 1));
 	}
-
 
 	public string getFeedIDofArticle(string articleID)
 	{
@@ -1047,7 +1036,6 @@ public class FeedReader.dbBase : GLib.Object {
 		}
 		return id;
 	}
-
 
 	public string getNewestArticle()
 	{
@@ -1119,8 +1107,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return result;
 	}
 
-
-	public feed? read_feed(string feedID)
+	public feed ? read_feed(string feedID)
 	{
 		var query = new QueryBuilder(QueryType.SELECT, "feeds");
 		query.selectField("*");
@@ -1150,7 +1137,6 @@ public class FeedReader.dbBase : GLib.Object {
 
 		return null;
 	}
-
 
 	public Gee.ArrayList<feed> read_feeds(bool starredCount = false)
 	{
@@ -1196,7 +1182,6 @@ public class FeedReader.dbBase : GLib.Object {
 
 		return tmp;
 	}
-
 
 	public uint getFeedUnread(string feedID)
 	{
@@ -1246,7 +1231,6 @@ public class FeedReader.dbBase : GLib.Object {
 		return count;
 	}
 
-
 	public Gee.ArrayList<feed> read_feeds_without_cat()
 	{
 		Gee.ArrayList<feed> tmp = new Gee.ArrayList<feed>();
@@ -1285,7 +1269,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return tmp;
 	}
 
-	public category? read_category(string catID)
+	public category ? read_category(string catID)
 	{
 		var query = new QueryBuilder(QueryType.SELECT, "categories");
 		query.selectField("*");
@@ -1307,7 +1291,6 @@ public class FeedReader.dbBase : GLib.Object {
 
 		return null;
 	}
-
 
 	public Gee.ArrayList<tag> read_tags()
 	{
@@ -1368,7 +1351,7 @@ public class FeedReader.dbBase : GLib.Object {
 			query += "instr(\"tags\", \"%s\") > 0 OR ".printf(Tag.getTagID());
 		}
 
-		int or = query.char_count()-4;
+		int or = query.char_count() - 4;
 		return query.substring(0, or) + ")";
 	}
 
@@ -1433,7 +1416,7 @@ public class FeedReader.dbBase : GLib.Object {
 		return tmpCategories;
 	}
 
-    public Gee.ArrayList<category> read_categories(Gee.ArrayList<feed>? feeds = null)
+	public Gee.ArrayList<category> read_categories(Gee.ArrayList<feed>? feeds = null)
 	{
 		Gee.ArrayList<category> tmp = new Gee.ArrayList<category>();
 		category tmpcategory;
@@ -1472,7 +1455,7 @@ public class FeedReader.dbBase : GLib.Object {
 					stmt.column_int(3),
 					stmt.column_text(4),
 					stmt.column_int(5)
-				);
+					);
 
 				tmp.add(tmpcategory);
 			}
@@ -1501,26 +1484,25 @@ public class FeedReader.dbBase : GLib.Object {
 			Logger.error(sqlite_db.errmsg());
 		}
 
-
 		var tmp = new Gee.LinkedList<article>();
 		while (stmt.step () == Sqlite.ROW)
 		{
 			tmp.add(new article(
-								stmt.column_text(0),								// articleID
-								"",													// title
-								stmt.column_text(1),								// url
-								stmt.column_text(4),								// feedID
-								ArticleStatus.UNREAD,								// unread
-								ArticleStatus.UNMARKED,								// marked
-								stmt.column_text(3),								// html
-								stmt.column_text(2),								// preview
-								"",													// author
-								new GLib.DateTime.now_local(),						// date
-								0,													// sortID
-								"",													// tags
-								"",													// media
-								""													// guid
-							));
+						stmt.column_text(0),                                        // articleID
+						"",                                                         // title
+						stmt.column_text(1),                                        // url
+						stmt.column_text(4),                                        // feedID
+						ArticleStatus.UNREAD,                                       // unread
+						ArticleStatus.UNMARKED,                                     // marked
+						stmt.column_text(3),                                        // html
+						stmt.column_text(2),                                        // preview
+						"",                                                         // author
+						new GLib.DateTime.now_local(),                              // date
+						0,                                                          // sortID
+						"",                                                         // tags
+						"",                                                         // media
+						""                                                          // guid
+						));
 		}
 
 		return tmp;
@@ -1571,7 +1553,7 @@ public class FeedReader.dbBase : GLib.Object {
 			query.addEqualsCondition("marked", ArticleStatus.MARKED.to_string());
 		}
 
-		if(searchTerm != ""){
+		if(searchTerm != "") {
 			if(searchTerm.has_prefix("title: "))
 			{
 				query.addCustomCondition("articleID IN (SELECT articleID FROM fts_table WHERE title MATCH '%s')".printf(Utils.prepareSearchQuery(searchTerm)));
@@ -1618,7 +1600,6 @@ public class FeedReader.dbBase : GLib.Object {
 		query.build();
 		query.print();
 
-
 		Sqlite.Statement stmt;
 		int ec = sqlite_db.prepare_v2 (query.get(), query.get().length, out stmt);
 		if(ec != Sqlite.OK)
@@ -1627,26 +1608,25 @@ public class FeedReader.dbBase : GLib.Object {
 			Logger.error(sqlite_db.errmsg());
 		}
 
-
 		var tmp = new Gee.LinkedList<article>();
 		while (stmt.step () == Sqlite.ROW)
 		{
 			tmp.add(new article(
-								stmt.column_text(2),								// articleID
-								stmt.column_text(3),								// title
-								stmt.column_text(5),								// url
-								stmt.column_text(1),								// feedID
-								(ArticleStatus)stmt.column_int(7),					// unread
-								(ArticleStatus)stmt.column_int(8),					// marked
-								"",													// html
-								stmt.column_text(6),								// preview
-								stmt.column_text(4),								// author
-								new GLib.DateTime.from_unix_local(stmt.column_int(10)),	// date
-								stmt.column_int(0),									// sortID
-								stmt.column_text(9),								// tags
-								stmt.column_text(12),								// media
-								stmt.column_text(11)								// guid
-							));
+						stmt.column_text(2),                                        // articleID
+						stmt.column_text(3),                                        // title
+						stmt.column_text(5),                                        // url
+						stmt.column_text(1),                                        // feedID
+						(ArticleStatus)stmt.column_int(7),                          // unread
+						(ArticleStatus)stmt.column_int(8),                          // marked
+						"",                                                         // html
+						stmt.column_text(6),                                        // preview
+						stmt.column_text(4),                                        // author
+						new GLib.DateTime.from_unix_local(stmt.column_int(10)),         // date
+						stmt.column_int(0),                                         // sortID
+						stmt.column_text(9),                                        // tags
+						stmt.column_text(12),                                       // media
+						stmt.column_text(11)                                        // guid
+						));
 		}
 
 		return tmp;

--- a/src/dbDaemon.vala
+++ b/src/dbDaemon.vala
@@ -15,7 +15,7 @@
 
 public class FeedReader.dbDaemon : dbBase {
 
-	private static dbDaemon? m_dataBase = null;
+	private static dbDaemon ? m_dataBase = null;
 
 	public static new dbDaemon get_default()
 	{
@@ -58,7 +58,6 @@ public class FeedReader.dbDaemon : dbBase {
 			Logger.error(sqlite_db.errmsg());
 		}
 
-
 		int cols = stmt.column_count ();
 		while (stmt.step () == Sqlite.ROW) {
 			for (int i = 0; i < cols; i++) {
@@ -90,7 +89,7 @@ public class FeedReader.dbDaemon : dbBase {
 		var query = new QueryBuilder(QueryType.SELECT, "main.articles");
 		query.selectField("articleID");
 		query.selectField("feedID");
-		query.addCustomCondition("datetime(date, 'unixepoch', 'localtime') <= datetime('now', '-%i days')".printf(weeks*7));
+		query.addCustomCondition("datetime(date, 'unixepoch', 'localtime') <= datetime('now', '-%i days')".printf(weeks * 7));
 		query.addEqualsCondition("marked", ArticleStatus.UNMARKED.to_string());
 		if(FeedServer.get_default().useMaxArticles())
 		{
@@ -182,8 +181,6 @@ public class FeedReader.dbDaemon : dbBase {
 			Logger.error(sqlite_db.errmsg());
 		}
 
-
-
 		int feedID_pos   = stmt.bind_parameter_index("$FEEDID");
 		int feedName_pos = stmt.bind_parameter_index("$FEEDNAME");
 		int feedURL_pos  = stmt.bind_parameter_index("$FEEDURL");
@@ -203,7 +200,7 @@ public class FeedReader.dbDaemon : dbBase {
 				catString += category + ",";
 			}
 
-			catString = catString.substring(0, catString.length-1);
+			catString = catString.substring(0, catString.length - 1);
 
 			stmt.bind_text(feedID_pos, feed_item.getFeedID());
 			stmt.bind_text(feedName_pos, Utils.UTF8fix(feed_item.getTitle()));
@@ -211,7 +208,7 @@ public class FeedReader.dbDaemon : dbBase {
 			stmt.bind_text(catID_pos, catString);
 			stmt.bind_text(xmlURL_pos, feed_item.getXmlUrl());
 
-			while(stmt.step() == Sqlite.ROW){}
+			while(stmt.step() == Sqlite.ROW) {}
 			stmt.reset();
 		}
 
@@ -251,7 +248,7 @@ public class FeedReader.dbDaemon : dbBase {
 			stmt.bind_text(label_position, tag_item.getTitle());
 			stmt.bind_int (color_position, tag_item.getColor());
 
-			while(stmt.step() == Sqlite.ROW){}
+			while(stmt.step() == Sqlite.ROW) {}
 			stmt.reset ();
 		}
 
@@ -292,7 +289,6 @@ public class FeedReader.dbDaemon : dbBase {
 		executeSQL("COMMIT TRANSACTION");
 	}
 
-
 	public void update_tag_color(string tagID, int color)
 	{
 		var query = new QueryBuilder(QueryType.UPDATE, "main.tags");
@@ -300,9 +296,6 @@ public class FeedReader.dbDaemon : dbBase {
 		query.addEqualsCondition("tagID", tagID, true, true);
 		executeSQL(query.build());
 	}
-
-
-
 
 	public void write_categories(Gee.List<category> categories)
 	{
@@ -324,7 +317,6 @@ public class FeedReader.dbDaemon : dbBase {
 			Logger.error("dbDaemon: write_categories - " + query.get());
 			Logger.error(sqlite_db.errmsg());
 		}
-
 
 		int catID_position       = stmt.bind_parameter_index("$CATID");
 		int feedName_position    = stmt.bind_parameter_index("$FEEDNAME");
@@ -362,7 +354,6 @@ public class FeedReader.dbDaemon : dbBase {
 			reset_query.updateValuePair(field, ArticleStatus.UNMARKED.to_string());
 		executeSQL(reset_query.build());
 
-
 		executeSQL("BEGIN TRANSACTION");
 
 		// then reapply states of the synced articles
@@ -388,11 +379,10 @@ public class FeedReader.dbDaemon : dbBase {
 		int articleID_position = stmt.bind_parameter_index("$ARTICLEID");
 		assert (articleID_position > 0);
 
-
 		foreach(string id in ids)
 		{
 			stmt.bind_text(articleID_position, id);
-			while(stmt.step() != Sqlite.DONE){}
+			while(stmt.step() != Sqlite.DONE) {}
 			stmt.reset();
 		}
 
@@ -424,11 +414,10 @@ public class FeedReader.dbDaemon : dbBase {
 		assert (html_position > 0);
 		assert (preview_position > 0);
 
-
 		stmt.bind_text(html_position, Article.getHTML());
 		stmt.bind_text(preview_position, Article.getPreview());
 
-		while(stmt.step() != Sqlite.DONE){}
+		while(stmt.step() != Sqlite.DONE) {}
 		stmt.reset();
 
 		executeSQL("COMMIT TRANSACTION");
@@ -466,7 +455,6 @@ public class FeedReader.dbDaemon : dbBase {
 		assert (modified_position > 0);
 		assert (articleID_position > 0);
 
-
 		foreach(article a in articles)
 		{
 			var unread = ActionCache.get_default().checkRead(a);
@@ -484,13 +472,12 @@ public class FeedReader.dbDaemon : dbBase {
 			stmt.bind_int (modified_position, a.getLastModified());
 			stmt.bind_text(articleID_position, a.getArticleID());
 
-			while(stmt.step() != Sqlite.DONE){}
+			while(stmt.step() != Sqlite.DONE) {}
 			stmt.reset();
 		}
 
 		executeSQL("COMMIT TRANSACTION");
 	}
-
 
 	public void write_articles(Gee.List<article> articles)
 	{
@@ -525,8 +512,6 @@ public class FeedReader.dbDaemon : dbBase {
 			Logger.error(query.get());
 			Logger.error("write_articles: " + sqlite_db.errmsg());
 		}
-
-
 
 		int articleID_position = stmt.bind_parameter_index("$ARTICLEID");
 		int feedID_position = stmt.bind_parameter_index("$FEEDID");
@@ -575,7 +560,7 @@ public class FeedReader.dbDaemon : dbBase {
 			stmt.bind_int (modified_position, article.getLastModified());
 			stmt.bind_text(media_position, article.getMediaString());
 
-			while(stmt.step() != Sqlite.DONE){}
+			while(stmt.step() != Sqlite.DONE) {}
 			stmt.reset();
 		}
 
@@ -672,7 +657,6 @@ public class FeedReader.dbDaemon : dbBase {
 		Logger.warning("dbDaemon: Deleting unsubscribed feeds");
 		executeSQL("DELETE FROM main.feeds WHERE \"subscribed\" = 0");
 	}
-
 
 	public void delete_nonexisting_categories()
 	{
@@ -786,7 +770,6 @@ public class FeedReader.dbDaemon : dbBase {
 			executeSQL(query.build());
 		}
 
-
 	}
 
 	public void move_category(string catID, string newParentID)
@@ -794,7 +777,7 @@ public class FeedReader.dbDaemon : dbBase {
 		var parent = read_category(newParentID);
 		var query = new QueryBuilder(QueryType.UPDATE, "categories");
 		query.updateValuePair("Parent", newParentID);
-		query.updateValuePair("Level", "%i".printf(parent.getLevel()+1));
+		query.updateValuePair("Level", "%i".printf(parent.getLevel() + 1));
 		query.addEqualsCondition("categorieID", catID);
 		executeSQL(query.build());
 	}
@@ -807,7 +790,7 @@ public class FeedReader.dbDaemon : dbBase {
 		executeSQL(query.build());
 	}
 
-	public void move_feed(string feedID, string currentCatID, string? newCatID = null)
+	public void move_feed(string feedID, string currentCatID, string ? newCatID = null)
 	{
 		var Feed = dbDaemon.get_default().read_feed(feedID);
 		var catArray = Feed.getCatIDs();
@@ -835,7 +818,7 @@ public class FeedReader.dbDaemon : dbBase {
 		for(int i = 0; i < catArray.length; i++)
 		{
 			catString += catArray[i];
-			if(i < catArray.length-1)
+			if(i < catArray.length - 1)
 				catString += ",";
 		}
 
@@ -892,7 +875,7 @@ public class FeedReader.dbDaemon : dbBase {
 		delete_articles(feedID);
 	}
 
-	public void addCachedAction(CachedActions action, string id, string? argument = "")
+	public void addCachedAction(CachedActions action, string id, string ? argument = "")
 	{
 		executeSQL("BEGIN TRANSACTION");
 
@@ -910,7 +893,6 @@ public class FeedReader.dbDaemon : dbBase {
 			Logger.error("addCachedAction: " + sqlite_db.errmsg());
 		}
 
-
 		int action_position = stmt.bind_parameter_index("$ACTION");
 		int id_position = stmt.bind_parameter_index("$ID");
 		int argument_position = stmt.bind_parameter_index("$ARGUMENT");
@@ -927,7 +909,6 @@ public class FeedReader.dbDaemon : dbBase {
 
 		executeSQL("COMMIT TRANSACTION");
 	}
-
 
 	public Gee.ArrayList<CachedAction> readCachedActions()
 	{
@@ -1001,7 +982,7 @@ public class FeedReader.dbDaemon : dbBase {
 	protected override bool showCategory(string catID, Gee.ArrayList<feed> feeds)
 	{
 		if(FeedServer.get_default().hideCategoryWhenEmpty(catID)
-		&& !Utils.categoryIsPopulated(catID, feeds))
+		   && !Utils.categoryIsPopulated(catID, feeds))
 		{
 			return false;
 		}

--- a/src/dbUI.vala
+++ b/src/dbUI.vala
@@ -15,7 +15,7 @@
 
 public class FeedReader.dbUI : dbBase {
 
-	private static dbUI? m_dataBase = null;
+	private static dbUI ? m_dataBase = null;
 
 	public static new dbUI get_default()
 	{
@@ -25,7 +25,6 @@ public class FeedReader.dbUI : dbBase {
 			if(m_dataBase.uninitialized())
 				m_dataBase.init();
 		}
-
 
 		return m_dataBase;
 	}
@@ -40,7 +39,7 @@ public class FeedReader.dbUI : dbBase {
 		try
 		{
 			if(DBusConnection.get_default().hideCategoryWhenEmpty(catID)
-			&& !Utils.categoryIsPopulated(catID, feeds))
+			   && !Utils.categoryIsPopulated(catID, feeds))
 			{
 				return false;
 			}

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,18 @@
+# Uncrustify-0.65-106-95188777
+input_tab_size                  = 4
+output_tab_size                 = 4
+utf8_bom                        = remove
+utf8_force                      = true
+sp_arith                        = add
+sp_assign                       = add
+sp_bool                         = add
+sp_inside_paren                 = remove
+sp_after_comma                  = add
+indent_columns                  = 4
+indent_namespace                = true
+indent_extern                   = true
+indent_class                    = true
+nl_max                          = 2
+# option(s) with 'not default' value: 14
+#
+


### PR DESCRIPTION
This adds an uncrustify config to:

 - indent with one tab
 - remove BOM
 - force UTF-8
 - force spaces around operators
 - remove spaces before commas
 - add spaces after commas
 - remove excess (>2) blank lines

There's a lot more we could do with this, but the indentation was
the really annoying one.

Ran using:

```
uncrustify -c uncrustify.cfg --no-backup */*.vala */*/*.vala */*/*/*.vala
```

See issue #516