### PR TITLE
Drop Keywords from desktop files

### DIFF
--- a/data/org.gnome.FeedReader-autostart.desktop.in
+++ b/data/org.gnome.FeedReader-autostart.desktop.in
@@ -8,5 +8,4 @@ Icon=org.gnome.FeedReader
 Terminal=false
 Type=Application
 X-GNOME-Gettext-Domain=tt-rss
-X-GNOME-Keywords=
 X-GNOME-UsesNotifications=true

--- a/data/org.gnome.FeedReader.desktop.in
+++ b/data/org.gnome.FeedReader.desktop.in
@@ -9,7 +9,6 @@ Terminal=false
 Type=Application
 X-GNOME-UsesNotifications=true
 X-GNOME-Gettext-Domain=FeedReader
-X-GNOME-Keywords=
 MimeType=x-scheme-handler/feedreader;
 Actions=AboutDialog;
 


### PR DESCRIPTION
1. `X-GNOME-Keywords` was surpassed by `Keywords` key, added in the version 1.1 of the XDG desktop-entry-spec.

2. It is empty so there is no need to have it there.

3. According to the spec, “Trailing empty strings must always be terminated with a semicolon.” Since this is not the case, gettext makes it eat the supported types from the following line:

```
X-GNOME-Keywords=MimeType=x-scheme-handler/feedreader;
```