### PR TITLE
Improve error messages when adding a feed fails

### DIFF
--- a/plugins/backend/local/localUtils.vala
+++ b/plugins/backend/local/localUtils.vala
@@ -20,23 +20,34 @@ public localUtils()
 
 }
 
-public Feed? downloadFeed(Soup.Session session, string xmlURL, string feedID, Gee.List<string> catIDs, out string errmsg)
+public Feed? downloadFeed(Soup.Session session, string feed_url, string feedID, Gee.List<string> catIDs, out string errmsg)
 {
-	errmsg = "";
+	var error = new StringBuilder(_("Failed to add feed"));
+	error.append_printf(" %s\n", feed_url);
 
-	// download
-	//Logger.debug(@"Requesting: $xmlURL");
-	var msg = new Soup.Message("GET", xmlURL);
+	var msg = new Soup.Message("GET", feed_url);
 	if (msg == null)
 	{
-		errmsg = @"Couldn't parse feed URL: $xmlURL";
+		error.append(_("Failed to parse URL."));
+		errmsg = error.str;
 		Logger.warning(errmsg);
 		return null;
 	}
+
 	uint status = session.send_message(msg);
-	if(status != 200)
+	if(status < 100 || status >= 400)
 	{
-		errmsg = "Could not download feed";
+		if(status < 100)
+		{
+			error.append(_("Network error connecting to the server."));
+		}
+		else
+		{
+			error.append(_("Got HTTP error code"));
+			error.append_printf(" %u %s", status, Soup.Status.get_phrase(status));
+		}
+
+		errmsg = error.str;
 		Logger.warning(errmsg);
 		return null;
 	}
@@ -51,7 +62,8 @@ public Feed? downloadFeed(Soup.Session session, string xmlURL, string feedID, Ge
 	}
 	catch(Error e)
 	{
-		errmsg = "Could not parse feed";
+		error.append(_("Could not parse feed as RSS or ATOM."));
+		errmsg = error.str;
 		Logger.warning(errmsg);
 		return null;
 	}
@@ -62,16 +74,15 @@ public Feed? downloadFeed(Soup.Session session, string xmlURL, string feedID, Ge
 	   && doc.link != "")
 		url = doc.link;
 
-	var Feed = new Feed(
+	errmsg = "";
+	return new Feed(
 		feedID,
 		doc.title,
 		url,
 		0,
 		catIDs,
 		doc.image_url,
-		xmlURL);
-
-	return Feed;
+		feed_url);
 }
 
 public string? convert(string? text, string? locale)


### PR DESCRIPTION
Previous a lot of errors just said "Failed to add the feed", which was confusing
for users.

 - Always show the URL we attempted to download in the error message
 - Add a special message for network errors
 - Show the HTTP status code if we got an error
 - Explain more specifically what happened when parsing fails