### PR TITLE
Fix #853: use dc:creator tag for author, author tag for author email

### DIFF
--- a/libraries/libmrss/mrss_parser.c
+++ b/libraries/libmrss/mrss_parser.c
@@ -720,8 +720,13 @@ __mrss_parser_rss_item (nxml_t * doc, nxml_data_t * cur, mrss_t * data)
 		}
 	    }
 
+	  /* author email */
+	  else if (!strcmp (cur->value, "author") && !item->author_email
+		   && (c = nxmle_get_string (cur, NULL)))
+	    item->author_email = c;
+
 	  /* author */
-	  else if (!strcmp (cur->value, "author") && !item->author
+	  else if (!strcmp (cur->value, "creator") && !item->author
 		   && (c = nxmle_get_string (cur, NULL)))
 	    item->author = c;
 


### PR DESCRIPTION
Fixes libmrss library to read correct tag for a post's author.

(Perhaps this should be fixed upstream instead of in this repository.)