### PR TITLE
tt-rss: fix feeds order

### DIFF
--- a/plugins/backend/ttrss/ttrssAPI.vala
+++ b/plugins/backend/ttrss/ttrssAPI.vala
@@ -222,7 +222,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 
 					for(uint i = 0; i < feed_count; i++)
 					{
-						var feed_node = response.get_object_element(i);
+						var feed_node = response.get_object_element(feed_count - i - 1);
 						string feed_id = UntypedJson.Object.get_string_member(feed_node, "id");
 						string? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir + feed_id + ".ico" : null;
 
@@ -264,7 +264,7 @@ public class FeedReader.ttrssAPI : GLib.Object {
 
 			for(uint i = 0; i < feed_count; i++)
 			{
-				var feed_node = response.get_object_element(i);
+				var feed_node = response.get_object_element(feed_count - i - 1);
 				string feed_id = UntypedJson.Object.get_string_member(feed_node, "id");
 				string? icon_url = feed_node.get_boolean_member("has_icon") ? m_iconDir + feed_id + ".ico" : null;
 


### PR DESCRIPTION
feeds seems to be a linked list. Add operation on linked list is often done by adding the element at the head of the list, not the tail. I did not find information on this specific implementation (https://valadoc.org/gee-0.8/Gee.LinkedList.add.html), but the observed behaviour is addition to the head. However, I can't be sure if this an API contract or an implementation detail.

The consequence of this behaviour is that the feeds appear in reverse order in the interface. This PR should fix it.