### PR TITLE
Local favicon reuse bug

### DIFF
--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -469,22 +469,19 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 
 	public string createCategory(string title, string? parentID)
 	{
-		string catID = "catID00001";
+		string catID;
 
-		if(!m_db.isTableEmpty("categories"))
+		string? id = m_db.getCategoryID(title);
+		if(id == null)
 		{
-			string? id = m_db.getCategoryID(title);
-			if(id == null)
-			{
-				catID = "catID%05d".printf(int.parse(m_db.getMaxID("categories", "categorieID").substring(5)) + 1);
-			}
-			else
-			{
-				catID = id;
-			}
+			catID = Uuid.string_random();
+		}
+		else
+		{
+			catID = id;
 		}
 
-		Logger.info("createCategory: ID = " + catID);
+		Logger.info(@"createCategory: title= $title ID = $catID");
 		return catID;
 	}
 

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -388,7 +388,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		{
 			string cID = createCategory(newCatName, null);
 			var cat = new Category(cID, newCatName, 0, 99, CategoryID.MASTER.to_string(), 1);
-			var list = new Gee.LinkedList<Category>();
+			var list = new Gee.ArrayList<Category>();
 			list.add(cat);
 			m_db_write.write_categories(list);
 			catIDs.add(cID);
@@ -402,12 +402,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 			catIDs.add("0");
 		}
 
-		feedID = "feedID00001";
-
-		if(!m_db.isTableEmpty("feeds"))
-		{
-			feedID = "feedID%05d".printf(int.parse(m_db.getMaxID("feeds", "feed_id").substring(6)) + 1);
-		}
+		feedID = Uuid.string_random();
 
 		Logger.info(@"addFeed: ID = $feedID");
 		Feed? Feed = m_utils.downloadFeed(m_session, feedURL, feedID, catIDs, out errmsg);
@@ -415,7 +410,7 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 		if(Feed != null)
 		{
 			if(!m_db.feed_exists(Feed.getURL())) {
-				var list = new Gee.LinkedList<Feed>();
+				var list = new Gee.ArrayList<Feed>();
 				list.add(Feed);
 				m_db_write.write_feeds(list);
 				return true;
@@ -427,21 +422,16 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 
 	public void addFeeds(Gee.List<Feed> feeds)
 	{
-		var finishedFeeds = new Gee.LinkedList<Feed>();
-
-		int highestID = 0;
-
-		if(!m_db.isTableEmpty("feeds"))
-			highestID = int.parse(m_db.getMaxID("feeds", "feed_id").substring(6)) + 1;
+		var finishedFeeds = new Gee.ArrayList<Feed>();
 
 		foreach(Feed f in feeds)
 		{
-			string feedID = "feedID" + highestID.to_string("%05d");
-			highestID++;
+			string feedID = Uuid.string_random();
 
-			Logger.info(@"addFeed: ID = $feedID");
+			string url = f.getXmlUrl();
+			Logger.info(@"addFeed: url = $url, ID = $feedID");
 			string errmsg = "";
-			Feed? Feed = m_utils.downloadFeed(m_session, f.getXmlUrl(), feedID, f.getCatIDs(), out errmsg);
+			Feed? Feed = m_utils.downloadFeed(m_session, url, feedID, f.getCatIDs(), out errmsg);
 
 			if(Feed != null)
 			{

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -464,7 +464,6 @@ public class FeedReader.localInterface : Peas.ExtensionBase, FeedServerInterface
 
 	public void removeFeed(string feedID)
 	{
-		m_utils.deleteIcon(feedID);
 		return;
 	}
 

--- a/plugins/backend/local/localUtils.vala
+++ b/plugins/backend/local/localUtils.vala
@@ -94,20 +94,4 @@ public class FeedReader.localUtils : GLib.Object {
 
 		return "";
 	}
-
-	public bool deleteIcon(string feedID)
-	{
-		try
-		{
-			string icon_path = GLib.Environment.get_user_data_dir() + "/feedreader/data/feed_icons/";
-			var file = GLib.File.new_for_path(icon_path + feedID + ".ico");
-			file.delete();
-			return true;
-		}
-		catch(GLib.Error e)
-		{
-			Logger.error("localUtils - deleteIcon: " + e.message);
-		}
-		return false;
-	}
 }

--- a/src/Backend/Backend.vala
+++ b/src/Backend/Backend.vala
@@ -726,7 +726,10 @@ namespace FeedReader {
 			asyncPayload pl = () => { FeedServer.get_default().removeFeed(feedID); };
 			callAsync.begin((owned)pl, (obj, res) => { callAsync.end(res); });
 
-			asyncPayload pl2 = () => { DataBase.writeAccess().delete_feed(feedID); };
+			asyncPayload pl2 = () => {
+				FeedReader.FavIcon.delete_feed(feedID);
+				DataBase.writeAccess().delete_feed(feedID);
+			};
 			callAsync.begin((owned)pl2, (obj, res) => {
 				callAsync.end(res);
 				newFeedList();


### PR DESCRIPTION
This makes two changes that each would individually fix #763:

 - Don't re-use feed and category ID's in the local plugin (use GUUID's)
 - Delete favicons when we delete a feed