### PR TITLE
Assume XML docs are UTF-8 in libnxml

### DIFF
--- a/libraries/libnxml/nxml_utf.c
+++ b/libraries/libnxml/nxml_utf.c
@@ -442,7 +442,7 @@ int __nxml_utf_detection(char *r_buffer, size_t r_size, char **buffer,
 int64_t
 __nxml_int_charset(int ch, unsigned char *str, char *charset)
 {
-	if (!charset || strcasecmp(charset, "utf-8"))
+	if (charset && !strcasecmp(charset, "utf-8"))
 	{
 		str[0] = ch;
 		return 1;


### PR DESCRIPTION
Previously this required XML documents to explicitly list themselves as
UTF-8 for us to handle UTF-8 codepoints correctly. This switches that
to assume we're using UTF-8 unless the charset is explicitly set.

Fixes #476