### PR TITLE
Remove extraneous slashes in ownCloud URLs

### DIFF
--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -215,7 +215,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public void getNewArticles(Gee.List<article> articles, int lastModified, OwnCloudType type, int id)
 	{
-		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + "/items/updated", m_username, m_password, "GET");
+		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + "items/updated", m_username, m_password, "GET");
 		message.add_int("lastModified", lastModified);
 		message.add_int("type", type);
 		message.add_int("id", id);
@@ -386,9 +386,9 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 		string url = "";
 
 		if(unread == ArticleStatus.UNREAD)
-			url = "/items/unread/multiple";
+			url = "items/unread/multiple";
 		else if(unread == ArticleStatus.READ)
-			url = "/items/read/multiple";
+			url = "items/read/multiple";
 
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
 		message.add_int_array("items", articleIDs);
@@ -405,7 +405,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 	public bool updateArticleMarked(string articleID, ArticleStatus marked)
 	{
 		var article = dbDaemon.get_default().read_article(articleID);
-		string url = "/items/%s/%s/".printf(article.getFeedID(), article.getHash());
+		string url = "items/%s/%s/".printf(article.getFeedID(), article.getHash());
 
 		if(marked == ArticleStatus.MARKED)
 			url += "star";
@@ -424,7 +424,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public bool addFeed(string feedURL, string? catID, out int64 feedID, out string errmsg)
 	{
-		string url = "/feeds";
+		string url = "feeds";
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "POST");
 		message.add_string("url", feedURL);
 		message.add_int("folderId", (catID != null) ? int.parse(catID) : 0);
@@ -464,7 +464,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public void removeFeed(string feedID)
 	{
-		string url = "/feeds/%s".printf(feedID);
+		string url = "feeds/%s".printf(feedID);
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "DELETE");
 		int error = message.send();
 
@@ -476,7 +476,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public void renameFeed(string feedID, string title)
 	{
-		string url = "/feeds/%s/rename".printf(feedID);
+		string url = "feeds/%s/rename".printf(feedID);
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
 		message.add_string("feedTitle", title);
 		int error = message.send();
@@ -489,7 +489,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public void moveFeed(string feedID, string? newCatID = null)
 	{
-		string url = "/feeds/%s/move".printf(feedID);
+		string url = "feeds/%s/move".printf(feedID);
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
 		message.add_int("folderId", (newCatID != null) ? int.parse(newCatID) : 0);
 		int error = message.send();
@@ -502,7 +502,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public int64 addFolder(string title)
 	{
-		string url = "/folders";
+		string url = "folders";
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "POST");
 		message.add_string("name", title);
 		int error = message.send();
@@ -525,7 +525,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public bool removeFolder(string catID)
 	{
-		string url = "/folders/%s".printf(catID);
+		string url = "folders/%s".printf(catID);
 
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "DELETE");
 		int error = message.send();
@@ -539,7 +539,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public void renameCategory(string catID, string title)
 	{
-		string url = "/folders/%s".printf(catID);
+		string url = "folders/%s".printf(catID);
 		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
 		message.add_string("name", title);
 		int error = message.send();


### PR DESCRIPTION
For many operations with ownCloud/NextCloud, FeedReader sends requests to URLs with extraneous slashes. NextCloud is forgiving of this, but The Arsse (my server implementation) is not, which leaves FeedReader unable to perform several operations.

```
"POST /index.php/apps/news/api/v1-2//folders HTTP/1.1" 501
"POST /index.php/apps/news/api/v1-2//feeds HTTP/1.1" 501
```

Please note I don't have an environment suitable for compiling FeedReader (and therefore testing this fix), but it seems pretty clear the slashes removed in this commit are the cause of the slash doubling.