### PR TITLE
Fix DataBaseWriteAccess.resetDB (#821)

### DIFF
--- a/src/DataBaseWriteAccess.vala
+++ b/src/DataBaseWriteAccess.vala
@@ -48,11 +48,14 @@ public class FeedReader.DataBase : DataBaseReadOnly {
 	public bool resetDB()
 	{
 		Logger.warning("resetDB");
-		m_db.simple_query("DROP TABLE main.feeds");
-		m_db.simple_query("DROP TABLE main.categories");
-		m_db.simple_query("DROP TABLE main.articles");
-		m_db.simple_query("DROP TABLE main.tags");
 		m_db.simple_query("DROP TABLE main.fts_table");
+		m_db.simple_query("DROP TABLE main.taggings");
+		m_db.simple_query("DROP TABLE main.Enclosures");
+		m_db.simple_query("DROP TABLE main.CachedActions");
+		m_db.simple_query("DROP TABLE main.tags");
+		m_db.simple_query("DROP TABLE main.articles");
+		m_db.simple_query("DROP TABLE main.categories");
+		m_db.simple_query("DROP TABLE main.feeds");
 		m_db.simple_query("VACUUM");
 
 		string query = "PRAGMA INTEGRITY_CHECK";


### PR DESCRIPTION
When the database is reset, it tries to drop the table `articles` before the table `Enclosures`. But this fails since `Enclosures` references `articles`. This means that the database is partially reset, which causes problems.

A nice way to solve it would be by adding `ON DELETE CASCADE` at the references, but it doesn't seem to work. Dropping the tables in the opposite order they are created works as well.