### PR TITLE
Change ownCloud ping to valid method

### DIFF
--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -550,7 +550,7 @@ public class FeedReader.OwncloudNewsAPI : GLib.Object {
 
 	public bool ping()
 	{
-		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL, m_username, m_password, "PUT");
+		var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + "version", m_username, m_password, "GET");
 		int error = message.send(true);
 
 		if(error == ConnectionError.NO_RESPONSE)

--- a/plugins/backend/owncloud/OwncloudNewsMessage.vala
+++ b/plugins/backend/owncloud/OwncloudNewsMessage.vala
@@ -135,7 +135,7 @@ public class FeedReader.OwnCloudNewsMessage : GLib.Object {
 
 		if(ping)
 		{
-			Logger.debug("ownCloud Message: ping successfull");
+			Logger.debug("ownCloud Message: ping successful");
 			return ConnectionError.SUCCESS;
 		}
 

--- a/plugins/backend/ttrss/ttrssMessage.vala
+++ b/plugins/backend/ttrss/ttrssMessage.vala
@@ -100,7 +100,7 @@ public class FeedReader.ttrssMessage : GLib.Object {
 
 		if(ping)
 		{
-			Logger.debug("TTRSS Message: ping successfull");
+			Logger.debug("TTRSS Message: ping successful");
 			return ConnectionError.SUCCESS;
 		}
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -215,7 +215,7 @@ public class FeedReader.Utils : GLib.Object {
 
 		if(status >= 200 && status <= 208)
 		{
-			Logger.debug("Ping successfull");
+			Logger.debug("Ping successful");
 			return true;
 		}
 


### PR DESCRIPTION
The previous method (a PUT to `api/v1-2/`) is not a part of the API description. Not only does The Arsse reject it, but NextCloud News itself gets confused and redirects to the user's NextCloud Files main page instead. It works, but may not in future NextCloud versions.

Instead, a GET to the `api/v1-2/version` route is both valid and low-overhead, and should continue to work in perpetuity.

I also corrected a repeated typo I noticed while I was looking around.

After this change FeedReader should work flawlessly with an instance of The Arsse.