### PR TITLE
Fixed syntax error in ttrss-plugin

### DIFF
--- a/data/tt-rss-feedreader-plugin/api_feedreader/init.php
+++ b/data/tt-rss-feedreader-plugin/api_feedreader/init.php
@@ -186,3 +186,4 @@ class Api_feedreader extends Plugin {
 		}
 	}
 }
+?>


### PR DESCRIPTION
Just noticed the missing when I wanted to install the plugin.