### PR TITLE
Add an RFC 822 date parser

### DIFF
--- a/plugins/backend/local/CMakeLists.txt
+++ b/plugins/backend/local/CMakeLists.txt
@@ -1,6 +1,9 @@
 set (PLUGNAME local)
 set (PLUGTARGET ${PLUGNAME}_target)
 
+set (TEST_NAME ${PLUGNAME}_test)
+set (TEST_TARGET ${TEST_NAME}_target)
+
 find_package(GLIB REQUIRED)
 find_package(Curl REQUIRED)
 include_directories(${GLIB_INCLUDE_DIRS})
@@ -17,6 +20,7 @@ add_subdirectory(rss-glib)
 vala_precompile(VALA_C ${PLUGTARGET}
 	localInterface.vala
 	localUtils.vala
+	Rfc822.vala
 	SuggestedFeedRow.vala
 
 PACKAGES
@@ -53,3 +57,27 @@ add_dependencies(${PLUGNAME} ${UI_NAME} ${FEEDREADER_NAME})
 install(TARGETS ${PLUGNAME} DESTINATION ${PKGLIBDIR}/plugins)
 install(FILES ${PLUGNAME}.plugin DESTINATION ${PKGLIBDIR}/plugins)
 
+# ----------------------------------------------------------
+# Tests
+# ----------------------------------------------------------
+
+install(TARGETS ${PLUGNAME} DESTINATION ${PKGLIBDIR}/plugins)
+install(FILES ${PLUGNAME}.plugin DESTINATION ${PKGLIBDIR}/plugins)
+vala_precompile(VALA_C ${TEST_TARGET}
+	Rfc822.vala
+	TestLocalRSS.vala
+
+PACKAGES
+	json-glib-1.0
+	libsoup-2.4
+	gee-0.8
+
+OPTIONS
+	--target-glib=2.32
+	--disable-warnings # since we frequently want to not catch errors
+)
+
+add_executable(${TEST_NAME} ${VALA_C})
+target_link_libraries(${TEST_NAME} ${API_NAME})
+
+add_test(${PLUGNAME} gtester -k -o ${CMAKE_BINARY_DIR}/${PLUGNAME}.gtester.log ${TEST_NAME})

--- a/plugins/backend/local/Rfc822.vala
+++ b/plugins/backend/local/Rfc822.vala
@@ -1,0 +1,144 @@
+namespace FeedReader.Rfc822 {
+
+	/**
+	 * Parse a date string in RFC 822 format
+	 * Note that we don't use Time.strptime because it uses the current locale
+	 * to parse month names, but RFC 822 specifically requires months to be
+	 * written in English.
+     * See: https://www.w3.org/Protocols/rfc822/#z28
+	 * And: https://groups.yahoo.com/neo/groups/rss-public/conversations/topics/536
+	 * */
+	public static DateTime? parseDate(string? str)
+	{
+		if (str == null)
+			return null;
+
+		Regex re;
+		try {
+			re = new Regex("""
+				# We don't care about the day of the week
+				\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s*)?
+				(?<day>\d{1,2})\s+
+				(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+
+				# The standard specifies 2-digit years but 4 digit years are
+				# recommended now.
+				# This pattern will also accept 3-digit years, so we'll have to
+				# check for that separately
+				(?<year>\d{2,4})\s+
+				(?<hour>\d{2})
+				:(?<minute>\d{2})
+				(?::(?<second>\d{2}))?\s+
+				(?<zone>UT|GMT|EST|EDT|MST|MDT|PST|PDT|[A-Z]|(?:[+-]\d{4}))
+				""",
+				RegexCompileFlags.CASELESS | RegexCompileFlags.EXTENDED,
+				RegexMatchFlags.ANCHORED);
+		} catch (RegexError e) {
+			stderr.printf("RFC822 regex failed to parse: %s\n", e.message);
+			assert(false);
+			return null;
+		}
+
+		MatchInfo info;
+		if (!re.match(str, 0, out info))
+			return null;
+
+		var dayStr = info.fetch_named("day");
+		var day = int.parse(dayStr);
+
+		var monthStr = info.fetch_named("month").ascii_down();
+		int month;
+		switch(monthStr) {
+		case "jan":
+			month = 1;
+			break;
+		case "feb":
+			month = 2;
+			break;
+		case "mar":
+			month = 3;
+			break;
+		case "apr":
+			month = 4;
+			break;
+		case "may":
+			month = 5;
+			break;
+		case "jun":
+			month = 6;
+			break;
+		case "jul":
+			month = 7;
+			break;
+		case "aug":
+			month = 8;
+			break;
+		case "sep":
+			month = 9;
+			break;
+		case "oct":
+			month = 10;
+			break;
+		case "nov":
+			month = 11;
+			break;
+		case "dec":
+			month = 12;
+			break;
+		default:
+			// The regex should make this impossible
+			assert(false);
+			return null;
+		}
+
+		var yearStr = info.fetch_named("year");
+		var year = int.parse(yearStr);
+		// Two-digit years from 00 to 49 should be interpreted as 2000 to 2049
+		if (year >= 0 && year <= 49)
+			year += 2000;
+		// Two-digit years from 50 to 99 should be interpreted as 1950 to 1999
+		else if (year >= 50 && year < 100)
+			year += 1900;
+		var hourStr = info.fetch_named("hour");
+		var hour = int.parse(hourStr);
+		var minuteStr = info.fetch_named("minute");
+		var minute = int.parse(minuteStr);
+		var secondStr = info.fetch_named("second");
+		var second = secondStr == null || secondStr == "" ? 0 : int.parse(secondStr);
+
+		var zoneStr = info.fetch_named("zone");
+		TimeZone zone;
+		switch(zoneStr.ascii_up()) {
+			// Note sure if new TimeZone(zoneStr) would always work for these,
+			// so specifically handle the cases the spec requires
+			case "EDT":
+				zone = new TimeZone("-04");
+				break;
+			case "CDT":
+			case "EST":
+				zone = new TimeZone("-05");
+				break;
+			case "CST":
+			case "MDT":
+				zone = new TimeZone("-06");
+				break;
+			case "MST":
+			case "PDT":
+				zone = new TimeZone("-07");
+				break;
+			case "PST":
+				zone = new TimeZone("-08");
+				break;
+
+			case "GMT":
+			case "UT":
+			case "Z":
+				zone = new TimeZone.utc();
+				break;
+			default:
+				zone = new TimeZone(zoneStr);
+				break;
+		}
+
+		return new DateTime(zone, year, month, day, hour, minute, second);
+	}
+}

--- a/plugins/backend/local/TestLocalRSS.vala
+++ b/plugins/backend/local/TestLocalRSS.vala
@@ -1,0 +1,109 @@
+using FeedReader;
+
+void main(string[] args)
+{
+	Test.init(ref args);
+
+    Test.add_data_func ("/Rfc822/parseDate/Basic", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 2006 23:59:45 +0000");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/LowerCase", () => {
+		var date = Rfc822.parseDate("thu, 09 feb 2006 16:59:45 mst");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/UpperCase", () => {
+		var date = Rfc822.parseDate("THU, 09 FEB 2006 16:59:45 MST");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/LotsOfWhiteSpace", () => {
+		var date = Rfc822.parseDate("  \t\n Thu, \t\n 09 \t\n Feb \t\n 2006 \t\n 23:59:45 \t\n +0000 \t\n");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/TwoDigitYear2000", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 00 23:59:45 +0000");
+		assert(new DateTime.utc(2000, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/TwoDigitYear2006", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 06 23:59:45 +0000");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/TwoDigitYear2049", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 49 23:59:45 +0000");
+		assert(new DateTime.utc(2049, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/TwoDigitYear1950", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 50 23:59:45 +0000");
+		assert(new DateTime.utc(1950, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/TwoDigitYear1956", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 56 23:59:45 +0000");
+		assert(new DateTime.utc(1956, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/TwoDigitYear1999", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 99 23:59:45 +0000");
+		assert(new DateTime.utc(1999, 2, 9, 23, 59, 45).equal(date));
+	});
+
+	// Just in case we get RSS feeds made by Romans
+    Test.add_data_func ("/Rfc822/parseDate/ThreeDigitYear", () => {
+		var date = Rfc822.parseDate("Thu, 09 Feb 156 23:59:45 +0000");
+		assert(new DateTime.utc(156, 2, 9, 23, 59, 45).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/OnlyRequired", () => {
+		var date = Rfc822.parseDate("09 Feb 2006 23:59 +0000");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 0).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/OneDigitDay", () => {
+		var date = Rfc822.parseDate("9 Feb 2006 23:59 +0000");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 0).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/UnsupportedZone", () => {
+		var date = Rfc822.parseDate("09 Feb 2006 23:59 X");
+		assert(new DateTime.utc(2006, 2, 9, 23, 59, 0).equal(date));
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/MissingDay", () => {
+		var date = Rfc822.parseDate("Feb 2006 23:59 +0000");
+		assert(date == null);
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/MissingMonth", () => {
+		var date = Rfc822.parseDate("09 2006 23:59 +0000");
+		assert(date == null);
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/MissingYear", () => {
+		var date = Rfc822.parseDate("09 Feb 23:59 +0000");
+		assert(date == null);
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/MissingHour", () => {
+		var date = Rfc822.parseDate("09 Feb 2006 59 +0000");
+		assert(date == null);
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/MissingMinute", () => {
+		var date = Rfc822.parseDate("09 Feb 2006 23 +0000");
+		assert(date == null);
+	});
+
+    Test.add_data_func ("/Rfc822/parseDate/MissingZone", () => {
+		var date = Rfc822.parseDate("09 Feb 2006 23:59");
+		assert(date == null);
+	});
+
+    Test.run ();
+}

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -600,15 +600,16 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 						articleID = item.link;
 					}
 
-					var date = new GLib.DateTime.now_local();
-					if(item.pub_date != null)
+					var date = Rfc822.parseDate(item.pub_date);
+					if (date != null)
 					{
-						GLib.Time time = GLib.Time();
-						time.strptime(item.pub_date, "%a, %d %b %Y %H:%M:%S %Z");
-						date = new GLib.DateTime.local(1900 + time.year, 1 + time.month, time.day, time.hour, time.minute, time.second);
-
-						if(date == null)
-							date = new GLib.DateTime.now_local();
+						Logger.info(@"Parsed $(item.pub_date) as $(date.to_string())");
+					}
+					else
+					{
+						if (item.pub_date != null)
+							Logger.warning(@"RFC 822 date parser failed to parse $(item.pub_date). Falling back to DateTime.now()");
+						date = new DateTime.now_local();
 					}
 
 					//Logger.info("Got content: " + item.description);


### PR DESCRIPTION
We were using Time.strptime, but there are several problems with that:

 - It's locale dependent, but RFC 822 always use English month names
 - Some components aren't required (the week day and seconds)
 - The time zone names don't necessarily match the Posix time zones

Fixes #652