### PR TITLE
Exchanging get_dbh() with get_pdo() fixes #750

### DIFF
--- a/data/tt-rss-feedreader-plugin/api_feedreader/init.php
+++ b/data/tt-rss-feedreader-plugin/api_feedreader/init.php
@@ -20,7 +20,7 @@ class Api_feedreader extends Plugin {
 	function init($host)
 	{
 		$this->host = $host;
-		$this->dbh = $host->get_dbh();
+		$this->dbh = $host->get_pdo();
 		$this->host->add_api_method("addLabel", $this);
 		$this->host->add_api_method("removeLabel", $this);
 		$this->host->add_api_method("renameLabel", $this);


### PR DESCRIPTION
If I get it right, to fix #750 we only need to replace `get_dbh()` with the new function `get_pdo()`.
(see [file classes/pluginhost.php](https://git.tt-rss.org/fox/tt-rss/src/master/classes/pluginhost.php#L96))