### PR TITLE
Promote Flatpak package using the Flathub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Translation status](https://hosted.weblate.org/widgets/feedreader/-/svg-badge.svg)](https://hosted.weblate.org/engage/feedreader/?utm_source=widget) [![CircleCI](https://circleci.com/gh/jangernert/FeedReader.svg?style=shield)](https://circleci.com/gh/jangernert/FeedReader) [![Bountysource](https://img.shields.io/bountysource/team/jangernert-feedreader/activity.svg)](https://www.bountysource.com/teams/jangernert-feedreader/issues) [![Join the chat at https://gitter.im/Feedreader-dev/Lobby](https://badges.gitter.im/Feedreader-dev/Lobby.svg)](https://gitter.im/Feedreader-dev/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+<a href="https://flathub.org/apps/details/org.gnome.FeedReader"><img src="https://flathub.org/assets/badges/flathub-badge-i-en.png" alt="Download on Flathub" width="190px"></a>
+
 
 # [FeedReader](http://jangernert.github.io/FeedReader/)
 
@@ -10,25 +12,6 @@ FeedReader is a modern desktop application designed to complement existing web-b
 
 Website : http://jangernert.github.io/FeedReader/<br/>
 For translators : https://hosted.weblate.org/projects/feedreader/
-
-## How to install
-
-The Flatpak build works on any distro and will always track the newest release.
-For that reason, it's the only way we recommend that you install FeedReader (we
-really don't have the resources to support multiple distro-specific package).
-
-For more information about Flatpak and how to use or install it for your distribution see the [Flatpak webpage](http://flatpak.org).
-
-Besides installing the Flatpak Framework, you should also install the following portal packages using your distributions package manager:
-
-  - `xdg-desktop-portal`
-  - `xdg-desktop-portal-gtk`
-
-Follow the Flatpak [setup guide](https://flatpak.org/setup/) for your distribution before installing FeedReader. You must ensure Flatpak is installed and add the Flathub repo. Then you can run:
-
-```
-flatpak install flathub org.gnome.FeedReader
-```
 
 ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ FeedReader is a modern desktop application designed to complement existing web-b
 Website : http://jangernert.github.io/FeedReader/<br/>
 For translators : https://hosted.weblate.org/projects/feedreader/
 
+
+## How to install
+The Flatpak build works on any distro and will always track the newest release. For that reason, it's the only way we recommend that you install FeedReader (we really don't have the resources to support multiple distro-specific package).
+For more information about Flatpak and how to use or install it for your distribution see the [Flatpak webpage](http://flatpak.org).
+ 
+
 ## Build from source
 
 These are the instructions for building and testing locally. We generally


### PR DESCRIPTION
Remove the instructions as they are already mentioned on the Flathub website. Installing Flatpak now grabs the portals too.