### PR TITLE
Set Feedbin to BackendFlags.FREE_SOFTWARE

### DIFF
--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -37,7 +37,7 @@ public class FeedReader.FeedbinInterface : Peas.ExtensionBase, FeedServerInterfa
 
 	public BackendFlags getFlags()
 	{
-		return (BackendFlags.HOSTED | BackendFlags.PROPRIETARY | BackendFlags.PAID);
+		return (BackendFlags.HOSTED | BackendFlags.FREE_SOFTWARE | BackendFlags.PAID);
 	}
 
 	public string getID()


### PR DESCRIPTION
Feedbin was released under the MIT license a while ago:

https://github.com/feedbin/feedbin/blob/master/LICENSE.md

I'm leaving the HOSTED and PAID flags since even though you
could technically self-host, I doubt anyone actually would.

Fixes #794