### PR TITLE
Remove threading

### DIFF
--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -162,6 +162,7 @@ public bool getCategoriesAndTags(Gee.List<Feed> feeds, Gee.List<Category> catego
 	uint length = array.get_length();
 	int orderID = 0;
 
+	var db = DataBase.readOnly();
 	for (uint i = 0; i < length; i++)
 	{
 		Json.Object object = array.get_object_element(i);
@@ -191,7 +192,7 @@ public bool getCategoriesAndTags(Gee.List<Feed> feeds, Gee.List<Category> catego
 					new Tag(
 						id,
 						title,
-						DataBase.readOnly().getTagColor()
+						db.getTagColor()
 						)
 					);
 			}
@@ -323,6 +324,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 	var array = root.get_array_member("items");
 	uint length = array.get_length();
 
+	var db = DataBase.readOnly();
 	for (uint i = 0; i < length; i++)
 	{
 		Json.Object object = array.get_object_element(i);
@@ -341,7 +343,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 				marked = true;
 			else if(cat.has_suffix("com.google/read"))
 				read = true;
-			else if(cat.contains("/label/") && DataBase.readOnly().getTagName(cat) != null)
+			else if(cat.contains("/label/") && db.getTagName(cat) != null)
 				tags.add(cat);
 		}
 

--- a/plugins/backend/bazqux/bazquxAPI.vala
+++ b/plugins/backend/bazqux/bazquxAPI.vala
@@ -24,11 +24,9 @@ public enum bazquxSubscriptionAction {
 private bazquxConnection m_connection;
 private bazquxUtils m_utils;
 private string m_userID;
-private DataBaseReadOnly m_db;
 
-public bazquxAPI(bazquxUtils utils, DataBaseReadOnly db)
+public bazquxAPI(bazquxUtils utils)
 {
-	m_db = db;
 	m_utils = utils;
 	m_connection = new bazquxConnection(utils);
 }
@@ -193,7 +191,7 @@ public bool getCategoriesAndTags(Gee.List<Feed> feeds, Gee.List<Category> catego
 					new Tag(
 						id,
 						title,
-						m_db.getTagColor()
+						DataBase.readOnly().getTagColor()
 						)
 					);
 			}
@@ -343,7 +341,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 				marked = true;
 			else if(cat.has_suffix("com.google/read"))
 				read = true;
-			else if(cat.contains("/label/") && m_db.getTagName(cat) != null)
+			else if(cat.contains("/label/") && DataBase.readOnly().getTagName(cat) != null)
 				tags.add(cat);
 		}
 

--- a/plugins/backend/bazqux/bazquxInterface.vala
+++ b/plugins/backend/bazqux/bazquxInterface.vala
@@ -257,13 +257,14 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = DataBase.readOnly().read_categories();
+	var db = DataBase.readOnly();
+	var categories = db.read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = DataBase.readOnly().read_feeds_without_cat();
+	var feeds = db.read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());

--- a/plugins/backend/bazqux/bazquxInterface.vala
+++ b/plugins/backend/bazqux/bazquxInterface.vala
@@ -19,15 +19,11 @@ private bazquxAPI m_api;
 private bazquxUtils m_utils;
 private Gtk.Entry m_userEntry;
 private Gtk.Entry m_passwordEntry;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new bazquxUtils(settings_backend, secrets);
-	m_api = new bazquxAPI(m_utils, db);
+	m_api = new bazquxAPI(m_utils);
 }
 
 public string getWebsite()
@@ -261,13 +257,13 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = m_db.read_categories();
+	var categories = DataBase.readOnly().read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = m_db.read_feeds_without_cat();
+	var feeds = DataBase.readOnly().read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());
@@ -424,7 +420,7 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 				left = 0;
 			}
 		}
-		m_db_write.updateArticlesByID(unreadIDs, "unread");
+		DataBase.writeAccess().updateArticlesByID(unreadIDs, "unread");
 	}
 
 	var articles = new Gee.LinkedList<Article>();

--- a/plugins/backend/decsync/decsyncInterface.vala
+++ b/plugins/backend/decsync/decsyncInterface.vala
@@ -185,7 +185,7 @@ public async void postLoginAction()
 	loginButton.get_style_context().remove_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 	loginStack.set_visible_child_name("waiting");
 	SourceFunc callback = postLoginAction.callback;
-	new GLib.Thread<void*>(null, () => {
+	new Thread<void*>(null, () => {
 			m_sync.initStoredEntries();
 			m_sync.executeStoredEntries({"feeds", "subscriptions"}, new Unit());
 			Idle.add((owned) callback);

--- a/plugins/backend/decsync/decsyncListeners.vala
+++ b/plugins/backend/decsync/decsyncListeners.vala
@@ -50,7 +50,7 @@ public override void onSubdirEntryUpdate(Gee.List<string> path, Decsync.Entry en
 	{
 		Logger.debug((added ? "mark " : "unmark ") + articleID);
 	}
-	Article? article = m_plugin.m_db.read_article(articleID);
+	Article? article = DataBase.readOnly().read_article(articleID);
 	if (article == null)
 	{
 		Logger.info("Unkown article " + articleID);
@@ -64,7 +64,7 @@ public override void onSubdirEntryUpdate(Gee.List<string> path, Decsync.Entry en
 	{
 		article.setMarked(added ? ArticleStatus.MARKED : ArticleStatus.UNMARKED);
 	}
-	m_plugin.m_db_write.update_article(article);
+	DataBase.writeAccess().update_article(article);
 }
 }
 
@@ -100,7 +100,7 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 	}
 	else
 	{
-		m_plugin.m_db_write.delete_feed(feedID);
+		DataBase.writeAccess().delete_feed(feedID);
 	}
 }
 }
@@ -135,7 +135,7 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		Logger.warning("Invalid name " + Json.to_string(entry.value, false));
 		return;
 	}
-	m_plugin.m_db_write.rename_feed(feedID, name);
+	DataBase.writeAccess().rename_feed(feedID, name);
 }
 }
 
@@ -163,7 +163,7 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		Logger.warning("Invalid feedID " + Json.to_string(entry.key, false));
 		return;
 	}
-	var feed = m_plugin.m_db.read_feed(feedID);
+	var feed = DataBase.readOnly().read_feed(feedID);
 	if (feed == null) return;
 	var currentCatID = feed.getCatString();
 	string newCatID;
@@ -181,7 +181,7 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		return;
 	}
 	addCategory(m_plugin, newCatID);
-	m_plugin.m_db_write.move_feed(feedID, currentCatID, newCatID);
+	DataBase.writeAccess().move_feed(feedID, currentCatID, newCatID);
 }
 }
 
@@ -215,7 +215,7 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		Logger.warning("Invalid name " + Json.to_string(entry.value, false));
 		return;
 	}
-	m_plugin.m_db_write.rename_category(catID, name);
+	DataBase.writeAccess().rename_category(catID, name);
 	Logger.debug("Renamed category " + catID + " to " + name);
 }
 }
@@ -259,19 +259,19 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		return;
 	}
 	addCategory(m_plugin, parentID);
