### PR TITLE
HIDPI favicons

### DIFF
--- a/plugins/backend/local/SuggestedFeedRow.vala
+++ b/plugins/backend/local/SuggestedFeedRow.vala
@@ -71,9 +71,9 @@ public class FeedReader.SuggestedFeedRow : Gtk.ListBoxRow {
 	private async void load_favicon(Gtk.Stack iconStack, Feed feed, string iconURL)
 	{
 		Gtk.Image? icon = null;
-		var pixBuf = yield FavIcon.for_feed(feed).get_pixbuf();
-		if(pixBuf != null)
-			icon = new Gtk.Image.from_pixbuf(pixBuf);
+		var surface = yield FavIcon.for_feed(feed).get_surface();
+		if(surface != null)
+			icon = new Gtk.Image.from_surface(surface);
 		else
 			icon = new Gtk.Image.from_icon_name("feed-rss-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
 

--- a/src/FavIcon.vala
+++ b/src/FavIcon.vala
@@ -44,12 +44,12 @@ public class FeedReader.FavIcon : GLib.Object
 		m_feed = feed;
 	}
 
-	private int GetScaleFactor()
+	private int get_scale_factor()
 	{
 		return MainWindow.get_default().get_style_context().get_scale();
 	}
 
-	private Cairo.Surface CreateSurfaceFromPixbuf(Gdk.Pixbuf pixbuf)
+	private Cairo.Surface create_surface_from_pixbuf(Gdk.Pixbuf pixbuf)
 	{
 		return Gdk.cairo_surface_create_from_pixbuf(pixbuf, GetScaleFactor(), null);
 	}
@@ -67,7 +67,7 @@ public class FeedReader.FavIcon : GLib.Object
 		try
 		{
 			Gdk.Pixbuf pixbuf = yield m_pixbuf.future.wait_async();
-			return CreateSurfaceFromPixbuf(pixbuf);
+			return create_surface_from_pixbuf(pixbuf);
 
 		}
 		catch(Error e)
@@ -93,12 +93,12 @@ public class FeedReader.FavIcon : GLib.Object
 				Logger.warning("FavIcon: Icon for feed %s is too small".printf(m_feed.getTitle()));
 				return;
 			}
-			int scale = GetScaleFactor();
+			int scale = get_scale_factor();
 			pixbuf = pixbuf.scale_simple(24 * scale, 24 * scale, Gdk.InterpType.BILINEAR);
 
 			m_pixbuf.set_value(pixbuf);
 			if(pixbuf != null)
-				surface_changed(m_feed, CreateSurfaceFromPixbuf(pixbuf));
+				surface_changed(m_feed, create_surface_from_pixbuf(pixbuf));
 		}
 		catch(Error e)
 		{

--- a/src/Widgets/ArticleRow.vala
+++ b/src/Widgets/ArticleRow.vala
@@ -270,13 +270,13 @@ public class FeedReader.ArticleRow : Gtk.ListBoxRow {
 
 		Feed feed = DataBase.readOnly().read_feed(m_article.getFeedID());
 		var favicon = FavIcon.for_feed(feed);
-		favicon.get_pixbuf.begin((obj, res) => {
-			var pixbuf = favicon.get_pixbuf.end(res);
-			if(pixbuf != null)
-				icon.pixbuf = pixbuf;
+		favicon.get_surface.begin((obj, res) => {
+			var surface = favicon.get_surface.end(res);
+			if(surface != null)
+				icon.surface = surface;
 		});
-		ulong handler_id = favicon.pixbuf_changed.connect((feed, pixbuf) => {
-			icon.pixbuf = pixbuf;
+		ulong handler_id = favicon.surface_changed.connect((feed, surface) => {
+			icon.surface = surface;
 		});
 		icon.destroy.connect(() => {
 			favicon.disconnect(handler_id);

--- a/src/Widgets/FeedRow.vala
+++ b/src/Widgets/FeedRow.vala
@@ -153,16 +153,16 @@ public class FeedReader.FeedRow : Gtk.ListBoxRow {
 		icon.get_style_context().add_class("fr-sidebar-symbolic");
 
 		var favicon = FavIcon.for_feed(m_feed);
-		favicon.get_pixbuf.begin((obj, res) => {
-			var pixbuf = favicon.get_pixbuf.end(res);
-			if(pixbuf != null)
+		favicon.get_surface.begin((obj, res) => {
+			var surface = favicon.get_surface.end(res);
+			if(surface != null)
 			{
-				icon.pixbuf = pixbuf;
+				icon.surface = surface;
 				m_icon.get_style_context().remove_class("fr-sidebar-symbolic");
 			}
 		});
-		ulong handler_id = favicon.pixbuf_changed.connect((feed, pixbuf) => {
-			icon.pixbuf = pixbuf;
+		ulong handler_id = favicon.surface_changed.connect((feed, surface) => {
+			icon.surface = surface;
 			icon.get_style_context().remove_class("fr-sidebar-symbolic");
 		});
 		icon.destroy.connect(() => {


### PR DESCRIPTION
Can be tested even without a hidpi display:
Last time I checked setting the scale factor in the gtk inspector doesn't work since it doesn't trigger to reload the icons. You need to start the app with `GDK_SCALE=2 feedreader`.