### PR TITLE
FreshAPI: Fix broken editTag function

### DIFF
--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -292,7 +292,7 @@ public class FeedReader.freshAPI : Object {
 
 		foreach(string id in arrayID)
 		{
-			msg.add("r", "-/" + id);
+			msg.add("i", "-/" + id);
 		}
 
 		var response = m_connection.postRequest(path,  msg.get(), "application/x-www-form-urlencoded");


### PR DESCRIPTION
The freshAPI editTag function was incorrectly using the wrong post field
to specify articleID ("r" instead of "i").
Which meant you couldn't (un)read/(un)star a article.

Fix #699