### PR TITLE
cmake: find valac executables with version number suffix

### DIFF
--- a/cmake/FindVala.cmake
+++ b/cmake/FindVala.cmake
@@ -45,7 +45,7 @@
 
 # Search for the valac executable in the usual system paths.
 find_program(VALA_EXECUTABLE
-  NAMES valac)
+  NAMES valac valac-0.38 valac-0.36 valac-0.34 valac-0.32 valac-0.30 valac-0.28 valac-0.26)
 
 # Handle the QUIETLY and REQUIRED arguments, which may be given to the find call.
 # Furthermore set VALA_FOUND to TRUE if Vala has been found (aka.


### PR DESCRIPTION
On some systems, the `valac` executable only exists with a suffix number (ex: `valac-0.36` exists but `valac` does not).
This commit makes `cmake` search all valac executables from 0.26 to 0.38 (last stable version).