### PR TITLE
Don't use legacy path for AppStream metainfo file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -26,7 +26,7 @@ i18n.merge_file(
   output: 'org.gnome.FeedReader.appdata.xml',
   po_dir: PO_DIR,
   install: true,
-  install_dir: join_paths(SHARE_DIR, 'appdata')
+  install_dir: join_paths(SHARE_DIR, 'metainfo')
 )
 
 


### PR DESCRIPTION
Metainfo files should be installed into /usr/share/metainfo.