### PR TITLE
Add custom docker file to speed up CI tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,31 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: fedora:latest
+      # See docker/Dockerfile
+      - image: feedreader/fedora-feedreader-devel
     working_directory: ~/FeedReader
     steps:
-      - run: >
-          dnf -y install
-          cmake
-          gcc
-          gettext
-          git
-          gnome-online-accounts-devel
-          gstreamer1-devel
-          gstreamer1-plugins-base-devel
-          gtk3-devel
-          json-glib-devel
-          libcurl-devel
-          libgee-devel
-          libnotify-devel
-          libpeas-devel
-          libsecret-devel
-          libsoup-devel
-          libxml2-devel
-          rest-devel
-          sqlite-devel
-          vala
-          webkitgtk4-devel
       - checkout
       - run: cmake .
       - run: make

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM fedora:latest
+
+RUN dnf -y install \
+        cmake \
+        gcc \
+        gettext \
+        git \
+        gnome-online-accounts-devel \
+        gstreamer1-devel \
+        gstreamer1-plugins-base-devel \
+        gtk3-devel \
+        json-glib-devel \
+        libcurl-devel \
+        libgee-devel \
+        libnotify-devel \
+        libpeas-devel \
+        libsecret-devel \
+        libsoup-devel \
+        libxml2-devel \
+        rest-devel \
+        sqlite-devel \
+        vala \
+        webkitgtk4-devel

--- a/docker/update_image.sh
+++ b/docker/update_image.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+NAME=docker.io/feedreader/fedora-feedreader-devel
+
+sudo docker build . -t "$NAME"
+sudo docker push "$NAME"


### PR DESCRIPTION
Also set make -j4 since we have a 2 CPU container.

Note that we will need to occasionally update the `Dockerfile` and re-run `update_image.sh` (probably once per Fedora release).