-	m_plugin.m_db_write.move_category(catID, parentID);
+	DataBase.writeAccess().move_category(catID, parentID);
 	Logger.debug("Moved category " + catID + " to " + parentID);
 }
 }
 
 private static void addCategory(decsyncInterface plugin, string catID)
 {
-	if (catID == plugin.uncategorizedID() || catID == CategoryID.MASTER.to_string() || plugin.m_db.read_category(catID) != null)
+	if (catID == plugin.uncategorizedID() || catID == CategoryID.MASTER.to_string() || DataBase.readOnly().read_category(catID) != null)
 	{
 		return;
 	}
 	var cat = new Category(catID, catID, 0, 99, CategoryID.MASTER.to_string(), 1);
-	plugin.m_db_write.write_categories(ListUtils.single(cat));
+	DataBase.writeAccess().write_categories(ListUtils.single(cat));
 	plugin.m_sync.executeStoredEntries({"categories", "names"}, new Unit(),
 	                                   stringEquals(catID)
 	                                   );

--- a/plugins/backend/decsync/decsyncListeners.vala
+++ b/plugins/backend/decsync/decsyncListeners.vala
@@ -50,7 +50,8 @@ public override void onSubdirEntryUpdate(Gee.List<string> path, Decsync.Entry en
 	{
 		Logger.debug((added ? "mark " : "unmark ") + articleID);
 	}
-	Article? article = DataBase.readOnly().read_article(articleID);
+	var db = DataBase.writeAccess();
+	Article? article = db.read_article(articleID);
 	if (article == null)
 	{
 		Logger.info("Unkown article " + articleID);
@@ -64,7 +65,7 @@ public override void onSubdirEntryUpdate(Gee.List<string> path, Decsync.Entry en
 	{
 		article.setMarked(added ? ArticleStatus.MARKED : ArticleStatus.UNMARKED);
 	}
-	DataBase.writeAccess().update_article(article);
+	db.update_article(article);
 }
 }
 
@@ -163,7 +164,8 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		Logger.warning("Invalid feedID " + Json.to_string(entry.key, false));
 		return;
 	}
-	var feed = DataBase.readOnly().read_feed(feedID);
+	var db = DataBase.writeAccess();
+	var feed = db.read_feed(feedID);
 	if (feed == null) return;
 	var currentCatID = feed.getCatString();
 	string newCatID;
@@ -181,7 +183,7 @@ public override void onSubfileEntryUpdate(Decsync.Entry entry, Unit extra)
 		return;
 	}
 	addCategory(m_plugin, newCatID);
-	DataBase.writeAccess().move_feed(feedID, currentCatID, newCatID);
+	db.move_feed(feedID, currentCatID, newCatID);
 }
 }
 

