### PR TITLE
Logger: Don’t set a custom log writer function

### DIFF
--- a/src/Logger.vala
+++ b/src/Logger.vala
@@ -49,6 +49,5 @@ public class FeedReader.Logger : GLib.Object {
 	public static void init(bool verbose)
 	{
 		m_log_debug_information = verbose;
-		GLib.Log.set_writer_func((LogWriterFunc)GLib.Log.writer_standard_streams);
 	}
 }


### PR DESCRIPTION
Unless you’re going to reimplement all the functionality from
g_log_writer_default() (or deliberately don’t want it), you should not
set a custom writer function. g_log_writer_default() likely does what
you want.

In particular, setting the writer function to
g_log_writer_standard_streams() meant that `G_MESSAGES_DEBUG` was
ignored, resulting in all debug messages being logged unconditionally
and sending gigabytes of data to the disk over the course of several
days. This noticeably slowed down people’s systems.

It also meant that fatal messages did not actually abort the program,
which hides bugs.

g_log_writer_default() handles those things, then tries sending log
messages to the journal. If that fails, it actually calls
g_log_writer_standard_streams().

Signed-off-by: Philip Withnall <withnall@endlessm.com>

Fixes: https://github.com/jangernert/FeedReader/issues/970