### PR TITLE
Set max-width of page elements to 100%

### DIFF
--- a/data/ArticleView/style.css
+++ b/data/ArticleView/style.css
@@ -55,6 +55,10 @@ img {
     height: auto;
 }
 
+* {
+    max-width: 100%;
+}
+
 ol,
 ul {
     list-style: disc outside none;


### PR DESCRIPTION
This causes extra-wide content to scale down.

Fixes #767