### PR TITLE
fix: freshrss with yunohost-like solutions

### DIFF
--- a/plugins/backend/fresh/fresh.plugin
+++ b/plugins/backend/fresh/fresh.plugin
@@ -2,7 +2,7 @@
 Module=fresh
 Loader=C
 Name=freshRSS
-Version=0.1
+Version=0.2
 Description=Add freshRSS backend to FeedReader
 Authors=Jan Lukas Gernert <jangernert@gmail.com>
 Copyright=Copyright © 2015-16 Jan Lukas Gernert

--- a/plugins/backend/fresh/freshAPI.vala
+++ b/plugins/backend/fresh/freshAPI.vala
@@ -28,7 +28,7 @@ public class FeedReader.freshAPI : Object {
 	{
 		Logger.debug("fresh backend: login");
 
-		if(!Utils.ping(m_utils.getUnmodifiedURL()))
+		if(!Utils.ping(m_utils.getApiURL())) // Ping with api URL
 		{
 			return LoginResponse.NO_CONNECTION;
 		}

--- a/plugins/backend/fresh/freshInterface.vala
+++ b/plugins/backend/fresh/freshInterface.vala
@@ -265,7 +265,7 @@ public class FeedReader.freshInterface : FeedServerInterface {
 
 	public override bool serverAvailable()
 	{
-		return Utils.ping(m_utils.getUnmodifiedURL());
+		return Utils.ping(m_utils.getApiURL()); // Ping with api URL
 	}
 
 	public override void setArticleIsRead(string articleIDs, ArticleStatus read)

--- a/plugins/backend/fresh/freshUtils.vala
+++ b/plugins/backend/fresh/freshUtils.vala
@@ -117,6 +117,11 @@ public class FeedReader.freshUtils : GLib.Object {
 		return Utils.gsettingReadString(m_settings, "url");
 	}
 
+	public string getApiURL()
+	{
+		return Utils.gsettingReadString(m_settings, "url")[0:-12];
+	}
+
 	public string getPasswd()
 	{
 		return m_password.get_password();


### PR DESCRIPTION
With self-hosted solution like YunoHost, FreshRSS is behind a SSO/LDAP solution then a ping with the base url will give a 404 error.
But by using the api url (like https://demo.freshrss.org/api/) we can prove that the server is reachable with that type of solution because base_url+"/api/" and base_url+"/api/greader.php" are "whitelisted"

PS: a ping with base_url+"/api/greader.php" provoke a http error 400 Bad Request