### PR TITLE
Use "oldest article first" sorting switch everywhere

### DIFF
--- a/src/DataBaseReadOnly.vala
+++ b/src/DataBaseReadOnly.vala
@@ -507,7 +507,7 @@ public class FeedReader.DataBaseReadOnly : GLib.Object {
 
 				query.select_field(order_by);
 
-				if(Settings.general().get_boolean("articlelist-oldest-first") && state == ArticleListState.UNREAD)
+				if(Settings.general().get_boolean("articlelist-oldest-first"))
 				{
 					query2.where(@"$order_by < (%s)".printf(query.to_string()));
 				}
@@ -570,7 +570,7 @@ public class FeedReader.DataBaseReadOnly : GLib.Object {
 					}
 
 					bool desc = true;
-					if(Settings.general().get_boolean("articlelist-oldest-first") && state == ArticleListState.UNREAD)
+					if(Settings.general().get_boolean("articlelist-oldest-first"))
 					{
 						desc = false;
 					}
@@ -1016,7 +1016,7 @@ public class FeedReader.DataBaseReadOnly : GLib.Object {
 					}
 
 					bool desc = true;
-					if(Settings.general().get_boolean("articlelist-oldest-first") && state == ArticleListState.UNREAD)
+					if(Settings.general().get_boolean("articlelist-oldest-first"))
 					{
 						desc = false;
 					}
@@ -1032,7 +1032,7 @@ public class FeedReader.DataBaseReadOnly : GLib.Object {
 					var query = articleQuery(id, selectedType, state, searchTerm);
 
 					string desc = "DESC";
-					if(Settings.general().get_boolean("articlelist-oldest-first") && state == ArticleListState.UNREAD)
+					if(Settings.general().get_boolean("articlelist-oldest-first"))
 					{
 						desc = "ASC";
 					}

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -101,7 +101,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 			ColumnView.get_default().newArticleList();
 		});
 
-		var newest_first = new SettingSwitch(_("Oldest first"), Settings.general(), "articlelist-oldest-first", _("Only affects \"Unread\" column"));
+		var newest_first = new SettingSwitch(_("Oldest first"), Settings.general(), "articlelist-oldest-first");
 		newest_first.changed.connect(() => {
 			ColumnView.get_default().newArticleList();
 		});


### PR DESCRIPTION
This was previously restricted to just the Unread articles tab, but
the hover text for this was non-obvious and it seems strange to have
this setting only apply on one tab.

Fixes #901