--- a/plugins/backend/demo/demoInterface.vala
+++ b/plugins/backend/demo/demoInterface.vala
@@ -10,7 +10,7 @@ public class FeedReader.demoInterface : Peas.ExtensionBase, FeedServerInterface 
 // This method gets executed right after the plugin is loaded. Do everything
 // you need to set up the plugin here.
 //--------------------------------------------------------------------------------------
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
 
 }

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -285,9 +285,10 @@ private void setRead(string id, FeedListType type)
 {
 	const int count = 1000;
 	int num_articles = 1;         // set to any value > 0
+	var db = DataBase.readOnly();
 	for(var offset = 0; num_articles > 0; offset += count)
 	{
-		var articles = DataBase.readOnly().read_articles(id, type, ArticleListState.ALL, "", count, offset);
+		var articles = db.read_articles(id, type, ArticleListState.ALL, "", count, offset);
 		var entry_ids = new Gee.ArrayList<int64?>();
 		foreach(var article in articles)
 		{
@@ -643,6 +644,7 @@ requires (count >= 0)
 {
 	try
 	{
+		var db = DataBase.readOnly();
 		int64? feed_id = null;
 		if(!is_tag_id && feed_id_str != null)
 			feed_id = int64.parse(feed_id_str);
@@ -683,7 +685,7 @@ requires (count >= 0)
 			for(var offset = 0, c = 1000; ; offset += c)
 			{
 				var articles = new Gee.ArrayList<Article>();
-				var existing_articles = DataBase.readOnly().read_articles(search_feed_id, search_type, ArticleListState.ALL, "", c, offset);
+				var existing_articles = db.read_articles(search_feed_id, search_type, ArticleListState.ALL, "", c, offset);
 				if(existing_articles.size == 0)
 					break;
 

--- a/plugins/backend/feedbin/feedbinInterface.vala
+++ b/plugins/backend/feedbin/feedbinInterface.vala
@@ -19,13 +19,9 @@ private FeedbinAPI m_api;
 private FeedbinUtils m_utils;
 private Gtk.Entry m_userEntry;
 private Gtk.Entry m_passwordEntry;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new FeedbinUtils(settings_backend, secrets);
 	m_api = new FeedbinAPI(m_utils.getUser(), m_utils.getPassword(), Constants.USER_AGENT);
 }
@@ -291,7 +287,7 @@ private void setRead(string id, FeedListType type)
 	int num_articles = 1;         // set to any value > 0
 	for(var offset = 0; num_articles > 0; offset += count)
 	{
-		var articles = m_db.read_articles(id, type, ArticleListState.ALL, "", count, offset);
+		var articles = DataBase.readOnly().read_articles(id, type, ArticleListState.ALL, "", count, offset);
 		var entry_ids = new Gee.ArrayList<int64?>();
 		foreach(var article in articles)
 		{
@@ -687,7 +683,7 @@ requires (count >= 0)
 			for(var offset = 0, c = 1000; ; offset += c)
 			{
 				var articles = new Gee.ArrayList<Article>();
-				var existing_articles = m_db.read_articles(search_feed_id, search_type, ArticleListState.ALL, "", c, offset);
+				var existing_articles = DataBase.readOnly().read_articles(search_feed_id, search_type, ArticleListState.ALL, "", c, offset);
 				if(existing_articles.size == 0)
 					break;
 

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -259,13 +259,14 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = DataBase.readOnly().read_categories();
+	var db = DataBase.readOnly();
+	var categories = db.read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = DataBase.readOnly().read_feeds_without_cat();
+	var feeds = db.read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());

--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -19,13 +19,9 @@ private FeedHQAPI m_api;
 private FeedHQUtils m_utils;
 private Gtk.Entry m_userEntry;
 private Gtk.Entry m_passwordEntry;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new FeedHQUtils(settings_backend, secrets);
 	m_api = new FeedHQAPI(m_utils);
 }
@@ -263,13 +259,13 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = m_db.read_categories();
+	var categories = DataBase.readOnly().read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = m_db.read_feeds_without_cat();
+	var feeds = DataBase.readOnly().read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());
@@ -418,7 +414,7 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 			continuation = m_api.updateArticles(unreadIDs, 1000, continuation);
 		}
 		while(continuation != null);
-		m_db_write.updateArticlesByID(unreadIDs, "unread");
+		DataBase.writeAccess().updateArticlesByID(unreadIDs, "unread");
 	}
 
 	var articles = new Gee.LinkedList<Article>();

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -19,10 +19,8 @@ private FeedlyConnection m_connection;
 private string m_userID;
 private Json.Array m_unreadcounts;
 private FeedlyUtils m_utils;
-private DataBaseReadOnly m_db;
 
-public FeedlyAPI(FeedlyUtils utils, DataBaseReadOnly db) {
-	m_db = db;
+public FeedlyAPI(FeedlyUtils utils) {
 	m_utils = utils;
 	m_connection = new FeedlyConnection(m_utils);
 }
@@ -280,7 +278,7 @@ public bool getTags(Gee.List<Tag> tags)
 			new Tag(
 				object.get_string_member("id"),
 				object.has_member("label") ? object.get_string_member("label") : "",
-				m_db.getTagColor()
+				DataBase.readOnly().getTagColor()
 				)
 			);
 	}
@@ -599,7 +597,7 @@ public bool addSubscription(string feedURL, string? title = null, string? catIDs
 
 		foreach(string catID in catArray)
 		{
-			string catName = m_db.getCategoryName(catID);
+			string catName = DataBase.readOnly().getCategoryName(catID);
 			Json.Object catObject = new Json.Object();
 			catObject.set_string_member("id", catID);
 			catObject.set_string_member("label", catName);
@@ -619,7 +617,7 @@ public bool addSubscription(string feedURL, string? title = null, string? catIDs
 
 public void moveSubscription(string feedID, string newCatID, string? oldCatID = null)
 {
-	var Feed = m_db.read_feed(feedID);
+	var Feed = DataBase.readOnly().read_feed(feedID);
 
 	Json.Object object = new Json.Object();
 	object.set_string_member("id", feedID);
@@ -633,7 +631,7 @@ public void moveSubscription(string feedID, string newCatID, string? oldCatID = 
 	{
 		if(catID != oldCatID)
 		{
-			string catName = m_db.getCategoryName(catID);
+			string catName = DataBase.readOnly().getCategoryName(catID);
 			Json.Object catObject = new Json.Object();
 			catObject.set_string_member("id", catID);
 			catObject.set_string_member("label", catName);
@@ -641,7 +639,7 @@ public void moveSubscription(string feedID, string newCatID, string? oldCatID = 
 		}
 	}
 
-	string newCatName = m_db.getCategoryName(newCatID);
+	string newCatName = DataBase.readOnly().getCategoryName(newCatID);
 	Json.Object catObject = new Json.Object();
 	catObject.set_string_member("id", newCatID);
 	catObject.set_string_member("label", newCatName);

--- a/plugins/backend/feedly/feedlyAPI.vala
+++ b/plugins/backend/feedly/feedlyAPI.vala
@@ -271,6 +271,7 @@ public bool getTags(Gee.List<Tag> tags)
 	Json.Array array = parser.get_root().get_array ();
 	uint length = array.get_length();
 
+	var db = DataBase.readOnly();
 	for (uint i = 0; i < length; i++) {
 		Json.Object object = array.get_object_element(i);
 
@@ -278,7 +279,7 @@ public bool getTags(Gee.List<Tag> tags)
 			new Tag(
 				object.get_string_member("id"),
 				object.has_member("label") ? object.get_string_member("label") : "",
-				DataBase.readOnly().getTagColor()
+				db.getTagColor()
 				)
 			);
 	}
@@ -595,9 +596,10 @@ public bool addSubscription(string feedURL, string? title = null, string? catIDs
 		var catArray = catIDs.split(",");
 		Json.Array cats = new Json.Array();
 
+		var db = DataBase.readOnly();
 		foreach(string catID in catArray)
 		{
-			string catName = DataBase.readOnly().getCategoryName(catID);
+			string catName = db.getCategoryName(catID);
 			Json.Object catObject = new Json.Object();
 			catObject.set_string_member("id", catID);
 			catObject.set_string_member("label", catName);
@@ -617,7 +619,8 @@ public bool addSubscription(string feedURL, string? title = null, string? catIDs
 
 public void moveSubscription(string feedID, string newCatID, string? oldCatID = null)
 {
-	var Feed = DataBase.readOnly().read_feed(feedID);
+	var db = DataBase.readOnly();
+	var Feed = db.read_feed(feedID);
 
 	Json.Object object = new Json.Object();
 	object.set_string_member("id", feedID);
@@ -631,7 +634,7 @@ public void moveSubscription(string feedID, string newCatID, string? oldCatID = 
 	{
 		if(catID != oldCatID)
 		{
-			string catName = DataBase.readOnly().getCategoryName(catID);
+			string catName = db.getCategoryName(catID);
 			Json.Object catObject = new Json.Object();
 			catObject.set_string_member("id", catID);
 			catObject.set_string_member("label", catName);
@@ -639,7 +642,7 @@ public void moveSubscription(string feedID, string newCatID, string? oldCatID = 
 		}
 	}
 
-	string newCatName = DataBase.readOnly().getCategoryName(newCatID);
+	string newCatName = db.getCategoryName(newCatID);
 	Json.Object catObject = new Json.Object();
 	catObject.set_string_member("id", newCatID);
 	catObject.set_string_member("label", newCatName);

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -17,15 +17,11 @@ public class FeedReader.feedlyInterface : Peas.ExtensionBase, FeedServerInterfac
 
 private FeedlyAPI m_api;
 private FeedlyUtils m_utils;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new FeedlyUtils(settings_backend);
-	m_api = new FeedlyAPI(m_utils, db);
+	m_api = new FeedlyAPI(m_utils);
 }
 
 public string getWebsite()
@@ -222,8 +218,8 @@ public void markAllItemsRead()
 	string catArray = "";
 	string feedArray = "";
 
-	var categories = m_db.read_categories();
-	var feeds = m_db.read_feeds_without_cat();
+	var categories = DataBase.readOnly().read_categories();
+	var feeds = DataBase.readOnly().read_feeds_without_cat();
 
 	foreach(Category cat in categories)
 	{
@@ -306,7 +302,7 @@ public void removeFeed(string feedID)
 
 public void renameFeed(string feedID, string title)
 {
-	var feed = m_db.read_feed(feedID);
+	var feed = DataBase.readOnly().read_feed(feedID);
 	m_api.addSubscription(feed.getFeedID(), title, feed.getCatString());
 }
 
@@ -337,7 +333,7 @@ public void deleteCategory(string catID)
 
 public void removeCatFromFeed(string feedID, string catID)
 {
-	var feed = m_db.read_feed(feedID);
+	var feed = DataBase.readOnly().read_feed(feedID);
 	m_api.addSubscription(feed.getFeedID(), feed.getTitle(), feed.getCatString().replace(catID + ",", ""));
 }
 

--- a/plugins/backend/feedly/feedlyInterface.vala
+++ b/plugins/backend/feedly/feedlyInterface.vala
@@ -218,8 +218,9 @@ public void markAllItemsRead()
 	string catArray = "";
 	string feedArray = "";
 
-	var categories = DataBase.readOnly().read_categories();
-	var feeds = DataBase.readOnly().read_feeds_without_cat();
+	var db = DataBase.readOnly();
+	var categories = db.read_categories();
+	var feeds = db.read_feeds_without_cat();
 
 	foreach(Category cat in categories)
 	{

--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -19,9 +19,8 @@ private freshConnection m_connection;
 private freshUtils m_utils;
 private DataBaseReadOnly m_db;
 
-public freshAPI(freshUtils utils, DataBaseReadOnly db)
+public freshAPI(freshUtils utils)
 {
-	m_db = db;
 	m_utils = utils;
 	m_connection = new freshConnection(m_utils);
 }
@@ -311,7 +310,7 @@ public void markAllAsRead(string streamID)
 	var msg = new freshMessage();
 	msg.add("T", m_connection.getToken());
 	msg.add("s", streamID);
-	msg.add("ts", m_db.getNewestArticle());
+	msg.add("ts", DataBase.readOnly().getNewestArticle());
 
 	var response = m_connection.postRequest(path, msg.get(), "application/x-www-form-urlencoded");
 

--- a/plugins/backend/fresh/freshInterface.vala
+++ b/plugins/backend/fresh/freshInterface.vala
@@ -24,15 +24,11 @@ private Gtk.Entry m_authPasswordEntry;
 private Gtk.Entry m_authUserEntry;
 private Gtk.Revealer m_revealer;
 private bool m_need_htaccess = false;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new freshUtils(settings_backend, secrets);
-	m_api = new freshAPI(m_utils, db);
+	m_api = new freshAPI(m_utils);
 }
 
 public string getWebsite()

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -24,11 +24,9 @@ public enum InoSubscriptionAction {
 private InoReaderConnection m_connection;
 private InoReaderUtils m_utils;
 private string m_userID;
-private DataBaseReadOnly m_db;
 
-public InoReaderAPI (InoReaderUtils utils, DataBaseReadOnly db)
+public InoReaderAPI (InoReaderUtils utils)
 {
-	m_db = db;
 	m_utils = utils;
 	m_connection = new InoReaderConnection(m_utils);
 }
@@ -192,7 +190,7 @@ public bool getCategoriesAndTags(Gee.List<Feed> feeds, Gee.List<Category> catego
 					new Tag(
 						id,
 						title,
-						m_db.getTagColor()
+						DataBase.readOnly().getTagColor()
 						)
 					);
 			}
@@ -338,7 +336,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 				marked = true;
 			else if(cat.has_suffix("com.google/read"))
 				read = true;
-			else if(cat.contains("/label/") && m_db.getTagName(cat) != null)
+			else if(cat.contains("/label/") && DataBase.readOnly().getTagName(cat) != null)
 				tags.add(cat);
 		}
 

--- a/plugins/backend/inoreader/InoReaderAPI.vala
+++ b/plugins/backend/inoreader/InoReaderAPI.vala
@@ -162,6 +162,7 @@ public bool getCategoriesAndTags(Gee.List<Feed> feeds, Gee.List<Category> catego
 	uint length = array.get_length();
 	int orderID = 0;
 
+	var db = DataBase.readOnly();
 	for (uint i = 0; i < length; i++)
 	{
 		Json.Object object = array.get_object_element(i);
@@ -190,7 +191,7 @@ public bool getCategoriesAndTags(Gee.List<Feed> feeds, Gee.List<Category> catego
 					new Tag(
 						id,
 						title,
-						DataBase.readOnly().getTagColor()
+						db.getTagColor()
 						)
 					);
 			}
@@ -318,6 +319,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 	var array = root.get_array_member("items");
 	uint length = array.get_length();
 
+	var db = DataBase.readOnly();
 	for (uint i = 0; i < length; i++)
 	{
 		Json.Object object = array.get_object_element(i);
@@ -336,7 +338,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 				marked = true;
 			else if(cat.has_suffix("com.google/read"))
 				read = true;
-			else if(cat.contains("/label/") && DataBase.readOnly().getTagName(cat) != null)
+			else if(cat.contains("/label/") && db.getTagName(cat) != null)
 				tags.add(cat);
 		}
 

--- a/plugins/backend/inoreader/InoReaderInterface.vala
+++ b/plugins/backend/inoreader/InoReaderInterface.vala
@@ -232,13 +232,14 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = DataBase.readOnly().read_categories();
+	var db = DataBase.readOnly();
+	var categories = db.read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = DataBase.readOnly().read_feeds_without_cat();
+	var feeds = db.read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());

--- a/plugins/backend/inoreader/InoReaderInterface.vala
+++ b/plugins/backend/inoreader/InoReaderInterface.vala
@@ -17,15 +17,11 @@ public class FeedReader.InoReaderInterface : Peas.ExtensionBase, FeedServerInter
 
 private InoReaderAPI m_api;
 private InoReaderUtils m_utils;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new InoReaderUtils(settings_backend);
-	m_api = new InoReaderAPI(m_utils, db);
+	m_api = new InoReaderAPI(m_utils);
 }
 
 public string getWebsite()
@@ -236,13 +232,13 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = m_db.read_categories();
+	var categories = DataBase.readOnly().read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = m_db.read_feeds_without_cat();
+	var feeds = DataBase.readOnly().read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());
@@ -415,7 +411,7 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 				left = 0;
 			}
 		}
-		m_db_write.updateArticlesByID(unreadIDs, "unread");
+		DataBase.writeAccess().updateArticlesByID(unreadIDs, "unread");
 		updateArticleList();
 	}
 

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -158,15 +158,21 @@ public void writeData()
 
 public async void postLoginAction()
 {
-	var children = m_feedlist.get_children();
-	foreach(var r in children)
-	{
-		var row = r as SuggestedFeedRow;
-		if(row.checked())
+	SourceFunc callback = postLoginAction.callback;
+	new GLib.Thread<void*>(null, () => {
+		var children = m_feedlist.get_children();
+		foreach(var r in children)
 		{
-			FeedReaderBackend.get_default().addFeed(row.getURL(), row.getCategory(), false);
+			var row = r as SuggestedFeedRow;
+			if(row.checked())
+			{
+				FeedReaderBackend.get_default().addFeed(row.getURL(), row.getCategory(), false);
+			}
 		}
-	}
+		Idle.add((owned) callback);
+		return null;
+	});
+	yield;
 }
 
 public string buildLoginURL()

--- a/plugins/backend/local/localInterface.vala
+++ b/plugins/backend/local/localInterface.vala
@@ -162,21 +162,15 @@ public void writeData()
 
 public async void postLoginAction()
 {
-	SourceFunc callback = postLoginAction.callback;
-	new GLib.Thread<void*>(null, () => {
-			var children = m_feedlist.get_children();
-			foreach(var r in children)
-			{
-			        var row = r as SuggestedFeedRow;
-			        if(row.checked())
-			        {
-			                FeedReaderBackend.get_default().addFeed(row.getURL(), row.getCategory(), false, false);
-				}
-			}
-			Idle.add((owned) callback);
-			return null;
-		});
-	yield;
+	var children = m_feedlist.get_children();
+	foreach(var r in children)
+	{
+		var row = r as SuggestedFeedRow;
+		if(row.checked())
+		{
+			FeedReaderBackend.get_default().addFeed(row.getURL(), row.getCategory(), false);
+		}
+	}
 }
 
 public string buildLoginURL()

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -24,11 +24,9 @@ public enum OldreaderSubscriptionAction {
 private OldReaderConnection m_connection;
 private OldReaderUtils m_utils;
 private string m_userID;
-private DataBaseReadOnly m_db;
 
-public OldReaderAPI(OldReaderUtils utils, DataBaseReadOnly db)
+public OldReaderAPI(OldReaderUtils utils)
 {
-	m_db = db;
 	m_utils = utils;
 	m_connection = new OldReaderConnection(m_utils);
 }
@@ -320,7 +318,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 				marked = true;
 			else if(cat.has_suffix("com.google/read"))
 				read = true;
-			else if(cat.contains("/label/") && m_db.getTagName(cat) != null)
+			else if(cat.contains("/label/") && DataBase.readOnly().getTagName(cat) != null)
 				tags.add(cat);
 		}
 

--- a/plugins/backend/oldreader/oldreaderAPI.vala
+++ b/plugins/backend/oldreader/oldreaderAPI.vala
@@ -300,6 +300,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 	var array = root.get_array_member("items");
 	uint length = array.get_length();
 
+	var db = DataBase.readOnly();
 	for (uint i = 0; i < length; i++)
 	{
 		Json.Object object = array.get_object_element(i);
@@ -318,7 +319,7 @@ public string? getArticles(Gee.List<Article> articles, int count, ArticleStatus 
 				marked = true;
 			else if(cat.has_suffix("com.google/read"))
 				read = true;
-			else if(cat.contains("/label/") && DataBase.readOnly().getTagName(cat) != null)
+			else if(cat.contains("/label/") && db.getTagName(cat) != null)
 				tags.add(cat);
 		}
 

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -19,15 +19,11 @@ private OldReaderAPI m_api;
 private OldReaderUtils m_utils;
 private Gtk.Entry m_userEntry;
 private Gtk.Entry m_passwordEntry;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new OldReaderUtils(settings_backend, secrets);
-	m_api = new OldReaderAPI(m_utils, db);
+	m_api = new OldReaderAPI(m_utils);
 }
 
 public string getWebsite()
@@ -262,13 +258,13 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = m_db.read_categories();
+	var categories = DataBase.readOnly().read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = m_db.read_feeds_without_cat();
+	var feeds = DataBase.readOnly().read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());
@@ -442,7 +438,7 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 				left = 0;
 			}
 		}
-		m_db_write.updateArticlesByID(unreadIDs, "unread");
+		DataBase.writeAccess().updateArticlesByID(unreadIDs, "unread");
 		updateArticleList();
 	}
 

--- a/plugins/backend/oldreader/oldreaderInterface.vala
+++ b/plugins/backend/oldreader/oldreaderInterface.vala
@@ -258,13 +258,14 @@ public void setCategoryRead(string catID)
 
 public void markAllItemsRead()
 {
-	var categories = DataBase.readOnly().read_categories();
+	var db = DataBase.readOnly();
+	var categories = db.read_categories();
 	foreach(Category cat in categories)
 	{
 		m_api.markAsRead(cat.getCatID());
 	}
 
-	var feeds = DataBase.readOnly().read_feeds_without_cat();
+	var feeds = db.read_feeds_without_cat();
 	foreach(Feed feed in feeds)
 	{
 		m_api.markAsRead(feed.getFeedID());

--- a/plugins/backend/owncloud/OwncloudNewsAPI.vala
+++ b/plugins/backend/owncloud/OwncloudNewsAPI.vala
@@ -29,11 +29,9 @@ private string m_username;
 private string m_password;
 private OwncloudNewsUtils m_utils;
 private Soup.Session m_session;
-private DataBaseReadOnly m_db;
 
-public OwncloudNewsAPI(OwncloudNewsUtils utils, DataBaseReadOnly db)
+public OwncloudNewsAPI(OwncloudNewsUtils utils)
 {
-	m_db = db;
 	m_parser = new Json.Parser ();
 	m_utils = utils;
 	m_session = new Soup.Session();
@@ -356,7 +354,7 @@ public bool markFeedRead(string feedID, bool isCatID)
 {
 	string url = "%s/%s/read".printf((isCatID) ? "folders" : "feeds", feedID);
 	var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
-	message.add_int("newestItemId", int.parse(m_db.getNewestArticle()));
+	message.add_int("newestItemId", int.parse(DataBase.readOnly().getNewestArticle()));
 	int error = message.send();
 
 	if(error == ConnectionError.SUCCESS)
@@ -370,7 +368,7 @@ public bool markAllItemsRead()
 {
 	string url = "items/read";
 	var message = new OwnCloudNewsMessage(m_session, m_OwnCloudURL + url, m_username, m_password, "PUT");
-	message.add_int("newestItemId", int.parse(m_db.getNewestArticle()));
+	message.add_int("newestItemId", int.parse(DataBase.readOnly().getNewestArticle()));
 	int error = message.send();
 
 	if(error == ConnectionError.SUCCESS)
@@ -404,7 +402,7 @@ public bool updateArticleUnread(string articleIDs, ArticleStatus unread)
 
 public bool updateArticleMarked(string articleID, ArticleStatus marked)
 {
-	var article = m_db.read_article(articleID);
+	var article = DataBase.readOnly().read_article(articleID);
 	string url = "items/%s/%s/".printf(article.getFeedID(), article.getHash());
 
 	if(marked == ArticleStatus.MARKED)

--- a/plugins/backend/owncloud/OwncloudNewsInterface.vala
+++ b/plugins/backend/owncloud/OwncloudNewsInterface.vala
@@ -24,15 +24,11 @@ private Gtk.Entry m_AuthUserEntry;
 private Gtk.Entry m_AuthPasswordEntry;
 private Gtk.Revealer m_revealer;
 private bool m_need_htaccess = false;
-private DataBaseReadOnly m_db;
-private DataBase m_db_write;
 
-public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write)
+public void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets)
 {
-	m_db = db;
-	m_db_write = db_write;
 	m_utils = new OwncloudNewsUtils(settings_backend, secrets);
-	m_api = new OwncloudNewsAPI(m_utils, db);
+	m_api = new OwncloudNewsAPI(m_utils);
 }
 
 public string getWebsite()
@@ -438,7 +434,7 @@ public bool getFeedsAndCats(Gee.List<Feed> feeds, Gee.List<Category> categories,
 
 public int getUnreadCount()
 {
-	return (int)m_db.get_unread_total();
+	return (int)DataBase.readOnly().get_unread_total();
 }
 
 public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, string? feedID, bool isTagID, GLib.Cancellable? cancellable = null)
@@ -471,7 +467,7 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 	var articles = new Gee.LinkedList<Article>();
 
 	if(count == -1)
-		m_api.getNewArticles(articles, m_db.getLastModified(), type, id);
+		m_api.getNewArticles(articles, DataBase.readOnly().getLastModified(), type, id);
 	else
 		m_api.getArticles(articles, 0, -1, read, type, id);
 

--- a/plugins/backend/ttrss/ttrssAPI.vala
+++ b/plugins/backend/ttrss/ttrssAPI.vala
@@ -22,11 +22,9 @@ private uint64 m_ttrss_apilevel;
 private Json.Parser m_parser;
 private string? m_iconDir = null;
 private Soup.Session m_session;
-private DataBaseReadOnly m_db;
 
-public ttrssAPI (ttrssUtils utils, DataBaseReadOnly db)
+public ttrssAPI (ttrssUtils utils)
 {
-	m_db = db;
 	m_parser = new Json.Parser();
 	m_utils = utils;
 	m_session = new Soup.Session();
@@ -307,7 +305,7 @@ public bool getTags(Gee.List<Tag> tags)
 				new Tag(
 					tag_node.get_int_member("id").to_string(),
 					tag_node.get_string_member("caption"),
-					m_db.getTagColor()
+					DataBase.readOnly().getTagColor()
 					)
 				);
 		}

--- a/plugins/backend/ttrss/ttrssAPI.vala
+++ b/plugins/backend/ttrss/ttrssAPI.vala
@@ -298,6 +298,7 @@ public bool getTags(Gee.List<Tag> tags)
 		var response = message.get_response_array();
 		var tag_count = response.get_length();
 
+		var db = DataBase.readOnly();
 		for(uint i = 0; i < tag_count; ++i)
 		{
 			var tag_node = response.get_object_element(i);
@@ -305,7 +306,7 @@ public bool getTags(Gee.List<Tag> tags)
 				new Tag(
 					tag_node.get_int_member("id").to_string(),
 					tag_node.get_string_member("caption"),
-					DataBase.readOnly().getTagColor()
+					db.getTagColor()
 					)
 				);
 		}

--- a/plugins/backend/ttrss/ttrssInterface.vala
+++ b/plugins/backend/ttrss/ttrssInterface.vala
@@ -468,12 +468,13 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 	if(cancellable != null && cancellable.is_cancelled())
 		return;
 
+	var db = DataBase.writeAccess();
 	if(unreadIDs != null && whatToGet == ArticleStatus.ALL)
 	{
 		Logger.debug("getArticles: newsplus plugin active");
 		var markedIDs = m_api.NewsPlus(ArticleStatus.MARKED, settings_general.get_int("max-articles"));
-		DataBase.writeAccess().updateArticlesByID(unreadIDs, "unread");
-		DataBase.writeAccess().updateArticlesByID(markedIDs, "marked");
+		db.updateArticlesByID(unreadIDs, "unread");
+		db.updateArticlesByID(markedIDs, "marked");
 		//updateArticleList();
 	}
 
@@ -505,14 +506,14 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 		// only update article states if they haven't been updated by the newsPlus-plugin
 		if(unreadIDs == null || whatToGet != ArticleStatus.ALL)
 		{
-			DataBase.writeAccess().update_articles(articles);
+			db.update_articles(articles);
 			updateArticleList();
 		}
 
 		foreach(Article article in articles)
 		{
 			var id = article.getArticleID();
-			if(!DataBase.readOnly().article_exists(id))
+			if(!db.article_exists(id))
 			{
 				articleIDs += id + ",";
 			}
@@ -536,7 +537,7 @@ public void getArticles(int count, ArticleStatus whatToGet, DateTime? since, str
 
 	if(articles.size > 0)
 	{
-		DataBase.writeAccess().write_articles(articles);
+		db.write_articles(articles);
 		refreshFeedListCounter();
 		updateArticleList();
 	}

--- a/plugins/share/Twitter/TwitterForm.vala
+++ b/plugins/share/Twitter/TwitterForm.vala
@@ -105,7 +105,7 @@ public async void setAPI(TwitterAPI api)
 {
 	SourceFunc callback = setAPI.callback;
 
-	new GLib.Thread<void*>(null, () => {
+	new Thread<void*>(null, () => {
 			m_urlLength = api.getUrlLength();
 			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
 			return null;

--- a/src/ActionCache.vala
+++ b/src/ActionCache.vala
@@ -119,12 +119,15 @@ private void removeOpposite(CachedAction action)
 
 private void removeForFeed(string feedID)
 {
+	DataBaseReadOnly db = null;
 	foreach(CachedAction a in m_list)
 	{
 		if(a.getType() == CachedActions.MARK_READ
 		   || a.getType() == CachedActions.MARK_UNREAD)
 		{
-			if(feedID == DataBase.readOnly().getFeedIDofArticle(a.getID()))
+			if (db == null)
+				db = DataBase.readOnly();
+			if(feedID == db.getFeedIDofArticle(a.getID()))
 			{
 				m_list.remove(a);
 			}
@@ -204,6 +207,7 @@ public ArticleStatus checkRead(Article a)
 	}
 	else if(a.getUnread() == ArticleStatus.UNREAD)
 	{
+		DataBaseReadOnly db = null;
 		foreach(CachedAction action in m_list)
 		{
 			switch(action.getType())
@@ -217,7 +221,9 @@ public ArticleStatus checkRead(Article a)
 				break;
 
 			case CachedActions.MARK_READ_CATEGORY:
-				var feedIDs = DataBase.readOnly().getFeedIDofCategorie(a.getArticleID());
+				if (db == null)
+					db = DataBase.readOnly();
+				var feedIDs = db.getFeedIDofCategorie(a.getArticleID());
 				foreach(string feedID in feedIDs)
 				{
 					if(feedID == a.getFeedID())

--- a/src/Backend/Backend.vala
+++ b/src/Backend/Backend.vala
@@ -305,7 +305,7 @@ public async bool checkOnlineAsync()
 		return null;
 	};
 
-	new GLib.Thread<void*>("checkOnlineAsync", run);
+	new Thread<void*>("checkOnlineAsync", run);
 	yield;
 	return online;
 }
@@ -774,13 +774,11 @@ public void moveFeed(string feedID, string currentCatID, string? newCatID = null
 			});
 }
 
-public void addFeed(string feedURL, string cat, bool isID, bool asynchron)
+public void addFeed(string feedURL, string cat, bool isID)
 {
 	string? catID = null;
 	string? newCatName = null;
 	string? feedID = null;
-	bool success = false;
-	string errmsg = "";
 
 	if(cat != "")
 	{
@@ -790,26 +788,13 @@ public void addFeed(string feedURL, string cat, bool isID, bool asynchron)
 			newCatName = cat;
 	}
 
-	if(asynchron)
+	string errmsg;
+	bool success = FeedServer.get_default().addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
+	errmsg = success ? "" : errmsg;
+	feedAdded(!success, errmsg);
+	if(success)
 	{
-		new GLib.Thread<void*>(null, () => {
-					success = FeedServer.get_default().addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
-					errmsg = (success) ? "" : errmsg; // just to be sure :P
-					feedAdded(!success, errmsg);
-
-					if(success)
-					{
-					        startSync();
-					}
-
-					return null;
-				});
-	}
-	else
-	{
-		success = FeedServer.get_default().addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
-		errmsg = (success) ? "" : errmsg;
-		feedAdded(!success, errmsg);
+		startSync();
 	}
 }
 
@@ -869,7 +854,7 @@ public void updateBadge()
 private async void callAsync(owned asyncPayload func)
 {
 	SourceFunc callback = callAsync.callback;
-	new GLib.Thread<void*>(null, () => {
+	new Thread<void*>(null, () => {
 				func();
 				Idle.add((owned) callback);
 				return null;

--- a/src/Backend/FeedServer.vala
+++ b/src/Backend/FeedServer.vala
@@ -56,13 +56,8 @@ private FeedServer()
 			        if(secrets == null)
 					secrets = Secret.Collection.create_sync(secret_service, "Login", Secret.COLLECTION_DEFAULT, Secret.CollectionCreateFlags.COLLECTION_CREATE_NONE);
 
-			        // Intentionally creating a new database handle here so we don't
-			        // have to deal with threading issues. *Do not use the static
-			        // getter for this!*
-			        var db = new DataBaseReadOnly();
-			        var db_write = new DataBase();
 			        var settings_backend = null; // FIXME: Why does SettingsBackend.get_default() crash on Arch Linux?
-			        (extension as FeedServerInterface).init(settings_backend, secrets, db, db_write);
+			        (extension as FeedServerInterface).init(settings_backend, secrets);
 			        PluginsChanedEvent();
 			}
 			catch(Error e)

--- a/src/Backend/FeedServerInterface.vala
+++ b/src/Backend/FeedServerInterface.vala
@@ -21,7 +21,7 @@ public signal void updateArticleList();
 public signal void showArticleListOverlay();
 public signal void writeArticles(Gee.List<Article> articles);
 
-public abstract void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets, DataBaseReadOnly db, DataBase db_write);
+public abstract void init(GLib.SettingsBackend? settings_backend, Secret.Collection secrets);
 
 public abstract bool supportTags();
 

--- a/src/CachedActionManager.vala
+++ b/src/CachedActionManager.vala
@@ -74,19 +74,21 @@ public void markAllRead()
 
 private void addAction(CachedAction action)
 {
-	if(DataBase.writeAccess().cachedActionNecessary(action))
+	var db = DataBase.writeAccess();
+	if(db.cachedActionNecessary(action))
 	{
-		DataBase.writeAccess().addCachedAction(action.getType(), action.getID());
+		db.addCachedAction(action.getType(), action.getID());
 	}
 	else
 	{
-		DataBase.writeAccess().deleteOppositeCachedAction(action);
+		db.deleteOppositeCachedAction(action);
 	}
 }
 
 public void executeActions()
 {
-	if(DataBase.readOnly().isTableEmpty("CachedActions"))
+	var db = DataBase.writeAccess();
+	if(db.isTableEmpty("CachedActions"))
 	{
 		Logger.debug("CachedActionManager - executeActions: no actions to perform");
 		return;
@@ -95,7 +97,7 @@ public void executeActions()
 
 	Logger.debug("CachedActionManager: executeActions");
 
-	var actions = DataBase.writeAccess().readCachedActions();
+	var actions = db.readCachedActions();
 
 	foreach(CachedAction action in actions)
 	{
@@ -141,7 +143,7 @@ public void executeActions()
 		execute(m_ids.substring(1), m_lastAction);
 	}
 
-	DataBase.writeAccess().resetCachedActions();
+	db.resetCachedActions();
 }
 
 private void execute(string ids, CachedActions action)

--- a/src/DataBaseWriteAccess.vala
+++ b/src/DataBaseWriteAccess.vala
@@ -15,19 +15,13 @@
 
 public class FeedReader.DataBase : DataBaseReadOnly {
 
-private static DataBase? m_dataBase = null;
-
 public static new DataBase writeAccess()
-ensures (m_dataBase != null)
 {
-	if(m_dataBase == null)
-	{
-		m_dataBase = new DataBase();
-		if(m_dataBase.uninitialized())
-			m_dataBase.init();
-	}
+	var database = new DataBase();
+	if(database.uninitialized())
+		database.init();
 
-	return m_dataBase;
+	return database;
 }
 
 public static new DataBaseReadOnly readOnly()

--- a/src/FeedReader.vala
+++ b/src/FeedReader.vala
@@ -216,17 +216,9 @@ protected override void shutdown()
 	base.shutdown();
 }
 
-public async void sync()
+public void sync()
 {
-	SourceFunc callback = sync.callback;
-	ThreadFunc<void*> run = () => {
-		FeedReaderBackend.get_default().startSync();
-		Idle.add((owned) callback);
-		return null;
-	};
-
-	new GLib.Thread<void*>("sync", run);
-	yield;
+	FeedReaderBackend.get_default().startSync();
 }
 
 public void cancelSync()

--- a/src/FeedReaderMain.vala
+++ b/src/FeedReaderMain.vala
@@ -76,7 +76,7 @@ public static int main (string[] args)
 	{
 		Logger.init(verbose);
 		Logger.debug(@"Adding feed $feedURL");
-		FeedReaderBackend.get_default().addFeed(feedURL, "", false, true);
+		FeedReaderBackend.get_default().addFeed(feedURL, "", false);
 		return 0;
 	}
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -33,15 +33,16 @@ public static Soup.Session getSession()
 public static void generatePreviews(Gee.List<Article> articles)
 {
 	string noPreview = _("No Preview Available");
+	var db = DataBase.readOnly();
 	foreach(var Article in articles)
 	{
-		if(!DataBase.readOnly().article_exists(Article.getArticleID()))
+		if(!db.article_exists(Article.getArticleID()))
 		{
 			if(Article.getPreview() != null && Article.getPreview() != "")
 			{
 				continue;
 			}
-			if(!DataBase.readOnly().preview_empty(Article.getArticleID()))
+			if(!db.preview_empty(Article.getArticleID()))
 			{
 				continue;
 			}
@@ -85,9 +86,10 @@ public static void generatePreviews(Gee.List<Article> articles)
 
 public static void checkHTML(Gee.List<Article> articles)
 {
+	var db = DataBase.readOnly();
 	foreach(var Article in articles)
 	{
-		if(!DataBase.readOnly().article_exists(Article.getArticleID()))
+		if(!db.article_exists(Article.getArticleID()))
 		{
 			string modified_html = _("No Text available for this article :(");
 			if(Article.getHTML() != "")
@@ -770,9 +772,10 @@ public static bool onlyShowFeeds()
 	if(Settings.general().get_boolean("only-feeds"))
 		return true;
 
-	if(!DataBase.readOnly().haveCategories()
+	var db = DataBase.readOnly();
+	if(!db.haveCategories()
 	   && !FeedReaderBackend.get_default().supportTags()
-	   && !DataBase.readOnly().haveFeedsWithoutCat())
+	   && !db.haveFeedsWithoutCat())
 		return true;
 
 	return false;

--- a/src/Widgets/AddPopover.vala
+++ b/src/Widgets/AddPopover.vala
@@ -142,7 +142,7 @@ private void addFeed()
 	}
 
 	Logger.debug("addFeed: %s, %s".printf(m_urlEntry.text, (catID == "") ? "null" : catID));
-	FeedReaderBackend.get_default().addFeed(m_urlEntry.text, catID, isID, true);
+	FeedReaderBackend.get_default().addFeed(m_urlEntry.text, catID, isID);
 
 	setBusy();
 }

--- a/src/Widgets/ColumnView.vala
+++ b/src/Widgets/ColumnView.vala
@@ -161,9 +161,7 @@ private ColumnView()
 	m_headerbar.refresh.connect(() => {
 			syncStarted();
 			var app = FeedReaderApp.get_default();
-			app.sync.begin((obj, res) => {
-				app.sync.end(res);
-			});
+			app.sync();
 		});
 
 	m_headerbar.cancel.connect(() => {
@@ -240,18 +238,14 @@ public void newArticleList(Gtk.StackTransitionType transition = Gtk.StackTransit
 	{
 		ulong id = 0;
 		id = m_articleList.draw.connect_after(() => {
-				m_articleList.newList.begin(transition, (obj, res) => {
-					m_articleList.newList.end(res);
-				});
+				m_articleList.newList(transition);
 				m_articleList.disconnect(id);
 				return false;
 			});
 	}
 	else
 	{
-		m_articleList.newList.begin(transition, (obj, res) => {
-				m_articleList.newList.end(res);
-			});
+		m_articleList.newList(transition);
 	}
 }
 
@@ -272,9 +266,7 @@ public void reloadArticleView()
 
 public void updateArticleList()
 {
-	m_articleList.updateArticleList.begin((obj,res) => {
-			m_articleList.updateArticleList.end(res);
-		});
+	m_articleList.updateArticleList();
 }
 
 private void setArticleListState(ArticleListState state)

--- a/src/Widgets/FeedList.vala
+++ b/src/Widgets/FeedList.vala
@@ -465,7 +465,8 @@ private void addTagCategory(int length)
 
 private void createCategories(ref Gee.List<Feed> feeds, bool masterCat, ArticleListState state)
 {
-	int maxCatLevel = DataBase.readOnly().getMaxCatLevel();
+	var db = DataBase.readOnly();
+	int maxCatLevel = db.getMaxCatLevel();
 	int length = (int)m_list.get_children().length();
 	bool supportTags = false;
 	bool supportCategories = true;
@@ -478,7 +479,7 @@ private void createCategories(ref Gee.List<Feed> feeds, bool masterCat, ArticleL
 	supportMultiLevelCategories = FeedReaderBackend.get_default().supportMultiLevelCategories();
 
 	if((supportTags
-	    && !DataBase.readOnly().isTableEmpty("tags"))
+	    && !db.isTableEmpty("tags"))
 	   || masterCat)
 	{
 		addMasterCategory(length, _("Categories"));
@@ -497,16 +498,16 @@ private void createCategories(ref Gee.List<Feed> feeds, bool masterCat, ArticleL
 
 	for(int i = 1; i <= maxCatLevel; i++)
 	{
-		var categories = DataBase.readOnly().read_categories_level(i, feeds);
+		var categories = db.read_categories_level(i, feeds);
 
-		if(DataBase.readOnly().haveFeedsWithoutCat())
+		if(db.haveFeedsWithoutCat())
 		{
 			categories.insert(
 				0,
 				new Category(
 					uncategorizedID,
 					_("Uncategorized"),
-					(int)DataBase.readOnly().get_unread_uncategorized(),
+					(int)db.get_unread_uncategorized(),
 					(int)(categories.size + 10),
 					CategoryID.MASTER.to_string(),
 					1
@@ -592,9 +593,10 @@ private void createTags()
 
 public void refreshCounters(ArticleListState state)
 {
-	uint allCount = (state == ArticleListState.MARKED) ? DataBase.readOnly().get_marked_total() : DataBase.readOnly().get_unread_total();
-	var feeds = DataBase.readOnly().read_feeds((state == ArticleListState.MARKED) ? true : false);
-	var categories = DataBase.readOnly().read_categories(feeds);
+	var db = DataBase.readOnly();
+	uint allCount = (state == ArticleListState.MARKED) ? db.get_marked_total() : db.get_unread_total();
+	var feeds = db.read_feeds((state == ArticleListState.MARKED) ? true : false);
+	var categories = db.read_categories(feeds);
 
 	// double-check
 	uint feedCount = 0;
@@ -674,7 +676,7 @@ public void refreshCounters(ArticleListState state)
 		}
 	}
 
-	if(DataBase.readOnly().haveFeedsWithoutCat())
+	if(db.haveFeedsWithoutCat())
 	{
 		foreach(Gtk.Widget row in FeedChildList)
 		{
@@ -683,12 +685,12 @@ public void refreshCounters(ArticleListState state)
 			{
 				if(state == ArticleListState.MARKED)
 				{
-					tmpCatRow.set_unread_count(DataBase.readOnly().get_marked_uncategorized());
+					tmpCatRow.set_unread_count(db.get_marked_uncategorized());
 					tmpCatRow.activateUnreadEventbox(false);
 				}
 				else
 				{
-					tmpCatRow.set_unread_count(DataBase.readOnly().get_unread_uncategorized());
+					tmpCatRow.set_unread_count(db.get_unread_uncategorized());
 					tmpCatRow.activateUnreadEventbox(true);
 				}
 				if(Settings.general().get_boolean("feedlist-only-show-unread") && tmpCatRow.getUnreadCount() != 0)

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -623,9 +623,7 @@ private bool shortcuts(Gdk.EventKey event)
 	{
 		Logger.debug("shortcut: sync");
 		var app = FeedReaderApp.get_default();
-		app.sync.begin((obj, res) => {
-				app.sync.end(res);
-			});
+		app.sync();
 		return true;
 	}
 

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -476,14 +476,15 @@ private void markSelectedRead()
 	{
 		if(selectedRow[1] == FeedID.ALL.to_string())
 		{
-			var categories = DataBase.readOnly().read_categories();
+			var db = DataBase.readOnly();
+			var categories = db.read_categories();
 			foreach(Category cat in categories)
 			{
 				FeedReaderBackend.get_default().markFeedAsRead(cat.getCatID(), true);
 				Logger.debug("MainWindow: mark all articles as read cat: %s".printf(cat.getTitle()));
 			}
 
-			var feeds = DataBase.readOnly().read_feeds_without_cat();
+			var feeds = db.read_feeds_without_cat();
 			foreach(Feed feed in feeds)
 			{
 				FeedReaderBackend.get_default().markFeedAsRead(feed.getFeedID(), false);

--- a/src/Widgets/SharePopover.vala
+++ b/src/Widgets/SharePopover.vala
@@ -122,25 +122,16 @@ private void clicked(Gtk.ListBoxRow row)
 
 }
 
-private async void shareAsync(string id, string url)
+private void shareInternal(string id, string url)
 {
-	SourceFunc callback = shareAsync.callback;
-	new GLib.Thread<void*>(null, () => {
-			Share.get_default().addBookmark(id, url);
-			Idle.add((owned) callback, GLib.Priority.HIGH_IDLE);
-			return null;
-		});
-	yield;
+	Share.get_default().addBookmark(id, url);
 }
 
 private void shareURL(string id, string url)
 {
 	this.hide();
 	startShare();
-	shareAsync.begin(id, url, (obj, res) => {
-			shareAsync.end(res);
-			shareDone();
-		});
+	shareInternal(id, url);
 	string idString = (id == null || id == "") ? "" : @" to $id";
 	Logger.debug(@"bookmark: $url$idString");
 }

--- a/src/Widgets/TagPopover.vala
+++ b/src/Widgets/TagPopover.vala
@@ -29,12 +29,13 @@ public TagPopover(Gtk.Widget widget)
 	m_availableTags = new Gee.ArrayList<Tag>();
 	m_tags = new Gee.ArrayList<Tag>();
 	Article? selectedArticle = ColumnView.get_default().getSelectedArticle();
+	var db = DataBase.readOnly();
 	if(selectedArticle != null)
 	{
 		Gee.List<string> tagIDs = selectedArticle.getTagIDs();
 		foreach(string tagID in tagIDs)
 		{
-			m_tags.add(DataBase.readOnly().read_tag(tagID));
+			m_tags.add(db.read_tag(tagID));
 		}
 	}
 


### PR DESCRIPTION
There are a bunch of errors related threading and unsafe sharing of databases and possibly other data structures. This pull request just strips all of that out, and makes every database handle only be used in one place and then released. This is not particularly efficient, but the UI is still responsive and I don't have time to fix the old threading situation. Working correctly seems better than being perfectly efficient.

See #840, #836, #834, #828 and possibly others.