### PR TITLE
When a category is removed, uncategorize feeds/categories explicitly to plugins

### DIFF
--- a/src/Backend/Backend.vala
+++ b/src/Backend/Backend.vala
@@ -568,6 +568,24 @@ namespace FeedReader {
 
 		public void removeCategory(string catID)
 		{
+			var feeds = DataBase.readOnly().read_feeds();
+			foreach(Feed feed in feeds)
+			{
+				if(feed.hasCat(catID))
+				{
+					moveFeed(feed.getFeedID(), catID);
+				}
+			}
+
+			var cats = DataBase.readOnly().read_categories(feeds);
+			foreach(var cat in cats)
+			{
+				if(cat.getParent() == catID)
+				{
+					moveCategory(cat.getCatID(), uncategorizedID());
+				}
+			}
+
 			asyncPayload pl = () => { FeedServer.get_default().deleteCategory(catID); };
 			callAsync.begin((owned)pl, (obj, res) => { callAsync.end(res); });
 

--- a/src/DataBaseWriteAccess.vala
+++ b/src/DataBaseWriteAccess.vala
@@ -647,26 +647,6 @@ public class FeedReader.DataBase : DataBaseReadOnly {
 	public void delete_category(string catID)
 	{
 		m_db.execute("DELETE FROM main.categories WHERE categorieID = ?", { catID });
-
-		if(FeedServer.get_default().supportMultiCategoriesPerFeed())
-		{
-			var rows = m_db.execute("SELECT feed_id, category_id FROM feeds WHERE instr(category_id, ?) > 0", { catID });
-			foreach(var row in rows)
-			{
-				string feedID = row[0].to_string();
-				string catIDs = row[1].to_string().replace(catID + ",", "");
-
-				m_db.execute("UPDATE main.feeds set category_id = ? WHERE feed_id = ?", { catIDs, feedID });
-			}
-		}
-		else
-		{
-			m_db.execute("UPDATE main.feeds set category_id = ? WHERE category_id = ?", { FeedServer.get_default().uncategorizedID(), catID });
-			if(FeedServer.get_default().supportMultiLevelCategories())
-			{
-				m_db.execute("UPDATE main.categories set Parent = \"-2\" WHERE categorieID = ?", { catID });
-			}
-		}
 	}
 
 	public void rename_category(string catID, string newName)


### PR DESCRIPTION
Currently, when a category is removed without children, its feeds/categories are uncategorized. However, these changes aren't sent to the plugins. For example, in Nextcloud the children are [removed](https://github.com/nextcloud/news/blob/master/docs/externalapi/External-Api.md#deleting-a-folder).

This pull request sends these changes explicitly to the plugin.