### PR TITLE
Don't add feeds on the UI thread

### DIFF
--- a/src/Backend/Backend.vala
+++ b/src/Backend/Backend.vala
@@ -865,14 +865,20 @@ namespace FeedReader {
 				}
 			}
 
-			string errmsg;
-			bool success = FeedServer.get_default().addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
-			errmsg = success ? "" : errmsg;
-			feedAdded(!success, errmsg);
-			if(success)
-			{
-				startSync();
-			}
+			asyncPayload pl = () => {
+				string errmsg;
+				bool success = FeedServer.get_default().addFeed(feedURL, catID, newCatName, out feedID, out errmsg);
+				errmsg = success ? "" : errmsg;
+				feedAdded(!success, errmsg);
+				if(success)
+				{
+					m_cancellable.reset();
+					sync(false, m_cancellable);
+				}
+			};
+			callAsync.begin((owned)pl, (obj, res) => {
+				callAsync.end(res);
+			});
 		}
 
 		public void removeFeed(string feedID)


### PR DESCRIPTION
On at least the DecSync backend, `addFeed` involves downloading the specified feed, and that's slow. Doing it synchronously means that the UI hangs for a while. I've never written any Vala before but this patch still lets me add feeds without stopping the UI, so hopefully it's good?