### PR TITLE
Better sync limit handling

### DIFF
--- a/plugins/backend/bazqux/bazquxInterface.vala
+++ b/plugins/backend/bazqux/bazquxInterface.vala
@@ -387,7 +387,7 @@ public class FeedReader.bazquxInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{

--- a/plugins/backend/demo/demoInterface.vala
+++ b/plugins/backend/demo/demoInterface.vala
@@ -564,6 +564,7 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	//
 	// "count":		the number of articles to get
 	// "whatToGet":	the kind of articles to get (all/unread/marked/etc.)
+	// "since":     how far back to sync articles (null = no limit)
 	// "feedID":	get only articles of a secific feed or tag
 	// "isTagID":	false if "feedID" is a feed-ID, true if "feedID" is a tag-ID
 	//
@@ -574,7 +575,7 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 	// But if the API suggests a different approach you can everything on your
 	// own (see ttrss-backend).
 	//--------------------------------------------------------------------------------------
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 
 	}

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -628,21 +628,10 @@ public class FeedReader.FeedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		}
 	}
 
-	public void getArticles(int count, ArticleStatus what_to_get, string? feed_id_str, bool is_tag_id, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus what_to_get, DateTime? since, string? feed_id_str, bool is_tag_id, GLib.Cancellable? cancellable = null)
 	{
 		try
 		{
-			var settings_state = new GLib.Settings("org.gnome.feedreader.saved-state");
-			DateTime? since = ((DropArticles)Settings.general().get_enum("drop-articles-after")).to_start_date();
-			if(!DataBase.readOnly().isTableEmpty("articles"))
-			{
-				var last_sync = new DateTime.from_unix_utc(settings_state.get_int("last-sync"));
-				if(since == null || last_sync.to_unix() > since.to_unix())
-				{
-					since = last_sync;
-				}
-			}
-
 			int64? feed_id = null;
 			if(!is_tag_id && feed_id_str != null)
 				feed_id = int64.parse(feed_id_str);

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -633,21 +633,7 @@ public class FeedReader.FeedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 		try
 		{
 			var settings_state = new GLib.Settings("org.gnome.feedreader.saved-state");
-			DateTime? since = null;
-			switch(Settings.general().get_enum("drop-articles-after"))
-			{
-				case DropArticles.ONE_WEEK:
-					since = new DateTime.now_utc().add_weeks(-1);
-					break;
-
-				case DropArticles.ONE_MONTH:
-					since = new DateTime.now_utc().add_months(-1);
-					break;
-
-				case DropArticles.SIX_MONTHS:
-					since = new DateTime.now_utc().add_months(-6);
-					break;
-			}
+			DateTime? since = ((DropArticles)Settings.general().get_enum("drop-articles-after")).to_start_date();
 			if(!DataBase.readOnly().isTableEmpty("articles"))
 			{
 				var last_sync = new DateTime.from_unix_utc(settings_state.get_int("last-sync"));

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -390,7 +390,7 @@ public class FeedReader.FeedHQInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -364,7 +364,7 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		string continuation = null;
 		string feedly_tagID = "";

--- a/plugins/backend/fresh/freshInterface.vala
+++ b/plugins/backend/fresh/freshInterface.vala
@@ -452,7 +452,7 @@ public class FeedReader.freshInterface : Peas.ExtensionBase, FeedServerInterface
 		return m_api.getUnreadCounts();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{

--- a/plugins/backend/inoreader/InoReaderInterface.vala
+++ b/plugins/backend/inoreader/InoReaderInterface.vala
@@ -378,7 +378,7 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -531,7 +531,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		return 0;
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		var f = DataBase.readOnly().read_feeds();
 		var articleArray = new Gee.LinkedList<Article>();

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -405,7 +405,7 @@ public class FeedReader.OldReaderInterface : Peas.ExtensionBase, FeedServerInter
 		return m_api.getTotalUnread();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		if(whatToGet == ArticleStatus.READ)
 		{

--- a/plugins/backend/owncloud/OwncloudNewsInterface.vala
+++ b/plugins/backend/owncloud/OwncloudNewsInterface.vala
@@ -432,7 +432,7 @@ public class FeedReader.OwncloudNewsInterface : Peas.ExtensionBase, FeedServerIn
 		return (int)DataBase.readOnly().get_unread_total();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		var type = OwncloudNewsAPI.OwnCloudType.ALL;
 		bool read = true;

--- a/plugins/backend/ttrss/ttrssInterface.vala
+++ b/plugins/backend/ttrss/ttrssInterface.vala
@@ -453,7 +453,7 @@ public class FeedReader.ttrssInterface : Peas.ExtensionBase, FeedServerInterface
 		return m_api.getUnreadCount();
 	}
 
-	public void getArticles(int count, ArticleStatus whatToGet, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
+	public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
 	{
 		var settings_general = new GLib.Settings("org.gnome.feedreader");
 

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -230,23 +230,9 @@ public class FeedReader.FeedServer : GLib.Object {
 			Notification.send(newArticles);
 		}
 
-		switch(Settings.general().get_enum("drop-articles-after"))
-		{
-			case DropArticles.NEVER:
-				break;
-
-			case DropArticles.ONE_WEEK:
-				DataBase.writeAccess().dropOldArtilces(1);
-				break;
-
-			case DropArticles.ONE_MONTH:
-				DataBase.writeAccess().dropOldArtilces(4);
-				break;
-
-			case DropArticles.SIX_MONTHS:
-				DataBase.writeAccess().dropOldArtilces(24);
-				break;
-		}
+		var drop_weeks = ((DropArticles)Settings.general().get_enum("drop-articles-after")).to_weeks();
+		if(drop_weeks != null)
+			DataBase.writeAccess().dropOldArtilces(-(int)drop_weeks);
 
 		var now = new DateTime.now_local();
 		Settings.state().set_int("last-sync", (int)now.to_unix());

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -861,7 +861,13 @@ public class FeedReader.FeedServer : GLib.Object {
 			return false;
 		}
 
-		return m_plugin.addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
+		if(!m_plugin.addFeed(feedURL, catID, newCatName, out feedID, out errmsg))
+			return false;
+
+		DateTime? since = ((DropArticles)Settings.general().get_enum("drop-articles-after")).to_start_date();
+		Logger.info("Downloading %d articles for feed %s (%s), since %s".printf(ArticleSyncCount(), feedID, feedURL, since.to_string()));
+		getArticles(ArticleSyncCount(), ArticleStatus.ALL, since, feedID);
+		return true;
 	}
 
 	public void addFeeds(Gee.List<Feed> feeds)

--- a/src/Backend/FeedServerInterface.vala
+++ b/src/Backend/FeedServerInterface.vala
@@ -108,7 +108,7 @@ public interface FeedReader.FeedServerInterface : GLib.Object {
 
 	public abstract int getUnreadCount();
 
-	public abstract void getArticles(int count, ArticleStatus whatToGet = ArticleStatus.ALL, string? feedID = null, bool isTagID = false, GLib.Cancellable? cancellable = null);
+	public abstract void getArticles(int count, ArticleStatus whatToGet = ArticleStatus.ALL, DateTime? since = null, string? feedID = null, bool isTagID = false, GLib.Cancellable? cancellable = null);
 
 	// UI stuff
 	public signal void tryLogin();

--- a/src/DataBaseWriteAccess.vala
+++ b/src/DataBaseWriteAccess.vala
@@ -598,24 +598,9 @@ public class FeedReader.DataBase : DataBaseReadOnly {
 			if(article.getDate().compare(now) == 1)
 				article.SetDate(now);
 
-				int weeks = 0;
-				switch(Settings.general().get_enum("drop-articles-after"))
-				{
-					case DropArticles.ONE_WEEK:
-						weeks = 1;
-						break;
-					case DropArticles.ONE_MONTH:
-						weeks = 4;
-						break;
-					case DropArticles.SIX_MONTHS:
-						weeks = 24;
-						break;
-				}
-
-				if(Settings.general().get_enum("drop-articles-after") != DropArticles.NEVER
-				&& article.getDate().compare(now.add_weeks(-weeks)) == -1)
-					continue;
-
+			int? weeks = ((DropArticles)Settings.general().get_enum("drop-articles-after")).to_weeks();
+			if(weeks != null && article.getDate().compare(now.add_weeks(-(int)weeks)) == -1)
+				continue;
 
 			stmt.bind_text(articleID_position, article.getArticleID());
 			stmt.bind_text(feedID_position, article.getFeedID());

--- a/src/Enums.vala
+++ b/src/Enums.vala
@@ -170,7 +170,33 @@ namespace FeedReader {
 		NEVER,
 		ONE_WEEK,
 		ONE_MONTH,
-		SIX_MONTHS
+		SIX_MONTHS;
+
+		public int? to_weeks()
+		{
+			switch(this)
+			{
+			case NEVER:
+				return null;
+			case ONE_WEEK:
+				return 1;
+			case ONE_MONTH:
+				return 4;
+			case SIX_MONTHS:
+				return 24;
+			default:
+				assert_not_reached();
+			}
+		}
+
+		public DateTime? to_start_date()
+		{
+			int? weeks = to_weeks();
+			if(weeks == null)
+				return null;
+
+			return new DateTime.now_utc().add_weeks(-(int)weeks);
+		}
 	}
 
 	public enum FeedListType {


### PR DESCRIPTION
This makes us pass a `since` argument to `getArticles()`, which:

 - Is a lot more efficient than what the Feedbin plugin was doing, since we only do it once per sync
 - Makes it easier for other plugins to re-use this logic (if any of them have an API like this)
 - Lets us easily do a full sync on newly added feeds (this was broken in the Feedbin plugin)

I also moved some things to the `DropArticles` enum to make them easier to reuse.

Fixes #556