### PR TITLE
Add libgumbo-dev to ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ sudo apt-get install \
 	libgstreamer-plugins-base1.0-dev \
 	libgoa-1.0-dev \
 	libcurl-dev \
-	libpeas-dev
+	libpeas-dev \
+	libgumbo-dev
 ```
 
 ### Fedora


### PR DESCRIPTION
libgumbo-dev was missing from the ubuntu dependencies