### PR TITLE
Set FeedHQ license to FREE_SOFTWARE

### DIFF
--- a/plugins/backend/feedhq/feedhqInterface.vala
+++ b/plugins/backend/feedhq/feedhqInterface.vala
@@ -33,7 +33,7 @@ public class FeedReader.FeedHQInterface : FeedServerInterface {
 
 	public override BackendFlags getFlags()
 	{
-		return (BackendFlags.HOSTED | BackendFlags.PROPRIETARY | BackendFlags.PAID);
+		return (BackendFlags.HOSTED | BackendFlags.FREE_SOFTWARE | BackendFlags.PAID);
 	}
 
 	public override string getID()


### PR DESCRIPTION
FeedHQ is free software under the BSD 3-Clause license [0]. This change
updates the backend metadata to reflect that. Similar to the change made
in #805.

[0]: https://github.com/feedhq/feedhq/blob/master/LICENCE