### PR TITLE
Replace Droid fonts with Noto fonts

### DIFF
--- a/schemas/org.gnome.feedreader.gschema.xml
+++ b/schemas/org.gnome.feedreader.gschema.xml
@@ -69,7 +69,7 @@
 		</key>
 
 		<key name='font' type="s">
-			<default>'Droid Sans 12'</default>
+			<default>'Noto Sans 12'</default>
 		</key>
 
 		<key name='drop-articles-after' enum='org.gnome.feedreader.drop-articles-duration'>


### PR DESCRIPTION
Droid fonts being superseded by Noto fonts
https://github.com/googlei18n/noto-fonts/issues/555

It looks better and more readable especially with mixed languages also it well supported by any distro.

## Droid:
![droid](https://user-images.githubusercontent.com/5614476/52744098-5bc1fe80-2fe4-11e9-86a3-b32b2b78b22c.png)

## Noto:
![noto](https://user-images.githubusercontent.com/5614476/52744099-5bc1fe80-2fe4-11e9-9cf2-50c57d7f7463.png)
