### PR TITLE
Status icon implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -262,6 +262,11 @@ else
 	message('libUnity support OFF')
 endif
 
+if get_option('statusicon')
+        message('Status icon support ON')
+        vala_args += ['-D', 'STATUSICON']
+endif
+
 # Creating an executable file
 feedreader_lib = shared_library(
   'FeedReader',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,11 @@ option('share-plugins',
         value : ['browser', 'email', 'instapaper', 'pocket', 'telegram', 'twitter', 'wallabag'],
         description: 'List of share plugins to install'
 )
+option('statusicon',
+        type: 'boolean',
+        value: false,
+        description: 'Enables status icon'
+)
 option('backend-plugins',
         type: 'array',
         choices: ['bazqux', 'feedbin', 'feedhq', 'feedly', 'fresh', 'inoreader', 'local', 'oldreader', 'owncloud', 'ttrss'],


### PR DESCRIPTION
Hi.

First of all thank you very much for FeedReader. It helped me to improve my workflow a lot: no need to run browser with TTRSS tab open all the time + notifications and awesome UI.

There's one thing that bothered me though: I'm not using Unity and I'm unable to figure out if there are any new items. Not a tragedy, but a bit annoying (checking FeedReader all the time). To cover this case I've implemented a Gtk.StatusIcon support in FeedReader.

Before you hit reject here are my reasons for merging this request:

* It improves UX a lot as you can figure out if FeedReader needs attention at a glance.
* Despite Gtk.StatusIcon is being deprecated there are no other means to provide indicators in Gtk applications. Unity and similar KDE solution are environment specific, they're not available in other window managers. E.g. I'm using Xfce4 and I don't have any other means to provide indication except system tray.
* System tray itself is not going anywhere. It will stay as very many applications still use it. Even if Gtk.StatusIcon will be removed I'm sure some library implementing this functionality will pop up eventually.
* I'm not the only one who would like to have tray icon: #694, #522, #58.

P. S. If it should be implemented in some different way then please let me know and I'll do my best to update the code.