### PR TITLE
Keep track of currently selected article

### DIFF
--- a/src/Widgets/ArticleList/ArticleList.vala
+++ b/src/Widgets/ArticleList/ArticleList.vala
@@ -126,10 +126,10 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		
 		Logger.debug("ArticleList: disallow signals from scroll");
 		m_currentScroll.allowSignals(false);
-		Gee.List<Article> articles = new Gee.LinkedList<Article>();
+		Gee.List<Article> articles = new Gee.ArrayList<Article>();
 		uint offset = 0;
 		int height = this.get_allocated_height();
-		uint limit = height/100 + 5;
+		uint limit = height / 100 + 5;
 		offset = getListOffset();
 		
 		Logger.debug("load articles from db");
@@ -623,7 +623,10 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 		if(selectedRow != "")
 		{
 			m_currentList.selectRow(selectedRow, 300);
-			Settings.state().set_string("articlelist-selected-row", "");
+		}
+		if(!m_currentList.has_id(selectedRow))
+		{
+			 Settings.state().set_string("articlelist-selected-row", "");
 		}
 	}
 	
@@ -749,7 +752,10 @@ public class FeedReader.ArticleList : Gtk.Overlay {
 	
 	private void rowActivated(Gtk.ListBoxRow row)
 	{
-		row_activated((ArticleRow)row);
+		var article_row = row as ArticleRow;
+		assert(article_row != null);
+		Settings.state().set_string("articlelist-selected-row", article_row.getID());
+		row_activated(article_row);
 	}
 	
 	public void clear()

--- a/src/Widgets/ArticleList/ArticleListBox.vala
+++ b/src/Widgets/ArticleList/ArticleListBox.vala
@@ -593,10 +593,15 @@ public class FeedReader.ArticleListBox : Gtk.ListBox {
 		}
 		return scroll;
 	}
-	
+
+	public bool has_id(string article_id)
+	{
+		return m_articles.has_key(article_id);
+	}
+
 	public void selectRow(string articleID, int time = 10)
 	{
-		if(m_articles.has_key(articleID))
+		if(has_id(articleID))
 		{
 			selectAfter(m_articles.get(articleID), time);
 		}


### PR DESCRIPTION
This lets us restore it when people go from one list to another, when
the article is still visible on the new list.

See #864