### PR TITLE
Change the default font to use the system "document font"

### DIFF
--- a/schemas/org.gnome.feedreader.gschema.xml
+++ b/schemas/org.gnome.feedreader.gschema.xml
@@ -35,10 +35,6 @@
 		<value nick="SYSTEM" value="1"/>
 	</enum>
 
-
-
-
-
 	<schema id="org.gnome.feedreader" path="/org/gnome/feedreader/" gettext-domain="feedreader">
 		<key name="sync" type="i">
 			<default>30</default>
@@ -68,8 +64,8 @@
 			<default>'DARK'</default>
 		</key>
 
-		<key name='font' type="s">
-			<default>'Droid Sans 12'</default>
+		<key name='font' type="ms">
+			<default>nothing</default>
 		</key>
 
 		<key name='drop-articles-after' enum='org.gnome.feedreader.drop-articles-duration'>

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -672,7 +672,17 @@ public static string buildArticle(string html, string title, string url, string?
 		article.insert(select_pos, "unselectable");
 	}
 
-	string font = Settings.general().get_string("font");
+	var font_setting = Settings.general().get_value("font").get_maybe();
+	string font;
+	if (font_setting == null)
+	{
+		// Default to using the system font
+		font = new GLib.Settings("org.gnome.desktop.interface").get_string("document-font-name");
+	}
+	else
+	{
+		font = font_setting.get_string();
+	}
 	var desc = Pango.FontDescription.from_string(font);
 	string fontfamilly = desc.get_family();
 	uint fontsize = (uint)GLib.Math.roundf(desc.get_size()/Pango.SCALE);

--- a/src/Widgets/Setting.vala
+++ b/src/Widgets/Setting.vala
@@ -40,13 +40,19 @@ public class FeedReader.SettingFont : FeedReader.Setting {
 
 public SettingFont(string name, GLib.Settings settings, string key){
 	base(name, null);
-	var font_button = new Gtk.FontButton.with_font(settings.get_string(key));
+	var current_font = settings.get_value(key).get_maybe();
+	var font_button = new Gtk.FontButton();
+	if (current_font != null)
+	{
+		font_button.font = current_font.get_string();
+	}
+
 	font_button.set_use_size(false);
 	font_button.set_show_size(true);
 	font_button.font_set.connect(() => {
-			settings.set_string(key, font_button.get_font_name());
-			changed();
-		});
+		var new_font = new Variant.string(font_button.get_font_name());
+		settings.set_value(key, new Variant.maybe(VariantType.STRING, new_font));
+	});
 
 	this.pack_end(font_button, false, false, 0);
 }


### PR DESCRIPTION
Previously we defaulted to Droid fonts, but we shouldn't be trying to
make assumptions about what fonts users have installed or what they
want to use here.

This makes it so we use the system document font by default and we
still allow users to override it at-will in the settings.

See #877