### PR TITLE
Update Arch Linux instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For translators : https://hosted.weblate.org/projects/feedreader/
 ## How to install
 ### Arch Linux : <br/>
 ```bash
-yaourt -S feedreader
+pacman -S feedreader
 ```
 ### Fedora : <br/>
 ```bash


### PR DESCRIPTION
`feedreader` is in the main package repos now so there's no need to use an AUR helper like `yuourt`.