### PR TITLE
Rename "Content Grabber" in Settings

### DIFF
--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -159,7 +159,7 @@ public class FeedReader.SettingsDialog : Gtk.Dialog {
 
 		var service_settings = headline(_("Additional Functionality:"));
 
-		var grabber = new SettingSwitch(_("Content Grabber"), Settings.general(),"content-grabber");
+		var grabber = new SettingSwitch(_("Download Full Text"), Settings.general(),"content-grabber");
 
 		var images = new SettingSwitch(_("Download Images"), Settings.general(),"download-images");
 


### PR DESCRIPTION
Per #933

This should probably be more clear while remaining short. I still think it could use subtext to explain that this is about the "read more" truncation, but this is a first step https://github.com/jangernert/FeedReader/issues/933#issuecomment-529095213