### PR TITLE
Add new article themes.

### DIFF
--- a/data/ArticleView/style.css
+++ b/data/ArticleView/style.css
@@ -476,6 +476,8 @@ body.theme.midnight div.frcontent p {
     text-align: justify;
 }
 
+/* SPRING THEME */
+
 body.theme.spring {
     background: #f8fff2;
 }
@@ -511,6 +513,8 @@ body.theme.spring div.frcontent h2 {
     border-color: #405e80;
 }
 
+/* PARCHMENT THEME */
+
 body.theme.parchment {
     background: #faf2e1;
 }
@@ -541,4 +545,106 @@ body.theme.parchment div.frcontent h5,
 body.theme.parchment div.frcontent h6,
 body.theme.parchment div.frcontent p {
     color: rgba(0, 0, 0, 0.8);
+}
+
+/* CLASSIC THEME */
+
+body.theme.classic {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+body.theme.classic header.post {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+body.theme.classic div.frcontent {
+    border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+body.theme.classic div.frcontent a {
+    color: #318c34;
+}
+
+body.theme.classic a {
+    color: #318c34;
+}
+
+body.theme.classic h1,
+body.theme.classic h2,
+body.theme.classic h3,
+body.theme.classic h4,
+body.theme.classic h5,
+body.theme.classic h6 {
+    color: #318c34;
+}
+
+/* ELEMENTARY THEME */
+
+body.theme.elementary {
+    background: #CDCDCD;
+    color: #787878;
+}
+
+body.theme.elementary header.post,
+body.theme.elementary header.post span {
+    background: #CDCDCD;
+    color: #787878;
+}
+
+body.theme.elementary div.frcontent {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 1px 0 1px 0;
+    text-shadow: 0 1px alpha(#fff, 0.4);
+    color: #787878;
+}
+
+body.theme.elementary div.frcontent a:hover {
+    background-color: #DEDEDE;
+}
+
+body.theme.elementary a:hover {
+    background-color: #DEDEDE;
+}
+
+body.theme.elementary h1,
+body.theme.elementary h2,
+body.theme.elementary h3,
+body.theme.elementary h4,
+body.theme.elementary h5,
+body.theme.elementary h6,
+body.theme.elementary h1 a,
+body.theme.elementary h2 a,
+body.theme.elementary h3 a,
+body.theme.elementary h4 a,
+body.theme.elementary h5 a,
+body.theme.elementary h6 a,
+body.theme.elementary div.frcontent body,
+body.theme.elementary div.frcontent ul,
+body.theme.elementary div.frcontent figcaption,
+body.theme.elementary div.frcontent p,
+body.theme.elementary pre,
+body.theme.elementary pre code,
+body.theme.elementary code {
+    color: #787878;
+}
+
+body.theme.elementary a {
+    color: #787878;
+}
+
+body.theme.elementary table,
+body.theme.elementary th,
+body.theme.elementary td {
+    border: 1px solid #DEDEDE;
+}
+
+body.theme.elementary div.frcontent th,
+body.theme.elementary header.post {
+    background: #CDCDCD;
+}
+
+body.theme.elementary header.post h1,
+body.theme.elementary header.post h1 a {
+        color: #FEFEFE;
 }

--- a/schemas/org.gnome.feedreader.gschema.xml
+++ b/schemas/org.gnome.feedreader.gschema.xml
@@ -5,6 +5,8 @@
 		<value nick="SPRING" value="1"/>
 		<value nick="MIDNIGHT" value="2"/>
 		<value nick="PARCHMENT" value="3"/>
+		<value nick="CLASSIC" value="4"/>
+		<value nick="ELEMENTARY" value="5"/>
 	</enum>
 
 	<enum id="org.gnome.feedreader.drop-articles-duration">

--- a/src/Enums.vala
+++ b/src/Enums.vala
@@ -164,7 +164,9 @@ namespace FeedReader {
 		DEFAULT,
 		SPRING,
 		MIDNIGHT,
-		PARCHMENT
+		PARCHMENT,
+		CLASSIC,
+		ELEMENTARY
 	}
 
 	public enum FeedListTheme {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -650,6 +650,12 @@ public class FeedReader.Utils : GLib.Object {
 			case ArticleTheme.PARCHMENT:
 				theme += "parchment";
 				break;
+			case ArticleTheme.CLASSIC:
+				theme += "classic";
+				break;
+			case ArticleTheme.ELEMENTARY:
+				theme += "elementary";
+				break;
 		}
 
 		string theme_id = "$THEME";

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -108,7 +108,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 
 		var articleview_settings = headline(_("Article View:"));
 
-		var article_theme = new SettingDropbox(_("Theme"), Settings.general(), "article-theme", {_("Default"), _("Spring"), _("Midnight"), _("Parchment")});
+		var article_theme = new SettingDropbox(_("Theme"), Settings.general(), "article-theme", {_("Default"), _("Spring"), _("Midnight (Dark)"), _("Parchment"), _("Classic"), _("Elementary")});
 		article_theme.changed.connect(() => {
 			ColumnView.get_default().reloadArticleView();
 		});


### PR DESCRIPTION
This PR does several things related to article themes:

- Adds a classic article theme that matches the style before PR #566.
- Adds a article theme that matches the elementary feed list theme.
-Updates the displayed text for the "Midnight" them to include a reference to the Dark article theme ("Midnight (Dark)").
- Adds theme titles in the style.css file for those that were missing one.